### PR TITLE
fix: add RBAC permissions for CI/CD pipeline to access ArgoCD fleet s…

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -406,6 +406,61 @@ spec:
           name: ${schema.spec.name}-role
           apiGroup: rbac.authorization.k8s.io
 
+    # ClusterRole for accessing ArgoCD fleet secrets (DORA metrics)
+    - id: clusterrole
+      template:
+       apiVersion: rbac.authorization.k8s.io/v1
+       kind: ClusterRole
+       metadata:
+          name: ${schema.spec.name}-argocd-access
+          ownerReferences:
+             - apiVersion: kro.run/v1alpha1
+               kind: CICDPipeline
+               name: ${schema.metadata.name}
+               uid: ${schema.metadata.uid}
+               blockOwnerDeletion: true
+               controller: false
+          labels:
+             app.kubernetes.io/name: ${schema.spec.application.name}
+             app.kubernetes.io/component: cicd-pipeline
+          annotations:
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"]}
+       rules:
+          - apiGroups: [""]
+            resources: ["secrets"]
+            resourceNames: ["fleet-secret-fleet-${schema.spec.aws.clusterName}"]
+            verbs: ["get", "list"]
+
+    # ClusterRoleBinding for ArgoCD access
+    - id: clusterrolebinding
+      readyWhen:
+       - ${clusterrolebinding.metadata.name != ""}
+      template:
+       apiVersion: rbac.authorization.k8s.io/v1
+       kind: ClusterRoleBinding
+       metadata:
+          name: ${schema.spec.name}-argocd-access
+          ownerReferences:
+             - apiVersion: kro.run/v1alpha1
+               kind: CICDPipeline
+               name: ${schema.metadata.name}
+               uid: ${schema.metadata.uid}
+               blockOwnerDeletion: true
+               controller: false
+          labels:
+             app.kubernetes.io/name: ${schema.spec.application.name}
+             app.kubernetes.io/component: cicd-pipeline
+          annotations:
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"]}
+       subjects:
+          - kind: ServiceAccount
+            name: ${schema.spec.name}-sa
+            namespace: ${schema.metadata.namespace}
+       roleRef:
+          kind: ClusterRole
+          name: ${schema.spec.name}-argocd-access
+          apiGroup: rbac.authorization.k8s.io
+
     # ConfigMap for ECR repository information and CI/CD configuration
     - id: configmap
       readyWhen:


### PR DESCRIPTION
*Issue #, if available:*

Fix issue chere get-cluster-secret is not working with error: 

```
Error from server (Forbidden): secrets "fleet-secret-fleet-peeks-spoke-dev" is forbidden: User "system:serviceaccount:team-java:java-cicd-sa" cannot get resource "secrets" in API group "" in the namespace "argocd"
Error from server (Forbidden): secrets "fleet-secret-fleet-peeks-spoke-dev" is forbidden: User "system:serviceaccount:team-java:java-cicd-sa" cannot get resource "secrets" in API group "" in the namespace "argocd"
Error from server (Forbidden): secrets "fleet-secret-fleet-peeks-spoke-dev" is forbidden: User "system:serviceaccount:team-java:java-cicd-sa" cannot get resource "secrets" in API group "" in the namespace "argocd"
time="2025-11-10T10:24:25 UTC" level=info msg="sub-process exited" argo=true error="<nil>"
time="2025-11-10T10:24:25 UTC" level=info msg="/tmp/cluster-secret -> /var/run/argo/outputs/artifacts/tmp/cluster-secret.tgz" argo=true
time="2025-11-10T10:24:25 UTC" level=info msg="Taring /tmp/cluster-secret"
time="2025-11-10T10:24:25 UTC" level=info msg="archived 4 files/dirs in /tmp/cluster-secret"
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
