### PR TITLE
Fix terraform state management in deploy/destroy scripts

### DIFF
--- a/platform/infra/terraform/common/deploy.sh
+++ b/platform/infra/terraform/common/deploy.sh
@@ -2,39 +2,90 @@
 
 # Disable Terraform color output to prevent ANSI escape sequences
 export TF_CLI_ARGS="-no-color"
+
 set -euo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR="$(cd ${SCRIPTDIR}/../..; pwd )"
 [[ -n "${DEBUG:-}" ]] && set -x
 
+# Logging functions
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
 
-# Initialize Terraform
-if [[ -n "${TFSTATE_BUCKET_NAME:-}" && -n "${TFSTATE_LOCK_TABLE:-}" ]]; then
+log_error() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1" >&2
+}
+
+log_success() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] SUCCESS: $1"
+}
+
+# Validate required environment variables
+validate_backend_config() {
+  log "Validating S3 backend configuration..."
+  
+  if [[ -z "${TFSTATE_BUCKET_NAME:-}" ]]; then
+    log_error "TFSTATE_BUCKET_NAME environment variable is required"
+    exit 1
+  fi
+  
+  if [[ -z "${TFSTATE_LOCK_TABLE:-}" ]]; then
+    log_error "TFSTATE_LOCK_TABLE environment variable is required"
+    exit 1
+  fi
+  
+  local region="${AWS_REGION:-us-east-1}"
+  
+  # Check if S3 bucket exists and is accessible
+  if ! aws s3api head-bucket --bucket "${TFSTATE_BUCKET_NAME}" 2>/dev/null; then
+    log_error "S3 bucket '${TFSTATE_BUCKET_NAME}' does not exist or is not accessible"
+    exit 1
+  fi
+  
+  # Check if DynamoDB table exists
+  if ! aws dynamodb describe-table --table-name "${TFSTATE_LOCK_TABLE}" --region "${region}" >/dev/null 2>&1; then
+    log_error "DynamoDB table '${TFSTATE_LOCK_TABLE}' does not exist or is not accessible in region '${region}'"
+    exit 1
+  fi
+  
+  log_success "Backend configuration validated"
+  log "S3 Bucket: ${TFSTATE_BUCKET_NAME}"
+  log "DynamoDB Table: ${TFSTATE_LOCK_TABLE}"
+  log "Region: ${region}"
+}
+
+# Main deployment function
+main() {
+  log "Starting common stack deployment..."
+  
+  # Validate backend configuration
+  validate_backend_config
+  
+  # Initialize Terraform with S3 backend
+  log "Initializing Terraform with S3 backend..."
   if ! terraform -chdir=$SCRIPTDIR init --upgrade \
     -backend-config="bucket=${TFSTATE_BUCKET_NAME}" \
     -backend-config="dynamodb_table=${TFSTATE_LOCK_TABLE}" \
     -backend-config="region=${AWS_REGION:-us-east-1}"; then
-    echo "ERROR: Terraform init failed with remote backend"
+    log_error "Terraform initialization failed"
     exit 1
   fi
-else
-  if ! terraform -chdir=$SCRIPTDIR init --upgrade; then
-    echo "ERROR: Terraform init failed"
+  
+  # Apply Terraform configuration
+  log "Applying git resources..."
+  if ! terraform -chdir=$SCRIPTDIR apply -auto-approve; then
+    log_error "Terraform apply failed"
     exit 1
   fi
-  echo "WARNING: TFSTATE_BUCKET_NAME and/or TFSTATE_LOCK_TABLE environment variables not set."
-  echo "WARNING: Terraform state will be stored locally and may be lost!"
-fi
+  
+  # Wait for SSH access
+  log "Waiting for SSH access to be configured..."
+  sleep 10
+  
+  log_success "Common stack deployment completed successfully"
+}
 
-echo "Applying git resources"
-
-if ! terraform -chdir=$SCRIPTDIR apply -auto-approve; then
-  echo "ERROR: Terraform apply failed"
-  exit 1
-fi
-
-# wait for ssh access allowed
-sleep 10
-echo "SUCCESS: Common stack deployment completed successfully"
-
+# Run main function
+main "$@"

--- a/platform/infra/terraform/hub/deploy.sh
+++ b/platform/infra/terraform/hub/deploy.sh
@@ -2,7 +2,6 @@
 
 # Disable Terraform color output to prevent ANSI escape sequences
 export TF_CLI_ARGS="-no-color"
