### PR TITLE
Adding metrics driven deployment into the manifest, with docs to expl…

### DIFF
--- a/deployment/teams/team-r/dev/application-load-test.yaml
+++ b/deployment/teams/team-r/dev/application-load-test.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rust-svc-load-test
+  namespace: argo-rollouts
+  labels:
+    workload: rust-backend
+spec:
+  containers:
+    - name: artillery-container
+      image: 891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-test@sha256:141b2d72f06b7d20a4bad596dba6d34d59b88ad71905aa4a76634e8a0946659f # TODO: Use the integration image here
+      # <service-name>.<namespace>.svc.cluster.local:<service-port>
+      command: ["run", "run", "-t", "http://rust-backend.argo-rollouts.svc.cluster.local", "/scripts/benchmark.yaml"]

--- a/deployment/teams/team-r/dev/application.yml
+++ b/deployment/teams/team-r/dev/application.yml
@@ -33,74 +33,61 @@ spec:
         targetPort: 8080
         replicas: 5
         serviceAccount: "rust-service-account"
-        dummyTestVariable: "test-67"
+        dummyTestVariable: "test-#" # (Optional) If changed and applied changes it can trigger a rollout for testing.
         functionalMetric:
-          interval: "1s" # user needs to add s, m, or h next to the number.
-          count: 1
           evaluationCriteria: [
             {
-              function: "sum",
+              interval: "1s", # user needs to add s, m, or h next to the number (second, minute, hour).
+              count: 1,
+              function: "sum", # Optional from list of "sum" | "avg" | "max" | "min" | "count"
+              successOrFailCondition: "success", # "success" or "fail" as options.
+              metric: "rocket_http_requests_total", # Required and is case and format sensitive.
+              comparisonType: ">", # Options ">" | ">=" | "<" | "<=" | "==" | "!="
+              threshold: 0
+            },
+            {
+              interval: "1s", 
               successOrFailCondition: "success",
-              metric: "rocket_http_requests_total",
+              function: "avg",
+              metric: "rocket_http_requests_duration_seconds_sum",
               comparisonType: ">",
               threshold: 0
             },
             {
+              interval: "1s", 
+              count: 1,
               successOrFailCondition: "success",
-              metric: "rocket_http_requests_total",
+              function: "max",
+              metric: "rocket_http_requests_duration_seconds_count",
               comparisonType: ">",
               threshold: 0
             },
             {
+              interval: "1s", 
+              count: 1,
+              function: "count",
               successOrFailCondition: "success",
-              metric: "rocket_http_requests_total",
+              metric: "rocket_http_requests_duration_seconds_bucket",
               comparisonType: ">",
               threshold: 0
             },
             {
-              successOrFailCondition: "success",
+              interval: "1s", 
+              count: 1,
+              successOrFailCondition: "fail",
               metric: "rocket_http_requests_total",
-              comparisonType: ">",
-              threshold: 0
-            },
-            {
-              successOrFailCondition: "success",
-              metric: "rocket_http_requests_total",
-              comparisonType: ">",
+              comparisonType: "<",
               threshold: 0
             }
           ]
-          # the following evaluationCriteriaRatios is another idea I'd like to discuss more
-          #evaluationCriteriaRatios: [
-          #  {
-          #    successOrFailCondition: "success",
-          #    overallFunction: "sum",
-          #    numeratorFunction: "sum",
-          #    denominatorFunction: "sum",
-          #    numeratorMetric: "rocket_http_requests_total",
-          #    denominatorMetric2: "rocket_http_requests_total",
-          #    comparisonType: ">",
-          #    threshold: 0
-          #  },
-          #  {
-          #    successOrFailCondition: "fail",
-          #    overallFunction: "sum",
-          #    numeratorFunction: "sum",
-          #    denominatorFunction: "sum",
-          #    numeratorMetric: "rocket_http_requests_total",
-          #    denominatorMetric2: "rocket_http_requests_total",
-          #    comparisonType: ">",
-          #    threshold: 0
-          #  }
-          #]
-        #functionalGate:
-        #  pause: "10s" 
-        #  image: "public.ecr.aws/i8e1q7x5/appmod-javafunctest:latest"
-        #  extraArgs: "red"
         # performanceGate:
         #   pause: "10s"
         #   image: "public.ecr.aws/i8e1q7x5/javaperftest:latest"
         #   extraArgs: "160"
