### PR TITLE
Add startupProbe to backstage

### DIFF
--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -75,7 +75,6 @@ spec:
               path: /api/auth/keycloak-oidc/start?scope=openid%20profile%20email%20groups&flow=popup&env=development
               port: http
             initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 12
+
 
 

--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -26,26 +26,6 @@ spec:
                   items:
                     - key: k8s-config.yaml
                       path: k8s-config.yaml
-      # add an InitContainer that waits until a url is reachable using curl
-      initContainers:
-        - name: wait-for-keycloak
-          image: curlimages/curl
-          command:
-            - /bin/sh
-            - -c
-            - |
-              echo "Check if Keycloak url is up on $KEYCLOAK_NAME_METADATA"
-              until curl -s -k -f $KEYCLOAK_NAME_METADATA; do
-                echo "Waiting for keycloak to be ready..."
-                sleep 10
-              done
-              echo ""
-              echo "Keycloak is up!"
-              #TODO: making it 5 minutes to be sure, we can decrease this later
-              sleep 300
-          envFrom:
-            - secretRef:
-                name: backstage-env-vars
       containers:
         - name: backstage
           image: ghcr.io/cnoe-io/backstage-app:135c0cb26f3e004a27a11edb6a4779035aff9805

--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -73,7 +73,7 @@ spec:
           startupProbe:
             httpGet:
               path: /api/auth/keycloak-oidc/start?scope=openid%20profile%20email%20groups&flow=popup&env=development
-              port: 7007
+              port: http
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 12

--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -70,4 +70,12 @@ spec:
                 name: gitea-credentials
             - secretRef:
                 name: argocd-credentials
+          startupProbe:
+            httpGet:
+              path: /api/auth/keycloak-oidc/start?scope=openid%20profile%20email%20groups&flow=popup&env=development
+              port: 7007
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 12
+
 

--- a/packages/backstage/dev/patches/deployment-backstage.yaml
+++ b/packages/backstage/dev/patches/deployment-backstage.yaml
@@ -75,6 +75,5 @@ spec:
               path: /api/auth/keycloak-oidc/start?scope=openid%20profile%20email%20groups&flow=popup&env=development
               port: http
             initialDelaySeconds: 10
-
-
+            timeoutSeconds: 10
 


### PR DESCRIPTION
Issue #218 

*Description of changes:*
Add startupProbe to detect if we have the login error, and if its detected the container will be restarted. This error only shows up once, every time we have restarted backstage continues to work.
The http probe should return 302, which is consider a success for kubelet, the pod will be marked with a warning
```
 Warning  ProbeWarning  28s    kubelet            Startup probe warning: Probe terminated redirects, Response body:
```

The initContainer wait didn't help. So removing it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