-#DEBUG=1 $BASE_DIR/platform/infra/terraform/hub/deploy.sh --cluster-name ${CLUSTER_NAME}
 
 set -euo pipefail
 
@@ -10,7 +9,56 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR="$(cd ${SCRIPTDIR}/../..; pwd )"
 [[ -n "${DEBUG:-}" ]] && set -x
 
+source "${ROOTDIR}/terraform/common.sh"
+
 TF_VAR_FILE=${TF_VAR_FILE:-"terraform.tfvars"}
+
+# Logging functions
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+log_error() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1" >&2
+}
+
+log_success() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] SUCCESS: $1"
+}
+
+# Validate required environment variables
+validate_backend_config() {
+  log "Validating S3 backend configuration..."
+  
+  if [[ -z "${TFSTATE_BUCKET_NAME:-}" ]]; then
+    log_error "TFSTATE_BUCKET_NAME environment variable is required"
+    exit 1
+  fi
+  
+  if [[ -z "${TFSTATE_LOCK_TABLE:-}" ]]; then
+    log_error "TFSTATE_LOCK_TABLE environment variable is required"
+    exit 1
+  fi
+  
+  local region="${AWS_REGION:-us-east-1}"
+  
+  # Check if S3 bucket exists and is accessible
+  if ! aws s3api head-bucket --bucket "${TFSTATE_BUCKET_NAME}" 2>/dev/null; then
+    log_error "S3 bucket '${TFSTATE_BUCKET_NAME}' does not exist or is not accessible"
+    exit 1
+  fi
+  
+  # Check if DynamoDB table exists
+  if ! aws dynamodb describe-table --table-name "${TFSTATE_LOCK_TABLE}" --region "${region}" >/dev/null 2>&1; then
+    log_error "DynamoDB table '${TFSTATE_LOCK_TABLE}' does not exist or is not accessible in region '${region}'"
+    exit 1
+  fi
+  
+  log_success "Backend configuration validated"
+  log "S3 Bucket: ${TFSTATE_BUCKET_NAME}"
+  log "DynamoDB Table: ${TFSTATE_LOCK_TABLE}"
+  log "Region: ${region}"
+}
 
 # Parse command line arguments
 CLUSTER_NAME=""
@@ -29,37 +77,44 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Initialize Terraform
-if [[ -n "${TFSTATE_BUCKET_NAME:-}" && -n "${TFSTATE_LOCK_TABLE:-}" ]]; then
-  terraform -chdir=$SCRIPTDIR init --upgrade \
+# Main deployment function
+main() {
+  log "Starting hub cluster deployment..."
+  
+  # Validate backend configuration
+  validate_backend_config
+  
+  # Initialize Terraform with S3 backend
+  log "Initializing Terraform with S3 backend..."
+  if ! terraform -chdir=$SCRIPTDIR init --upgrade \
     -backend-config="bucket=${TFSTATE_BUCKET_NAME}" \
     -backend-config="dynamodb_table=${TFSTATE_LOCK_TABLE}" \
-    -backend-config="region=${AWS_REGION:-us-east-1}"
-else
-  terraform -chdir=$SCRIPTDIR init --upgrade
-  echo "WARNING: TFSTATE_BUCKET_NAME and/or TFSTATE_LOCK_TABLE environment variables not set."
-  echo "WARNING: Terraform state will be stored locally and may be lost!"
-fi
-
-echo "Deploy Hub cluster"
-
-# Get AWS Account ID
-AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-echo "Using AWS Account ID: $AWS_ACCOUNT_ID"
-
-# Apply with custom cluster name if provided
-if [ -n "$CLUSTER_NAME" ]; then
-  echo "Using custom cluster name: $CLUSTER_NAME"
-  if ! terraform -chdir=$SCRIPTDIR apply -var-file=$TF_VAR_FILE -var="cluster_name=$CLUSTER_NAME" -var="account_ids=$AWS_ACCOUNT_ID" -auto-approve; then
-    echo "ERROR: Terraform apply failed for cluster $CLUSTER_NAME"
+    -backend-config="region=${AWS_REGION:-us-east-1}"; then
+    log_error "Terraform initialization failed"
     exit 1
   fi
-else
-  echo "Using default cluster name: peeks-hub-cluster"
-  if ! terraform -chdir=$SCRIPTDIR apply -var-file=$TF_VAR_FILE -var="account_ids=$AWS_ACCOUNT_ID" -auto-approve; then
-    echo "ERROR: Terraform apply failed for default cluster"
-    exit 1
+  
+  # Get AWS Account ID
+  AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  log "Using AWS Account ID: $AWS_ACCOUNT_ID"
+  
+  # Apply with custom cluster name if provided
+  if [ -n "$CLUSTER_NAME" ]; then
+    log "Deploying with custom cluster name: $CLUSTER_NAME"
+    if ! terraform -chdir=$SCRIPTDIR apply -var-file=$TF_VAR_FILE -var="cluster_name=$CLUSTER_NAME" -var="account_ids=$AWS_ACCOUNT_ID" -auto-approve; then
+      log_error "Terraform apply failed for cluster $CLUSTER_NAME"
+      exit 1
+    fi
+  else
+    log "Deploying with default cluster name: peeks-hub-cluster"
+    if ! terraform -chdir=$SCRIPTDIR apply -var-file=$TF_VAR_FILE -var="account_ids=$AWS_ACCOUNT_ID" -auto-approve; then
+      log_error "Terraform apply failed for default cluster"
+      exit 1
+    fi
   fi
-fi
+  
+  log_success "Hub cluster deployment completed successfully"
+}
 