+        #functionalGate:
+        #  pause: "10s" 
+        #  image: "public.ecr.aws/i8e1q7x5/appmod-javafunctest:latest"
+        #  extraArgs: "red"
       dependsOn:
         - rust-service-account
       traits: 
@@ -110,4 +97,3 @@ spec:
             rewritePath: true 
             http:
               /rust-app: 80
-      

--- a/deployment/teams/team-r/dev/application.yml
+++ b/deployment/teams/team-r/dev/application.yml
@@ -7,7 +7,7 @@ spec:
     - name: dynamodb-table
       type: dynamodb-table
       properties:
-        tableName: rust-microservice-table
+        tableName: rust-service-table
         partitionKeyName: partition_key
         sortKeyName: sort_key 
         region: us-west-2
@@ -27,16 +27,76 @@ spec:
     - name: rust-backend
       type: appmod-service
       properties:
-        image:  929819487611.dkr.ecr.us-west-2.amazonaws.com/moderneng/rust-microservice:latest
+        image:  891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-microservice:latest
         image_name: rust-microservice
         port: 80
         targetPort: 8080
-        replicas: 1
+        replicas: 5
         serviceAccount: "rust-service-account"
-        # functionalGate:
-        #   pause: "10s" 
-        #   image: "public.ecr.aws/i8e1q7x5/appmod-javafunctest:latest"
-        #   extraArgs: "red"
+        dummyTestVariable: "test-67"
+        functionalMetric:
+          interval: "1s" # user needs to add s, m, or h next to the number.
+          count: 1
+          evaluationCriteria: [
+            {
+              function: "sum",
+              successOrFailCondition: "success",
+              metric: "rocket_http_requests_total",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              successOrFailCondition: "success",
+              metric: "rocket_http_requests_total",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              successOrFailCondition: "success",
+              metric: "rocket_http_requests_total",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              successOrFailCondition: "success",
+              metric: "rocket_http_requests_total",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              successOrFailCondition: "success",
+              metric: "rocket_http_requests_total",
+              comparisonType: ">",
+              threshold: 0
+            }
+          ]
+          # the following evaluationCriteriaRatios is another idea I'd like to discuss more
+          #evaluationCriteriaRatios: [
+          #  {
+          #    successOrFailCondition: "success",
+          #    overallFunction: "sum",
+          #    numeratorFunction: "sum",
+          #    denominatorFunction: "sum",
+          #    numeratorMetric: "rocket_http_requests_total",
+          #    denominatorMetric2: "rocket_http_requests_total",
+          #    comparisonType: ">",
+          #    threshold: 0
+          #  },
+          #  {
+          #    successOrFailCondition: "fail",
+          #    overallFunction: "sum",
+          #    numeratorFunction: "sum",
+          #    denominatorFunction: "sum",
+          #    numeratorMetric: "rocket_http_requests_total",
+          #    denominatorMetric2: "rocket_http_requests_total",
+          #    comparisonType: ">",
+          #    threshold: 0
+          #  }
+          #]
+        #functionalGate:
+        #  pause: "10s" 
+        #  image: "public.ecr.aws/i8e1q7x5/appmod-javafunctest:latest"
+        #  extraArgs: "red"
         # performanceGate:
         #   pause: "10s"
         #   image: "public.ecr.aws/i8e1q7x5/javaperftest:latest"

--- a/docs/Argo-Rollouts-Metrics-Manifest.md
+++ b/docs/Argo-Rollouts-Metrics-Manifest.md
@@ -1,53 +1,28 @@
-# Application Specification
+### Things still in the works:
+- Need to modify image example for load testing to return a success rather than fail when it finishes load testing.
+- Do no currently have a functional test image for the sample application.
 
