### PR TITLE
increate timeout for k8s client in spark

### DIFF
--- a/platform/backstage/templates/spark-job/skeleton/manifests/deployment.yaml
+++ b/platform/backstage/templates/spark-job/skeleton/manifests/deployment.yaml
@@ -89,3 +89,8 @@ spec:
               volumeMounts:
                 - name: "test-volume"
                   mountPath: "/tmp"
+            sparkConf:
+              "spark.kubernetes.submission.connectionTimeout": "300000"
+              "spark.kubernetes.submission.requestTimeout": "300000"
+              "spark.kubernetes.driver.connectionTimeout": "300000"
+              "spark.kubernetes.driver.requestTimeout": "300000"


### PR DESCRIPTION
Fixes #222 

*Description of changes:*
k8s api-server is overwhelm with other controllers, and taking long to respond to spark controller, increasing k8s client timeouts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
