### PR TITLE
added gp3 as default storage class for automode mgmt cluster

### DIFF
--- a/platform/infra/terraform/mgmt/terraform/mgmt-cluster/eks.tf
+++ b/platform/infra/terraform/mgmt/terraform/mgmt-cluster/eks.tf
@@ -61,6 +61,9 @@ output "configure_kubectl" {
 resource "kubernetes_storage_class" "ebs-gp3-sc" {
   metadata {
     name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
   }
 
   storage_provisioner = "ebs.csi.eks.amazonaws.com" # Altering this to target EKS Auto Mode.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
adding GP3 as default storage class in automode. this will help vcluster and fleet mgmt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
