### PR TITLE
Complete Auto Mode Integration

### DIFF
--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/auto-mode.yaml
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/auto-mode.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: eks.amazonaws.com/v1
+kind: NodeClass
+metadata:
+  name: modern-engineering-nodeclass
+spec:
+  role: "modern-engineering"
+  ephemeralStorage: # EKS Auto Mode section that handles temporary storage.
+    size: "50Gi"
+  subnetSelectorTerms:
+    - tags:
+        eks.amazonaws.com/discovery: modern-engineering
+  securityGroupSelectorTerms:
+    - tags:
+        eks.amazonaws.com/discovery: modern-engineering
+  tags:
+    eks.amazonaws.com/discovery: modern-engineering
+---
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: modern-engineering-nodepool
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: eks.amazonaws.com
+        kind: NodeClass
+        name: modern-engineering-nodeclass # Calls the NodeClass modern-engineering-nodeclass in this file.
+      requirements:
+        - key: "eks.amazonaws.com/instance-category"
+          operator: In
+          values: ["c", "m", "r"]
+        - key: "eks.amazonaws.com/instance-cpu"
+          operator: In
+          values: ["4", "8", "16", "32"]
+        - key: "eks.amazonaws.com/instance-hypervisor"
+          operator: In
+          values: ["nitro"]
+        - key: "kubernetes.io/arch"
+          operator: In
+          values: ["amd64"]
+        - key: "eks.amazonaws.com/instance-generation"
+          operator: Gt
+          values: ["2"]
+  limits:
+    cpu: "1000"
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 300s
+  weight: 10