-echo "SUCCESS: Hub cluster deployment completed successfully"
+# Run main function
+main "$@"

--- a/platform/infra/terraform/spokes/deploy.sh
+++ b/platform/infra/terraform/spokes/deploy.sh
@@ -2,8 +2,6 @@
 
 # Disable Terraform color output to prevent ANSI escape sequences
 export TF_CLI_ARGS="-no-color"
-#usage:
-#DEBUG=1 $BASE_DIR/platform/infra/terraform/spokes/deploy.sh ${SPOKE} --cluster-name-prefix ${CLUSTER_NAME_PREFIX}
 
 set -euo pipefail
 
@@ -11,163 +9,225 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR="$(cd ${SCRIPTDIR}/../..; pwd )"
 [[ -n "${DEBUG:-}" ]] && set -x
 
-if [[ $# -eq 0 ]] ; then
-    echo "No arguments supplied"
-    echo "Usage: deploy.sh <environment> [--cluster-name-prefix <prefix>] [--deploy-db]"
-    echo "Example: deploy.sh dev"
-    echo "Example with database: deploy.sh dev --deploy-db"
-    echo "Example with custom cluster name prefix: deploy.sh dev --cluster-name-prefix peeks-spoke-test --deploy-db"
-    echo ""
-    echo "Required environment variables:"
-    echo "  TFSTATE_BUCKET_NAME - S3 bucket for Terraform state"
-    echo "  AWS_REGION - AWS region for resources"
+# Logging functions
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+log_error() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1" >&2
+}
+
+log_success() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] SUCCESS: $1"
+}
+
+# Validate required environment variables
+validate_backend_config() {
+  log "Validating S3 backend configuration..."
+  
+  if [[ -z "${TFSTATE_BUCKET_NAME:-}" ]]; then
+    log_error "TFSTATE_BUCKET_NAME environment variable is required"
     exit 1
-fi
-
-# Check required environment variables
-if [[ -z "${TFSTATE_BUCKET_NAME:-}" ]]; then
-    echo "Error: TFSTATE_BUCKET_NAME environment variable is required"
+  fi
+  
+  if [[ -z "${TFSTATE_LOCK_TABLE:-}" ]]; then
+    log_error "TFSTATE_LOCK_TABLE environment variable is required"
     exit 1
-fi
-
-if [[ -z "${AWS_REGION:-}" ]]; then
-    echo "Error: AWS_REGION environment variable is required"
+  fi
+  
+  local region="${AWS_REGION:-us-east-1}"
+  
+  # Check if S3 bucket exists and is accessible
+  if ! aws s3api head-bucket --bucket "${TFSTATE_BUCKET_NAME}" 2>/dev/null; then
+    log_error "S3 bucket '${TFSTATE_BUCKET_NAME}' does not exist or is not accessible"
     exit 1
-fi
+  fi
+  
+  # Check if DynamoDB table exists
+  if ! aws dynamodb describe-table --table-name "${TFSTATE_LOCK_TABLE}" --region "${region}" >/dev/null 2>&1; then
+    log_error "DynamoDB table '${TFSTATE_LOCK_TABLE}' does not exist or is not accessible in region '${region}'"
+    exit 1
+  fi
+  
+  log_success "Backend configuration validated"
+  log "S3 Bucket: ${TFSTATE_BUCKET_NAME}"
+  log "DynamoDB Table: ${TFSTATE_LOCK_TABLE}"
+  log "Region: ${region}"
+}
 
