### PR TITLE
Fixed ingress nginx CVE and  found the ACK CRD timefix

### DIFF
--- a/platform/infra/terraform/deploy-apps/ack-dev.yaml
+++ b/platform/infra/terraform/deploy-apps/ack-dev.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - chart: ack-chart
       repoURL: public.ecr.aws/aws-controllers-k8s
-      targetRevision: 46.19.33
+      targetRevision: 46.20.1
       helm:
         releaseName: ack-chart
         valueFiles:

--- a/platform/infra/terraform/deploy-apps/ack-prod.yaml
+++ b/platform/infra/terraform/deploy-apps/ack-prod.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - chart: ack-chart
       repoURL: public.ecr.aws/aws-controllers-k8s
-      targetRevision: 46.19.33
+      targetRevision: 46.20.1
       helm:
         releaseName: ack-chart
         valueFiles:

--- a/platform/infra/terraform/deploy-apps/manifests/ingress-nginx-dev.yaml
+++ b/platform/infra/terraform/deploy-apps/manifests/ingress-nginx-dev.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - chart: ingress-nginx
       repoURL: https://kubernetes.github.io/ingress-nginx
-      targetRevision: 4.10.0
+      targetRevision: 4.12.1
       helm:
         releaseName: ingress-nginx-dev
         parameters:

--- a/platform/infra/terraform/deploy-apps/manifests/ingress-nginx-prod.yaml
+++ b/platform/infra/terraform/deploy-apps/manifests/ingress-nginx-prod.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - chart: ingress-nginx
       repoURL: https://kubernetes.github.io/ingress-nginx
-      targetRevision: 4.10.0
+      targetRevision: 4.12.1
       helm:
         releaseName: ingress-nginx-prod
         parameters:

--- a/platform/infra/terraform/mgmt/terraform/ack.tf
+++ b/platform/infra/terraform/mgmt/terraform/ack.tf
@@ -29,7 +29,8 @@ resource "kubectl_manifest" "application_argocd_ack" {
   )
 
   provisioner "local-exec" {
-    command = "kubectl wait --for=jsonpath=.status.health.status=Healthy -n argocd application/ack --timeout=300s"
+
+    command = "kubectl wait --for=jsonpath=.status.health.status=Healthy -n argocd application/ack --timeout=900s &&  kubectl wait --for=jsonpath=.status.sync.status=Synced --timeout=900s -n argocd application/ack"
 
     interpreter = ["/bin/bash", "-c"]
   }

--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/day2-ops/templates/argocd-apps/ingress-nginx.yaml
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/day2-ops/templates/argocd-apps/ingress-nginx.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - chart: ingress-nginx
       repoURL: https://kubernetes.github.io/ingress-nginx
-      targetRevision: 4.10.0
+      targetRevision: 4.12.1
       helm:
         releaseName: ingress-nginx
         valueFiles:

--- a/platform/infra/terraform/mgmt/terraform/templates/argocd-apps/ack.yaml
+++ b/platform/infra/terraform/mgmt/terraform/templates/argocd-apps/ack.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - chart: ack-chart
       repoURL: public.ecr.aws/aws-controllers-k8s
-      targetRevision: 46.19.33
+      targetRevision: 46.20.1
       helm:
         releaseName: ack-chart
         valueFiles:


### PR DESCRIPTION
*Issue #, if available:*
#211 
*Description of changes:*
Fix #211  Resolution to update nginx
ACK timeout increase to resolve the CRD deployment to 15minutes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