-The following configuration specifies an application that includes a Rust-based backend. It requires a DynamoDB table and a service account, with `ComponentDefinitions` provided separately.
-
-The main focus here is on configuring the `appmod-service` component, which leverages the solution setup when the application is ready. Below are the necessary fields to complete for a successful setup:
-
-- **name**: `rust-backend` - Assign a name to your application.
-- **type**: `appmod-service` - Designate this as the appmod solution.
-- **properties**: Contains values required to set up Argo Rollouts properly.
-  - `image`: `891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-microservice:latest` - Path to the container image running the application.
-  - `image_name`: `rust-microservice` - Name of the targeted image.
-  - `port`: `80` - The port for the application.
-  - `targetPort`: `8080` - The application's target port.
-  - `replicas`: `5` - The number of replicas for the rollout.
-  - `serviceAccount`: `"rust-service-account"` - Service account name for the specified workload.
-  - `dummyTestVariable`: `"test-#"` - Optional variable for testing. Modifying this value counts as a change, triggering a rollout.
-  - **functionalMetric** (Optional): 
-    - `interval`: `"1s"` - Specify interval with suffix `s`, `m`, or `h`.
-    - `count`: `1`
-    - **evaluationCriteria**: Define an array of metrics to be tested.
-      - `function`: `"sum"` - Optional. Choose a metric tracking augmentation function from `"sum"`, `"rate"`, `"avg"`, `"max"`, `"min"`, `"increase"`, `"count"`.
-      - `successOrFailCondition`: `"success"` - Determines if the metric should pass or fail. Options are `"success"` or `"fail"`.
-      - `metric`: `"rocket_http_requests_total"` - The case-sensitive name of the metric to track.
-      - `comparisonType`: `">"` - Choose a comparison operator from `">"`, `">="`, `"<"`, `"<="`, `"=="`, `"!="`.
-      - `threshold`: `0` - Specify a numeric threshold.
-
----
-
-# Technical Details of the CUE Configuration
+# Technical Details of the CUE Parameter Configuration
 
 ### Parameter Setup
 
-The parameter `functionalMetric` of type `#MetricGate` is added for metric configuration.
+The parameter `functionalMetric` of type `#MetricGate` are added for metric configuration.
 
 ```cue
 parameter:
-  functionalMetric: #MetricGate
+  functionalMetric?: #MetricGate
 
 #MetricGate: {
-  interval: *"1s" | string
-  count: *1 | int
-  evaluationCriteria: [
-    ...{
-      function?: "sum" | "rate" | "avg" | "max" | "min" | "increase" | "count" # These are some of the most popular options for functions.
-      successOrFailCondition: "success" | "fail" # Two options of pass or fail.
-      metric: string 
-      comparisonType: ">" | ">=" | "<" | "<=" | "==" | "!="
-      threshold: number # Can be a whole number or decimal.
-    }
-  ]
+    evaluationCriteria:
+    [...{
+            interval: *"1s" | string
+            count: *1 | int
+            function?: "sum" | "avg" | "max" | "min" | "count"
+            successOrFailCondition: *"success" | "fail" # Two options of pass or fail.
+            metric: string
+            comparisonType: *">" | ">=" | "<" | "<=" | "==" | "!="
+            threshold: *0 | number # Can be a whole number or decimal.
+        }]
 }
 ```
 