--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/eks.tf
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/eks.tf
@@ -7,75 +7,46 @@ module "eks" {
   version = "~> 20.10"
 
   cluster_name    = local.name
-  cluster_version = "1.30"
+  cluster_version = local.eks_version
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster
   enable_cluster_creator_admin_permissions = true
   cluster_endpoint_public_access           = true
 
+  # Enable Auto Mode and reference our custom NodePool
+  cluster_compute_config = {
+    enabled    = true
+  }
+
   cluster_addons = {
-    coredns = {
-      configuration_values = jsonencode({
-        tolerations = [
-          # Allow CoreDNS to run on the same nodes as the Karpenter controller
-          # for use during cluster creation when Karpenter nodes do not yet exist
-          {
-            key    = "karpenter.sh/controller"
-            value  = "true"
-            effect = "NoSchedule"
-          }
-        ]
-      })
-    }
     eks-pod-identity-agent = {}
     kube-proxy             = {}
     vpc-cni                = {}
-    aws-ebs-csi-driver     = {
-      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
-    }
   }
 
   enable_irsa = true
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
+  
+  # This adds the tag to everything. And tags 3 security groups. So karpetner was grabbing 3 rather than 1 causing an issue.
+  #  tags = merge(local.tags, {
+  #   # NOTE - if creating multiple security groups with this module, only tag the
+  #   # security group that Karpenter should utilize with the following tag
+  #   # (i.e. - at most, only one security group should have this tag in your account)
+  #   "eks.amazonaws.com/discovery" = local.name
+  #  })
 
-  eks_managed_node_groups = {
-    static_ng = {
-      use_custom_launch_template = false
-      launch_template_name       = ""
-      instance_types             = ["m5.2xlarge"]
-
-      min_size     = 2
-      max_size     = 6
-      desired_size = 2
-      disk_size    = 100
-
-      block_device_mappings = {
-        xvda = {
-          device_name = "/dev/xvda"
-          ebs = {
-            volume_size           = 100
-            volume_type           = "gp3"
-            delete_on_termination = true
-          }
-        }
-      }
-      labels = {
-        # Used to ensure Karpenter runs on nodes that it does not manage
-        "karpenter.sh/controller" = "true"
-      }
-    }
-  }
-
-  tags = merge(local.tags, {
+  node_security_group_tags = merge(local.tags, { # Now only add it to the node security groups.
     # NOTE - if creating multiple security groups with this module, only tag the
     # security group that Karpenter should utilize with the following tag
     # (i.e. - at most, only one security group should have this tag in your account)
-    "karpenter.sh/discovery" = local.name
+    "eks.amazonaws.com/discovery" = local.name
   })
+  tags = local.tags # Now everything you create you can attach the generic ones you don't use for discovering.
 }
+
 
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
@@ -86,84 +57,183 @@ output "configure_kubectl" {
 # EBS Configuration
 ################################################################################
 
-module "ebs_csi_driver_irsa" {
-  source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  role_name             = "${local.name}-ebs-csi-driver"
-  role_policy_arns = {
-    policy = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-  }
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
-  }
-  tags = local.tags
-}
-
+## EKS Auto Mode and Karpenter utilize StorageClass in the same way. EKS Auto Mode simply does not need the IRSA role Karpenter needed before.
 resource "kubernetes_storage_class" "ebs-gp3-sc" {
   metadata {
     name = "gp3"
   }
 
-  storage_provisioner = "ebs.csi.aws.com"
+  storage_provisioner = "ebs.csi.eks.amazonaws.com" # Altering this to target EKS Auto Mode.
+  volume_binding_mode = "WaitForFirstConsumer"
   reclaim_policy      = "Delete"
-}
 
+  parameters = {
+    type      = "gp3"     # Required: Specify volume type # Is this fine?-------------------------------------------------------------------------------------------------------------------
+    encrypted = "true"    # Required: EKS Auto Mode provisions encrypted volumes # Is this fine?-------------------------------------------------------------------------------------------------------------------
+  }
+}
 
 ################################################################################
 # Controller & Node IAM roles
 ################################################################################
 
-module "karpenter" {
-  source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 20.26.0"
+# Revised IAM Role for EKS Auto Mode
+resource "aws_iam_role" "eks_node_role" {
+  name = "modern-engineering"
 
-  cluster_name = module.eks.cluster_name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
 
-  # Name needs to match role name passed to the EC2NodeClass
-  node_iam_role_use_name_prefix   = false
-  node_iam_role_name              = local.name
-  create_pod_identity_association = true
-
-  tags = local.tags
-}
-
-################################################################################
-# Helm charts
-################################################################################
-
-resource "helm_release" "karpenter" {
-  namespace           = "kube-system"
-  name                = "karpenter"
-  repository          = "oci://public.ecr.aws/karpenter"
-  chart               = "karpenter"
-  version             = "0.36.2"
-  wait                = false
-
-  values = [
-    <<-EOT
-    nodeSelector:
-      karpenter.sh/controller: 'true'
-    tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - key: karpenter.sh/controller
-        operator: Exists
-        effect: NoSchedule
-    settings:
-      clusterName: ${module.eks.cluster_name}
-      clusterEndpoint: ${module.eks.cluster_endpoint}
-      interruptionQueue: ${module.karpenter.queue_name}
-    EOT
-  ]
-
-  lifecycle {
-    ignore_changes = [
-      repository_password
-    ]
+  tags = {
+    Name = "modern-engineering-node-role"
   }
-
 }
 
+# Attach Required IAM Policies for EKS Auto Mode
+resource "aws_iam_role_policy_attachment" "eks_node_policies" {
+  for_each = toset([
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly",
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/AmazonSSMPatchAssociation"
+  ])
 
+  policy_arn = each.key
+  role       = aws_iam_role.eks_node_role.name
+}
+
+# Attach Custom IAM Policy for Auto Mode (custom-aws-tagging-eks-auto)
+resource "aws_iam_policy" "custom_aws_tagging_eks_auto" {
+  name        = "custom-aws-tagging-eks-auto"
+  description = "Custom IAM policy for EKS Auto Mode node permissions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Compute"
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateFleet",
+          "ec2:RunInstances",
+          "ec2:CreateLaunchTemplate"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/eks:eks-cluster-name" = "$${aws:PrincipalTag/eks:eks-cluster-name}"
+          }
+          StringLike = {
+            "aws:RequestTag/eks:kubernetes-node-class-name" = "*"
+            "aws:RequestTag/eks:kubernetes-node-pool-name"  = "*"
+          }
+        }
+      },
+      {
+        Sid    = "Storage"
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateVolume",
+          "ec2:CreateSnapshot"
+        ]
+        Resource = [
+          "arn:aws:ec2:*:*:volume/*",
+          "arn:aws:ec2:*:*:snapshot/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/eks:eks-cluster-name" = "$${aws:PrincipalTag/eks:eks-cluster-name}"
+          }
+        }
+      },
+      {
+        Sid    = "Networking"
+        Effect = "Allow"
+        Action = "ec2:CreateNetworkInterface"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/eks:eks-cluster-name" = "$${aws:PrincipalTag/eks:eks-cluster-name}"
+          }
+          StringLike = {
+            "aws:RequestTag/eks:kubernetes-cni-node-name" = "*"
+          }
+        }
+      },
+      {
+        Sid    = "LoadBalancer"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup",
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:CreateRule",
+          "ec2:CreateSecurityGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/eks:eks-cluster-name" = "$${aws:PrincipalTag/eks:eks-cluster-name}"
+          }
+        }
+      },
+      {
+        Sid    = "ShieldProtection"
+        Effect = "Allow"
+        Action = [
+          "shield:CreateProtection"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/eks:eks-cluster-name" = "$${aws:PrincipalTag/eks:eks-cluster-name}"
+          }
+        }
+      },
+      {
+        Sid    = "ShieldTagResource"
+        Effect = "Allow"
+        Action = [
+          "shield:TagResource"
+        ]
+        Resource = "arn:aws:shield::*:protection/*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/eks:eks-cluster-name" = "$${aws:PrincipalTag/eks:eks-cluster-name}"
+          }
+        }
+      }
+    ]
+  })
+}
+
+## Below is responsible for giving EKS Auto Mode the permissions it needs to access the cluster and create its needed instances.
+# Attach the Custom IAM Policy to the EKS Node Role
+resource "aws_iam_role_policy_attachment" "custom_aws_tagging_eks_auto_attach" {
+  policy_arn = aws_iam_policy.custom_aws_tagging_eks_auto.arn
+  role       = aws_iam_role.eks_node_role.name
+}
+
+# Create the access entry for EC2 nodes in EKS Auto Mode
+resource "aws_eks_access_entry" "auto_mode_node_access" {
+  cluster_name  = module.eks.cluster_name
+  principal_arn = aws_iam_role.eks_node_role.arn  # Dynamically uses modern-engineering role
+  type          = "EC2"
+}
+
+# Associate the Auto Node Policy with EKS Auto Mode Nodes
+resource "aws_eks_access_policy_association" "auto_mode_node_policy" {
+  cluster_name  = module.eks.cluster_name
+  principal_arn = aws_iam_role.eks_node_role.arn  # Dynamically uses modern-engineering role
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAutoNodePolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+}