-env=$1
-shift
+# Usage function
+usage() {
+  echo "Usage: deploy.sh <environment> [--cluster-name-prefix <prefix>] [--deploy-db]"
+  echo "Example: deploy.sh dev"
+  echo "Example with database: deploy.sh dev --deploy-db"
+  echo "Example with custom cluster name prefix: deploy.sh dev --cluster-name-prefix peeks-spoke-test --deploy-db"
+  echo ""
+  echo "Required environment variables:"
+  echo "  TFSTATE_BUCKET_NAME - S3 bucket for Terraform state"
+  echo "  TFSTATE_LOCK_TABLE - DynamoDB table for Terraform state locking"
+  echo "  AWS_REGION - AWS region for resources (optional, defaults to us-east-1)"
+  exit 1
+}
 
-# Parse additional command line arguments
-CLUSTER_NAME_PREFIX=""
-DEPLOY_DB=false
+# Wait for GitLab CloudFront distribution
+wait_for_gitlab_distribution() {
+  log "Waiting for GitLab CloudFront distribution to be created by hub cluster..."
+  local gitlab_domain=""
+  local max_attempts=30
+  local attempt=0
 
-while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    --cluster-name-prefix)
-      CLUSTER_NAME_PREFIX="$2"
-      shift
-      shift
-      ;;
-    --deploy-db)
-      DEPLOY_DB=true
-      shift
-      ;;
-    *)
-      shift
-      ;;
-  esac
-done
-
-echo "Using S3 bucket: ${TFSTATE_BUCKET_NAME}"
-echo "Using AWS region: ${AWS_REGION}"
-echo "Deploying $env with workspaces/${env}.tfvars ..."
-
-# Wait for GitLab CloudFront distribution to be created by hub cluster
-echo "Waiting for GitLab CloudFront distribution to be created by hub cluster..."
-GITLAB_DOMAIN=""
-MAX_ATTEMPTS=30
-ATTEMPT=0
-
-while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
-    echo "Attempt $((ATTEMPT + 1))/$MAX_ATTEMPTS: Checking for GitLab CloudFront distribution..."
+  while [[ $attempt -lt $max_attempts ]]; do
+    log "Attempt $((attempt + 1))/$max_attempts: Checking for GitLab CloudFront distribution..."
     
-    # Check for GitLab distribution
-    GITLAB_DOMAIN=$(aws cloudfront list-distributions --query "DistributionList.Items[?contains(Origins.Items[0].Id, 'gitlab')].DomainName | [0]" --output text 2>/dev/null || echo "None")
+    gitlab_domain=$(aws cloudfront list-distributions --query "DistributionList.Items[?contains(Origins.Items[0].Id, 'gitlab')].DomainName | [0]" --output text 2>/dev/null || echo "None")
     
-    if [[ "$GITLAB_DOMAIN" != "None" && -n "$GITLAB_DOMAIN" ]]; then
-        echo "✓ Found GitLab CloudFront distribution: ${GITLAB_DOMAIN}"
-        break
+    if [[ "$gitlab_domain" != "None" && -n "$gitlab_domain" ]]; then
+      log_success "Found GitLab CloudFront distribution: ${gitlab_domain}"
+      echo "$gitlab_domain"
+      return 0
     fi
     
-    if [[ $ATTEMPT -eq $((MAX_ATTEMPTS - 1)) ]]; then
-        echo "⚠️  Warning: GitLab CloudFront distribution not found after $MAX_ATTEMPTS attempts"
-        echo "   GitLab domain: ${GITLAB_DOMAIN}"
-        echo "   Continuing with empty value..."
-        GITLAB_DOMAIN=""
-        break
+    if [[ $attempt -eq $((max_attempts - 1)) ]]; then
+      log "Warning: GitLab CloudFront distribution not found after $max_attempts attempts"
+      log "Continuing with empty value..."
+      echo ""
+      return 0
     fi
     
-    echo "   Waiting 30 seconds before next attempt..."
+    log "Waiting 30 seconds before next attempt..."
     sleep 30
-    ATTEMPT=$((ATTEMPT + 1))
-done
+    attempt=$((attempt + 1))
+  done
+}
 
