### PR TITLE
wait for keycloak to be healthy before starting backstage

### DIFF
--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -26,6 +26,23 @@ spec:
                   items:
                     - key: k8s-config.yaml
                       path: k8s-config.yaml
+      # add an InitContainer that waits until a url is reachable using curl
+      initContainers:
+        - name: wait-for-keycloak
+          image: curlimages/curl
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Keycloak url to be up $KEYCLOAK_NAME_METADATA"
+              until curl -s -k -f $KEYCLOAK_NAME_METADATA; do
+                echo "Waiting for keycloak to be ready..."
+                sleep 10
+              done
+              sleep 60
+          envFrom:
+            - secretRef:
+                name: backstage-env-vars
       containers:
         - name: backstage
           image: ghcr.io/cnoe-io/backstage-app:135c0cb26f3e004a27a11edb6a4779035aff9805

--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -39,6 +39,7 @@ spec:
                 echo "Waiting for keycloak to be ready..."
                 sleep 10
               done
+              echo ""
               echo "Keycloak is up!"
               #TODO: making it 5 minutes to be sure, we can decrease this later
               sleep 300

--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -34,12 +34,14 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "Waiting for Keycloak url to be up $KEYCLOAK_NAME_METADATA"
+              echo "Check if Keycloak url is up on $KEYCLOAK_NAME_METADATA"
               until curl -s -k -f $KEYCLOAK_NAME_METADATA; do
                 echo "Waiting for keycloak to be ready..."
                 sleep 10
               done
-              sleep 60
+              echo "Keycloak is up!"
+              #TODO: making it 5 minutes to be sure, we can decrease this later
+              sleep 300
           envFrom:
             - secretRef:
                 name: backstage-env-vars


### PR DESCRIPTION
Fix #218 

*Description of changes:*
Add init container in backstage pod to check for keycloak

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
