### PR TITLE
When regex is used and rewrite is set to false the trait spits out unroutable ingress

### DIFF
--- a/deployment/addons/kubevela/templates/traits/path-based-ingress.yaml
+++ b/deployment/addons/kubevela/templates/traits/path-based-ingress.yaml
@@ -45,11 +45,11 @@ spec:
         	metadata: {
         		name: context.name
         		annotations: {
-        			if parameter.rewritePath {
-        				"nginx.ingress.kubernetes.io/rewrite-target": "/$2"
-        				"nginx.ingress.kubernetes.io/use-regex":      "true"
-        			}
-        		}
+              "nginx.ingress.kubernetes.io/use-regex": "true"
+              if parameter.rewritePath {
+                "nginx.ingress.kubernetes.io/rewrite-target": "/$2"
+              }
+            }
         	}
         	spec: {
         		ingressClassName: parameter.class

--- a/platform/traits/path-based-ingress.cue
+++ b/platform/traits/path-based-ingress.cue
@@ -46,9 +46,9 @@ template: {
         metadata: {
             name: context.name
             annotations: {
+                "nginx.ingress.kubernetes.io/use-regex": "true"
                 if parameter.rewritePath {
                     "nginx.ingress.kubernetes.io/rewrite-target": "/$2"
-                    "nginx.ingress.kubernetes.io/use-regex": "true"
                 }
             }
         }


### PR DESCRIPTION
*Issue #, if available:* based on user feedback from the delivery

*Description of changes:* allows regex shape for path, without rewrite of extended path. Affects UI application in module 2 for the rust application (at least).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