@@ -71,58 +46,7 @@ if parameter.functionalMetric !=  _|_ {
 }
 }
 ```
-# Implementation of Metrics
 
-The following CUE code snippet creates an `AnalysisTemplate` for monitoring functional metrics in Argo Rollouts. This template defines metrics-based criteria that determine the success or failure of rollouts.
-
-## Analysis Template Code
-
-```cue
-if parameter.functionalMetric != _|_ {
-    "success-rate-analysis-template": {
-        apiVersion: "argoproj.io/v1alpha1"
-        kind:       "AnalysisTemplate"
-        metadata: {
-            name:      "functional-metric-\(context.name)"
-        }
-        spec: {
-            args: [{
-                name: "amp-workspace" # Calls the needed amp-workspace url from the secret amp-workspace.
-                valueFrom: secretKeyRef: {
-                    name: "workspace-url"
-                    key:  "secretURL"
-                }
-            }]
-            metrics: 
-            [
-                for idx, criteria in parameter.functionalMetric.evaluationCriteria { # Loops through all the metrics the user specifies in the array.
-                    name: "metric-\(context.name)-\(idx)"
-                    interval: parameter.functionalMetric.interval
-                    count: parameter.functionalMetric.count
-                    if criteria.successOrFailCondition == "success" { # Handles successCondition variables.
-                        successCondition: "result[0] \(criteria.comparisonType) \(criteria.threshold)"
-                    }
-                    if criteria.successOrFailCondition == "fail" { # Handles failureCondition variables.
-                        failureCondition: "result[0] \(criteria.comparisonType) \(criteria.threshold)"
-                    }
-                    provider: prometheus: {
-                        address: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-6ba7e445-e203-43a5-b1b0-c7bc15e354ef" # Having trouble making this work like YAML's {{args.amp-workspace}} so hard coded for now.
-                        query: [
-                            if criteria.function != _|_ { # Handles the optional addition of a function added to the front of a query.
-                                "\(criteria.function)(\(criteria.metric))"
-                            }
-                            if criteria.function == _|_ { # Handles if no function is specified.
-                                "\(criteria.metric)"
-                            }
-                        ][0] # The [0] uses the if statement that is true.
-                        authentication: sigv4: region: "us-west-2" # Hanldes authentication with Amazon Managed Prometheus.
-                    }
-                }
-            ]
-        }
-    }
-}
-```
 # Sample Application Configuration for Rust App with Argo Rollouts and DynamoDB
 
 The following configuration defines a Rust-based application that requires a DynamoDB table, a service account, and a backend service component configured with Argo Rollouts. 
@@ -130,94 +54,164 @@ The following configuration defines a Rust-based application that requires a Dyn
 ## Application Overview
 
 ```YAML
