### PR TITLE
`repoUrl` missing on app-deploy template

### DIFF
--- a/platform/backstage/templates/app-deploy/template.yaml
+++ b/platform/backstage/templates/app-deploy/template.yaml
@@ -32,7 +32,6 @@ spec:
           type: string
           pattern: ^[a-zA-Z0-9-_.]+$
         repoUrl:
-          default: gitea.elamaras.people.aws.dev
           title: Repo URL of your Gitea Repo integrated with Backstage
           type: string
         appNamespace:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