-# Deploy database first if requested
-if [ "$DEPLOY_DB" = true ]; then
-  echo "Deploying database for $env environment..."
+# Deploy database
+deploy_database() {
+  local env=$1
+  local cluster_name_prefix=$2
+  
+  log "Deploying database for $env environment..."
   
   if ! terraform -chdir=${SCRIPTDIR}/db init -reconfigure \
     -backend-config="bucket=${TFSTATE_BUCKET_NAME}" \
     -backend-config="key=spokes/db/${env}/terraform.tfstate" \
-    -backend-config="region=${AWS_REGION}"; then
-    echo "ERROR: Database terraform init failed"
+    -backend-config="dynamodb_table=${TFSTATE_LOCK_TABLE}" \
+    -backend-config="region=${AWS_REGION:-us-east-1}"; then
+    log_error "Database terraform init failed"
     exit 1
   fi
   
   terraform -chdir=${SCRIPTDIR}/db workspace select -or-create $env
   
-  if [ -n "$CLUSTER_NAME_PREFIX" ]; then
-    if ! terraform -chdir=${SCRIPTDIR}/db apply -var-file="../workspaces/${env}.tfvars" -var="cluster_name_prefix=$CLUSTER_NAME_PREFIX" -auto-approve; then
-      echo "ERROR: Database deployment failed with custom cluster name prefix"
+  if [ -n "$cluster_name_prefix" ]; then
+    if ! terraform -chdir=${SCRIPTDIR}/db apply -var-file="../workspaces/${env}.tfvars" -var="cluster_name_prefix=$cluster_name_prefix" -auto-approve; then
+      log_error "Database deployment failed with custom cluster name prefix"
       exit 1
     fi
   else
     if ! terraform -chdir=${SCRIPTDIR}/db apply -var-file="../workspaces/${env}.tfvars" -auto-approve; then
-      echo "ERROR: Database deployment failed"
+      log_error "Database deployment failed"
       exit 1
     fi
   fi
   
-  echo "Database deployment completed for $env"
-fi
+  log_success "Database deployment completed for $env"
+}
 
 # Deploy EKS cluster
-echo "Deploying EKS cluster for $env environment..."
+deploy_eks_cluster() {
+  local env=$1
+  local cluster_name_prefix=$2
+  local gitlab_domain=$3
+  
+  log "Deploying EKS cluster for $env environment..."
 
-if [[ -n "${TFSTATE_BUCKET_NAME:-}" && -n "${TFSTATE_LOCK_TABLE:-}" ]]; then
   if ! terraform -chdir=$SCRIPTDIR init --upgrade \
     -backend-config="bucket=${TFSTATE_BUCKET_NAME}" \
     -backend-config="key=spokes/${env}/terraform.tfstate" \
     -backend-config="dynamodb_table=${TFSTATE_LOCK_TABLE}" \
-    -backend-config="region=${AWS_REGION}"; then
-    echo "ERROR: Terraform init failed"
+    -backend-config="region=${AWS_REGION:-us-east-1}"; then
+    log_error "Terraform init failed"
     exit 1
   fi
-else
-  if ! terraform -chdir=$SCRIPTDIR init --upgrade; then
-    echo "ERROR: Terraform init failed"
-    exit 1
-  fi
-  echo "WARNING: TFSTATE_BUCKET_NAME and/or TFSTATE_LOCK_TABLE environment variables not set."
-  echo "WARNING: Terraform state will be stored locally and may be lost!"
-fi
 
-terraform -chdir=$SCRIPTDIR workspace select -or-create $env
+  terraform -chdir=$SCRIPTDIR workspace select -or-create $env
 
-# Apply with custom cluster name prefix if provided
-if [ -n "$CLUSTER_NAME_PREFIX" ]; then
-  echo "Using custom cluster name prefix: $CLUSTER_NAME_PREFIX"
-  if ! terraform -chdir=$SCRIPTDIR apply \
-    -var-file="workspaces/${env}.tfvars" \
-    -var="cluster_name_prefix=$CLUSTER_NAME_PREFIX" \
-    -var="git_hostname=$GITLAB_DOMAIN" \
-    -var="gitlab_domain_name=$GITLAB_DOMAIN" \
-    -auto-approve; then
-    echo "ERROR: EKS cluster deployment failed with custom cluster name prefix"
-    exit 1
+  # Apply with custom cluster name prefix if provided
+  if [ -n "$cluster_name_prefix" ]; then
+    log "Using custom cluster name prefix: $cluster_name_prefix"
+    if ! terraform -chdir=$SCRIPTDIR apply \
+      -var-file="workspaces/${env}.tfvars" \
+      -var="cluster_name_prefix=$cluster_name_prefix" \
+      -var="git_hostname=$gitlab_domain" \
+      -var="gitlab_domain_name=$gitlab_domain" \
+      -auto-approve; then
+      log_error "EKS cluster deployment failed with custom cluster name prefix"
+      exit 1
+    fi
+  else
+    log "Using default cluster name prefix: peeks-spoke"
+    if ! terraform -chdir=$SCRIPTDIR apply \
+      -var-file="workspaces/${env}.tfvars" \
+      -var="git_hostname=$gitlab_domain" \
+      -var="gitlab_domain_name=$gitlab_domain" \
+      -auto-approve; then
+      log_error "EKS cluster deployment failed"
+      exit 1
+    fi
   fi
-else
-  echo "Using default cluster name prefix: peeks-spoke"
-  if ! terraform -chdir=$SCRIPTDIR apply \
-    -var-file="workspaces/${env}.tfvars" \
-    -var="git_hostname=$GITLAB_DOMAIN" \
-    -var="gitlab_domain_name=$GITLAB_DOMAIN" \
-    -auto-approve; then
-    echo "ERROR: EKS cluster deployment failed"
-    exit 1
-  fi
-fi
+}
 