-    apiVersion: core.oam.dev/v1beta1
-    kind: Application
-    metadata:
-        name: rust-app
-    spec:
-        components:
-            - name: dynamodb-table
-            type: dynamodb-table
-            properties:
-                tableName: rust-service-table
-                partitionKeyName: partition_key
-                sortKeyName: sort_key
-                region: us-west-2
-            traits:
-                - type: component-iam-policy
-                properties:
-                    service: dynamodb
-            - name: rust-service-account
-            type: dp-service-account
-            properties:
-                componentNamesForAccess:
-                - dynamodb-table
-                clusterName: modernengg-dev
-                clusterRegion: us-west-2
-                dependsOn:
-                - dynamodb-table
-            - name: rust-backend
-            type: appmod-service
-            properties:
-                image: 891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-microservice:latest
-                image_name: rust-microservice
-                port: 80
-                targetPort: 8080
-                replicas: 5
-                serviceAccount: "rust-service-account"
-                dummyTestVariable: "test-67"
-                functionalMetric:
-                interval: "1s" # Add time unit: s, m, or h.
-                count: 1
-                evaluationCriteria: [
-                    {
-                    function: "sum",
-                    successOrFailCondition: "success",
-                    metric: "rocket_http_requests_total",
-                    comparisonType: ">",
-                    threshold: 0
-                    },
-                    {
-                    successOrFailCondition: "success",
-                    metric: "rocket_http_requests_total",
-                    comparisonType: ">",
-                    threshold: 0
-                    },
-                    {
-                    successOrFailCondition: "success",
-                    metric: "rocket_http_requests_total",
-                    comparisonType: ">",
-                    threshold: 0
-                    },
-                    {
-                    successOrFailCondition: "success",
-                    metric: "rocket_http_requests_total",
-                    comparisonType: ">",
-                    threshold: 0
-                    },
-                    {
-                    successOrFailCondition: "success",
-                    metric: "rocket_http_requests_total",
-                    comparisonType: ">",
-                    threshold: 0
-                    }
-                ]
-                # Uncomment these sections for additional gates
-                # functionalGate:
-                #   pause: "10s"
-                #   image: "public.ecr.aws/i8e1q7x5/appmod-javafunctest:latest"
-                #   extraArgs: "red"
-                # performanceGate:
-                #   pause: "10s"
-                #   image: "public.ecr.aws/i8e1q7x5/javaperftest:latest"
-                #   extraArgs: "160"
-            dependsOn:
-                - rust-service-account
-            traits: 
-                - type: path-based-ingress
-                properties:
-                    domain: "*.elb.us-west-2.amazonaws.com"
-                    rewritePath: true 
-                    http:
-                    /rust-app: 80
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: rust-app
+spec:
+  components:
+    - name: dynamodb-table
+      type: dynamodb-table
+      properties:
+        tableName: rust-service-table
+        partitionKeyName: partition_key
+        sortKeyName: sort_key 
+        region: us-west-2
+      traits:
+        - type: component-iam-policy
+          properties:
+            service: dynamodb
+    - name: rust-service-account
+      type: dp-service-account
+      properties:
+        componentNamesForAccess:
+          - dynamodb-table
+        clusterName: modernengg-dev
+        clusterRegion: us-west-2
+        dependsOn:
+          - dynamodb-table
+    - name: rust-backend
+      type: appmod-service
+      properties:
+        image:  891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-microservice:latest
+        image_name: rust-microservice
+        port: 80
+        targetPort: 8080
+        replicas: 5
+        serviceAccount: "rust-service-account"
+        dummyTestVariable: "test-1"
+        functionalMetric:
+          evaluationCriteria: [
+            {
+              interval: "1s", # user needs to add s, m, or h next to the number.
+              count: 1,
+              function: "sum",
+              successOrFailCondition: "success",
+              metric: "rocket_http_requests_total",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              interval: "1s", # user needs to add s, m, or h next to the number.
+              successOrFailCondition: "success",
+              function: "avg",
+              metric: "rocket_http_requests_duration_seconds_sum",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              interval: "1s", # user needs to add s, m, or h next to the number.
+              count: 1,
+              successOrFailCondition: "success",
+              function: "max",
+              metric: "rocket_http_requests_duration_seconds_count",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              interval: "1s", # user needs to add s, m, or h next to the number.
+              count: 1,
+              function: "count",
+              successOrFailCondition: "success",
+              metric: "rocket_http_requests_duration_seconds_bucket",
+              comparisonType: ">",
+              threshold: 0
+            },
+            {
+              interval: "1s", # user needs to add s, m, or h next to the number.
+              count: 1,
+              successOrFailCondition: "fail",
+              metric: "rocket_http_requests_total",
+              comparisonType: "<",
+              threshold: 0
+            }
+
+          ]
+        #functionalGate:
+        #  pause: "10s" 
+        #  image: "public.ecr.aws/i8e1q7x5/appmod-javafunctest:latest"
+        #  extraArgs: "red"
+        # performanceGate:
+        #   pause: "10s"
+        #   image: "public.ecr.aws/i8e1q7x5/javaperftest:latest"
+        #   extraArgs: "160"
+      dependsOn:
+        - rust-service-account
+      traits: 
+        - type: path-based-ingress
+          properties:
+            domain: "*.elb.us-west-2.amazonaws.com"
+            rewritePath: true 
+            http:
+              /rust-app: 80
 ```
+## Sample Application Breakdown
+
+The following configuration specifies an application that includes a Rust-based backend. It requires a DynamoDB table and a service account, with `ComponentDefinitions` provided separately.
+
+The main focus here is on configuring the `appmod-service` component, which leverages the solution setup when the application is ready. Below are the necessary fields to complete for a successful setup:
+
+- **name**: `rust-backend` - Assign a name to your application.
+- **type**: `appmod-service` - Designate this as the appmod solution.
+- **properties**: Contains values required to set up Argo Rollouts properly.
+  - `image`: `891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-microservice:latest` - Path to the container image running the application.
+  - `image_name`: `rust-microservice` - Names the container it runs on.
+  - `port`: `80` - The port for the application.
+  - `targetPort`: `8080` - The application's target port.
+  - `replicas`: `5` - The number of replicas for the rollout.
+  - `serviceAccount`: `"rust-service-account"` - Service account name for the specified workload.
+  - `dummyTestVariable`: `"test-#"` - Optional variable for testing. Modifying this value counts as a change, triggering a rollout.
+  - **functionalMetric** (Optional): 
+    - **evaluationCriteria**: Define an array of metrics to be tested. Each metric in the array specify the following values:
+      - `interval`: `"1s"` - Specify interval with suffix `s`, `m`, or `h`.
+      - `count`: `1`
+      - `function`: `"sum"` - Optional. Choose a metric tracking augmentation function from `"sum"`, `"avg"`, `"max"`, `"min"`, `"count"`.
+      - `successOrFailCondition`: `"success"` - Determines if the metric should pass or fail. Options are `"success"` or `"fail"`.
+      - `metric`: `"rocket_http_requests_total"` - The case-sensitive name of the metric to track.
+      - `comparisonType`: `">"` - Choose a comparison operator from `">"`, `">="`, `"<"`, `"<="`, `"=="`, `"!="`.
+      - `threshold`: `0` - Specify a numeric threshold.
+
+---
+# Troubleshooting User Scenarios
+
+If the given metric does not exist or returns nothing, you should expect an error in the **Rollout**:
+
+- **Strategy:** Canary  
+- **Name:** rust-backend  
+- **Namespace:** test-123  
+- **Status:** ✖ Degraded  
+- **Message:** `RolloutAborted: Rollout aborted update to revision 16: Metric "metric[0]-rust-backend: rocket_http_reqsdfadfuests_total" assessed Error due to consecutiveErrors (5) > consecutiveErrorLimit (4): "Error Message: reflect: slice index out of range"`
+
+---
+
+If a metric fails the test/condition the user sets up, the first failure hit returns this in **Rollouts**:
+
+- **Strategy:** Canary  
+- **Name:** rust-backend  
+- **Namespace:** test-123  
+- **Status:** ✖ Degraded  
+- **Message:** `RolloutAborted: Rollout aborted update to revision 13: Metric "metric[2]-rust-backend: rocket_http_requests_total" assessed Failed due to failed (1) > failureLimit (0)`
+
+---
+
+If `evaluationCriteria[]` values are of the wrong type specified that the CUE Manifest requires when they deploy their application, they get this as an **Application Message**:
+
+- **Message:** `run step(provider=oam,do=component-apply): GenerateComponentManifest: evaluate base template app=rust-app in namespace=test-123: invalid cue template of workload rust-backend after merge parameter and context: parameter.functionalMetric.evaluationCriteria.0.count: 2 errors in empty disjunction: (and 5 more errors)`
+
+---
+
+While default values work fine if they don't put a value in for one that has a default set up, if a user did not enter a required variable that lacks a default (like `metrics` inside of `evaluationCriteria`, for example), expect the following as an **Application Message**:
+
+- **Message:** `run step(provider=oam,do=component-apply): GenerateComponentManifest: evaluate template trait=path-based-ingress app=rust-backend: cue: marshal error: outputs."success-rate-analysis-template".spec.metrics.1.name: invalid interpolation: non-concrete value string (type string)`
+
+

--- a/docs/Argo-Rollouts-Metrics-Manifest.md
+++ b/docs/Argo-Rollouts-Metrics-Manifest.md
@@ -1,0 +1,223 @@
+# Application Specification
+
+The following configuration specifies an application that includes a Rust-based backend. It requires a DynamoDB table and a service account, with `ComponentDefinitions` provided separately.
+
+The main focus here is on configuring the `appmod-service` component, which leverages the solution setup when the application is ready. Below are the necessary fields to complete for a successful setup:
+
+- **name**: `rust-backend` - Assign a name to your application.
+- **type**: `appmod-service` - Designate this as the appmod solution.
+- **properties**: Contains values required to set up Argo Rollouts properly.
+  - `image`: `891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-microservice:latest` - Path to the container image running the application.
+  - `image_name`: `rust-microservice` - Name of the targeted image.
+  - `port`: `80` - The port for the application.
+  - `targetPort`: `8080` - The application's target port.
+  - `replicas`: `5` - The number of replicas for the rollout.
+  - `serviceAccount`: `"rust-service-account"` - Service account name for the specified workload.
+  - `dummyTestVariable`: `"test-#"` - Optional variable for testing. Modifying this value counts as a change, triggering a rollout.
+  - **functionalMetric** (Optional): 
+    - `interval`: `"1s"` - Specify interval with suffix `s`, `m`, or `h`.
+    - `count`: `1`
+    - **evaluationCriteria**: Define an array of metrics to be tested.
+      - `function`: `"sum"` - Optional. Choose a metric tracking augmentation function from `"sum"`, `"rate"`, `"avg"`, `"max"`, `"min"`, `"increase"`, `"count"`.
+      - `successOrFailCondition`: `"success"` - Determines if the metric should pass or fail. Options are `"success"` or `"fail"`.
+      - `metric`: `"rocket_http_requests_total"` - The case-sensitive name of the metric to track.
+      - `comparisonType`: `">"` - Choose a comparison operator from `">"`, `">="`, `"<"`, `"<="`, `"=="`, `"!="`.
+      - `threshold`: `0` - Specify a numeric threshold.
+
+---
+
+# Technical Details of the CUE Configuration
+
+### Parameter Setup
+
+The parameter `functionalMetric` of type `#MetricGate` is added for metric configuration.
+
+```cue
+parameter:
+  functionalMetric: #MetricGate
+
+#MetricGate: {
+  interval: *"1s" | string
+  count: *1 | int
+  evaluationCriteria: [
+    ...{
+      function?: "sum" | "rate" | "avg" | "max" | "min" | "increase" | "count" # These are some of the most popular options for functions.
+      successOrFailCondition: "success" | "fail" # Two options of pass or fail.
+      metric: string 
+      comparisonType: ">" | ">=" | "<" | "<=" | "==" | "!="
+      threshold: number # Can be a whole number or decimal.
+    }
+  ]
+}
+```
+
+### Creates Analysis Template
+```cue
+if parameter.functionalMetric !=  _|_ {
+{
+    analysis: {
+        templates: [
+            {
+                templateName: "functional-metric-\(context.name)"
+            }
+        ],
+        args: [
+            {
+                name: "service-name"
+                value: previewService
+            }
+        ]
+    }
+}
+}
+```
+# Implementation of Metrics
+
+The following CUE code snippet creates an `AnalysisTemplate` for monitoring functional metrics in Argo Rollouts. This template defines metrics-based criteria that determine the success or failure of rollouts.
+
+## Analysis Template Code
+
+```cue
+if parameter.functionalMetric != _|_ {
+    "success-rate-analysis-template": {
+        apiVersion: "argoproj.io/v1alpha1"
+        kind:       "AnalysisTemplate"
+        metadata: {
+            name:      "functional-metric-\(context.name)"
+        }
+        spec: {
+            args: [{
+                name: "amp-workspace" # Calls the needed amp-workspace url from the secret amp-workspace.
+                valueFrom: secretKeyRef: {
+                    name: "workspace-url"
+                    key:  "secretURL"
+                }
+            }]
+            metrics: 
+            [
+                for idx, criteria in parameter.functionalMetric.evaluationCriteria { # Loops through all the metrics the user specifies in the array.
+                    name: "metric-\(context.name)-\(idx)"
+                    interval: parameter.functionalMetric.interval
+                    count: parameter.functionalMetric.count
+                    if criteria.successOrFailCondition == "success" { # Handles successCondition variables.
+                        successCondition: "result[0] \(criteria.comparisonType) \(criteria.threshold)"
+                    }
+                    if criteria.successOrFailCondition == "fail" { # Handles failureCondition variables.
+                        failureCondition: "result[0] \(criteria.comparisonType) \(criteria.threshold)"
+                    }
+                    provider: prometheus: {
+                        address: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-6ba7e445-e203-43a5-b1b0-c7bc15e354ef" # Having trouble making this work like YAML's {{args.amp-workspace}} so hard coded for now.
+                        query: [
+                            if criteria.function != _|_ { # Handles the optional addition of a function added to the front of a query.
+                                "\(criteria.function)(\(criteria.metric))"
+                            }
+                            if criteria.function == _|_ { # Handles if no function is specified.
+                                "\(criteria.metric)"
+                            }
+                        ][0] # The [0] uses the if statement that is true.
+                        authentication: sigv4: region: "us-west-2" # Hanldes authentication with Amazon Managed Prometheus.
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+# Sample Application Configuration for Rust App with Argo Rollouts and DynamoDB
+
+The following configuration defines a Rust-based application that requires a DynamoDB table, a service account, and a backend service component configured with Argo Rollouts. 
+
+## Application Overview
+
+```YAML
+    apiVersion: core.oam.dev/v1beta1
+    kind: Application
+    metadata:
+        name: rust-app
+    spec:
+        components:
+            - name: dynamodb-table
+            type: dynamodb-table
+            properties:
+                tableName: rust-service-table
+                partitionKeyName: partition_key
+                sortKeyName: sort_key
+                region: us-west-2
+            traits:
+                - type: component-iam-policy
+                properties:
+                    service: dynamodb
+            - name: rust-service-account
+            type: dp-service-account
+            properties:
+                componentNamesForAccess:
+                - dynamodb-table
+                clusterName: modernengg-dev
+                clusterRegion: us-west-2
+                dependsOn:
+                - dynamodb-table
+            - name: rust-backend
+            type: appmod-service
+            properties:
+                image: 891612574912.dkr.ecr.us-west-2.amazonaws.com/modernengg/rust-microservice:latest
+                image_name: rust-microservice
+                port: 80
+                targetPort: 8080
+                replicas: 5
+                serviceAccount: "rust-service-account"
+                dummyTestVariable: "test-67"
+                functionalMetric:
+                interval: "1s" # Add time unit: s, m, or h.
+                count: 1
+                evaluationCriteria: [
+                    {
+                    function: "sum",
+                    successOrFailCondition: "success",
+                    metric: "rocket_http_requests_total",
+                    comparisonType: ">",
+                    threshold: 0
+                    },
+                    {
+                    successOrFailCondition: "success",
+                    metric: "rocket_http_requests_total",
+                    comparisonType: ">",
+                    threshold: 0
+                    },
+                    {
+                    successOrFailCondition: "success",
+                    metric: "rocket_http_requests_total",
+                    comparisonType: ">",
+                    threshold: 0
+                    },
+                    {
+                    successOrFailCondition: "success",
+                    metric: "rocket_http_requests_total",
+                    comparisonType: ">",
+                    threshold: 0
+                    },
+                    {
+                    successOrFailCondition: "success",
+                    metric: "rocket_http_requests_total",
+                    comparisonType: ">",
+                    threshold: 0
+                    }
+                ]
+                # Uncomment these sections for additional gates
+                # functionalGate:
+                #   pause: "10s"
+                #   image: "public.ecr.aws/i8e1q7x5/appmod-javafunctest:latest"
+                #   extraArgs: "red"
+                # performanceGate:
+                #   pause: "10s"
+                #   image: "public.ecr.aws/i8e1q7x5/javaperftest:latest"
+                #   extraArgs: "160"
+            dependsOn:
+                - rust-service-account
+            traits: 
+                - type: path-based-ingress
+                properties:
+                    domain: "*.elb.us-west-2.amazonaws.com"
+                    rewritePath: true 
+                    http:
+                    /rust-app: 80
+```


### PR DESCRIPTION
Main part works well. Missing a few parts, and needs some discussion. Enough for a general review to begin though.

Added a doc with extensive rundown of my additions and how to use it. Added a load test for the current application example since its needed to make the application emit metrics to track. Added changes to the CUE file, and it has another commented out option I'd like to discuss if it would be useful called evaluationCriteriaRatios in application.yml as well.

Existing issues:
- AMP URL is hardcoded currently. Ran into issues since YAML's address: "{{args.amp-workspace}}" does not work and cannot find a way to convert this to CUE currently.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