--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/install.sh
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/install.sh
@@ -17,7 +17,7 @@ terraform apply -auto-approve
 
 aws eks --region us-west-2 update-kubeconfig --name modern-engineering
 
-kubectl apply -f ./karpenter.yaml
+kubectl apply -f ./auto-mode.yaml # Installs AutoMode to the management cluster.
 
 export GITHUB_URL=$(yq '.repo_url' ${REPO_ROOT}/platform/infra/terraform/mgmt/setups/config.yaml)
 

--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/main.tf
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/main.tf
@@ -29,12 +29,6 @@ provider "kubernetes" {
   }
 }
 
-# Required for public ECR where Karpenter artifacts are hosted
-provider "aws" {
-  region = "us-east-1"
-  alias  = "virginia"
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
@@ -53,16 +47,13 @@ provider "helm" {
 # Common data/locals
 ################################################################################
 
-data "aws_ecrpublic_authorization_token" "token" {
-  provider = aws.virginia
-}
-
 data "aws_availability_zones" "available" {}
 
 locals {
   name   = "modern-engineering"
   region = "us-west-2"
-
+  eks_version = "1.32"
+  
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 

--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/uninstall.sh
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/uninstall.sh
@@ -17,6 +17,6 @@ cd -
 
 cd "${REPO_ROOT}/platform/infra/terraform/mgmt/terraform/mgmt-cluster"
 
-kubectl delete -f ./karpenter.yaml || true
+kubectl delete -f ./auto-mode.yaml || true
 
 terraform destroy -auto-approve

--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/vpc.tf
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/vpc.tf
@@ -18,8 +18,8 @@ module "vpc" {
 
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
-    # Tags subnets for Karpenter auto-discovery
-    "karpenter.sh/discovery" = local.name
+    # Tags subnets for Auto-Mode auto-discovery
+    "eks.amazonaws.com/discovery" = local.name
   }
 
   tags = local.tags


### PR DESCRIPTION
*Description of changes:*

- Auto Mode is now fully functional and has been run end to end on @hmuthusamy and my machines successfully. Ack may cause an error at some point unrelated to auto mode, but re running it after a clean up seems to get past it (Hari cleaned up, and I just waited awhile and when I retried it got past it).

- All pods are running successfully in the cluster, and all Pods match the current workshop setup at the same initial deployment stage of 2 Unknown, 41 synced, and 4 out of sync but all green in the Argo UI and they are the same pod names for each after giving it time post deployment.

Now as @elamaran11 stated in a previous draft PR https://github.com/aws-samples/appmod-blueprints/pull/178#pullrequestreview-2630007543:

1. Did any one do apple to apple comparison of TE in Workshop vs the deployment run with Auto Mode in your environment. Do you see any difference in behavior
2. Did we have anyone run the workshop like run end to end with your auto mode environment. This is mandatory for merge.
This is a breaking change, so we need to have thorough review, before we can merge.

If these changes can be merged to dev and tested without revealing any breaking changes it should be good to merge into Main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