-echo "SUCCESS: Spoke cluster deployment completed successfully for $env"
+# Main function
+main() {
+  if [[ $# -eq 0 ]]; then
+    usage
+  fi
+
+  local env=$1
+  shift
+
+  # Parse additional command line arguments
+  local cluster_name_prefix=""
+  local deploy_db=false
+
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+      --cluster-name-prefix)
+        cluster_name_prefix="$2"
+        shift
+        shift
+        ;;
+      --deploy-db)
+        deploy_db=true
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  log "Starting spoke cluster deployment for environment: $env"
+  
+  # Validate backend configuration
+  validate_backend_config
+  
+  # Wait for GitLab distribution
+  local gitlab_domain
+  gitlab_domain=$(wait_for_gitlab_distribution)
+  
+  # Deploy database if requested
+  if [ "$deploy_db" = true ]; then
+    deploy_database "$env" "$cluster_name_prefix"
+  fi
+  
+  # Deploy EKS cluster
+  deploy_eks_cluster "$env" "$cluster_name_prefix" "$gitlab_domain"
+  
+  log_success "Spoke cluster deployment completed successfully for $env"
+}
+
+# Run main function
+main "$@"

--- a/scripts/0-install.sh
+++ b/scripts/0-install.sh
@@ -6,6 +6,11 @@
 
 set -e
 
+# Source environment variables
+if [ -f /home/ec2-user/.bashrc.d/env.bash ]; then
+    source /home/ec2-user/.bashrc.d/env.bash
+fi
+
 # Source colors for output formatting
 source "$(dirname "$0")/colors.sh"
 

--- a/scripts/update_template_defaults.sh
+++ b/scripts/update_template_defaults.sh
@@ -3,6 +3,11 @@
 # Exit on error
 set -e
 
+# Source environment variables
+if [ -f /home/ec2-user/.bashrc.d/env.bash ]; then
+    source /home/ec2-user/.bashrc.d/env.bash
+fi
+
 # Source colors for output formatting
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPT_DIR/colors.sh"


### PR DESCRIPTION
## Summary
Simplifies terraform scripts to require S3 backend configuration and fixes state management issues in taskcat operations.

## Changes
- Remove local state fallback from all deploy/destroy scripts (hub, spokes, common)
- Add mandatory validation for TFSTATE_BUCKET_NAME and TFSTATE_LOCK_TABLE environment variables
- Fail fast with clear error messages if S3 backend prerequisites not configured
- Consistent logging and error handling across all terraform scripts
- Fix terraform state management issues that were causing taskcat-delete failures

## Required Environment Variables
```bash
export TFSTATE_BUCKET_NAME=your-terraform-state-bucket
export TFSTATE_LOCK_TABLE=your-terraform-lock-table
export AWS_REGION=us-east-1  # optional, defaults to us-east-1
```

## Testing
- All scripts now validate S3 backend configuration before proceeding
- Scripts exit immediately with clear error messages if prerequisites missing
- No more fallback to local state that could cause state management issues

Fixes the terraform state issues mentioned in taskcat-delete operations.