### PR TITLE
hotfix for deploying multiple apps

### DIFF
--- a/deployment/addons/kubevela/templates/components/appmod-service.yaml
+++ b/deployment/addons/kubevela/templates/components/appmod-service.yaml
@@ -156,7 +156,7 @@ spec:
         		apiVersion: "external-secrets.io/v1beta1"
         		kind:       "ExternalSecret"
         		metadata: {
-        			name:      "amp-workspace-secrets"
+        			name:      "amp-workspace-secrets-\(context.name)"
         			namespace: context.namespace
         		}
         		spec: {
@@ -165,7 +165,7 @@ spec:
         				kind: "ClusterSecretStore"
         			}
         			target: {
-        				name: "amp-workspace"
+        				name: "amp-workspace-\(context.name)"
         				template: type: "Opaque"
         			}
         			data: [
@@ -195,13 +195,13 @@ spec:
         				args: [{
         					name: "amp-workspace-url"
         					valueFrom: secretKeyRef: {
-        						name: "amp-workspace"
+        						name: "amp-workspace-\(context.name)"
         						key:  "amp-workspace-url"
         					}
         				}, {
         					name: "amp-workspace-region"
         					valueFrom: secretKeyRef: {
-        						name: "amp-workspace"
+        						name: "amp-workspace-\(context.name)"
         						key:  "amp-workspace-region"
         					}
         				}]

--- a/platform/components/appmod-service.cue
+++ b/platform/components/appmod-service.cue
@@ -164,7 +164,7 @@ template: {
 			apiVersion: "external-secrets.io/v1beta1"
 			kind:       "ExternalSecret"
 			metadata: {
-				name:      "amp-workspace-secrets"
+				name:      "amp-workspace-secrets-\(context.name)"
 				namespace: context.namespace
 			}
 			spec: {
@@ -173,7 +173,7 @@ template: {
 					kind: "ClusterSecretStore"
 				}
 				target: {
-					name: "amp-workspace"
+					name: "amp-workspace-\(context.name)"
 					template: type: "Opaque"
 				}
 				data: [
@@ -205,13 +205,13 @@ template: {
 					args: [{
 						name: "amp-workspace-url"
 						valueFrom: secretKeyRef: {
-							name: "amp-workspace"
+							name: "amp-workspace-\(context.name)"
 							key: "amp-workspace-url"
 						}
 					}, {
 						name: "amp-workspace-region"
 						valueFrom: secretKeyRef: {
-							name: "amp-workspace"
+							name: "amp-workspace-\(context.name)"
 							key: "amp-workspace-region"
 						}
 					}]
@@ -307,7 +307,7 @@ template: {
 														"image": parameter.performanceGate.image,
 														"args": [
 															"\(previewService):\(parameter.port)",
-															"\(parameter.functionalGate.extraArgs)"
+															"\(parameter.performanceGate.extraArgs)"
 															
 														]
 													}


### PR DESCRIPTION
*Issue #, if available:*
#180
*Description of changes:*

Hotfix for deploying multiple applications into the same namespace.  Adds the component name to the end of the secret.

Need to look into kubevela shared resources(https://kubevela.io/docs/end-user/policies/shared-resource/) to see if fix is possible using this/if it would be a better approach

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
