### PR TITLE
Fix Appmod-Service for rust app and add IRSA for Argo Rollouts

### DIFF
--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -654,6 +654,41 @@ argo-rollouts:
   chartName: argo-rollouts
   chartRepository: https://argoproj.github.io/argo-helm
   defaultVersion: '2.39.5'
+  valuesObject:
+    serviceAccount:
+      annotations: # Using IRSA as Pod Identity is not supported
+        eks.amazonaws.com/role-arn: 'arn:aws:iam::{{.metadata.annotations.aws_account_id}}:role/{{.metadata.annotations.aws_cluster_name}}-argo-rollouts'
+    extraObjects:
+    - apiVersion: iam.services.k8s.aws/v1alpha1
+      kind: Role
+      metadata:
+        name: '{{.metadata.annotations.aws_cluster_name}}-argo-rollouts'
+        annotations:
+          argocd.argoproj.io/sync-wave: '-1' # Should be created before SA
+      spec:
+        name: '{{.metadata.annotations.aws_cluster_name}}-argo-rollouts'
+        description: "IRSA role for Argo Rollouts"
+        assumeRolePolicyDocument: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": "arn:aws:iam::{{.metadata.annotations.aws_account_id}}:oidc-provider/{{.metadata.annotations.eks_oidc_issuer}}"
+                },
+                "Action": "sts:AssumeRoleWithWebIdentity",
+                "Condition": {
+                  "StringEquals": {
+                    "{{.metadata.annotations.eks_oidc_issuer}}:sub": "system:serviceaccount:argo-rollouts:argo-rollouts",
+                    "{{.metadata.annotations.eks_oidc_issuer}}:aud": "sts.amazonaws.com"
+                  }
+                }
+              }
+            ]
+          }
+        policies:
+          - arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess
   selector:
     matchExpressions:
       - key: enable_argo_rollouts

--- a/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
+++ b/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
@@ -10,6 +10,8 @@ spec:
   schematic:
     cue:
       template: |2
+        import "strings"
+        
         let previewService = "\(context.name)-preview"
         let ampWorkspaceUrl = "{{ "{{" }}args.amp-workspace-url{{ "}}" }}" //TODO: inconsistent with cue, needs to be looked at
         let ampWorkspaceRegion = "{{ "{{" }}args.amp-workspace-region{{ "}}" }}" //TODO: inconsistent with cue, needs to be looked at
@@ -114,14 +116,15 @@ spec:
         			]
         		}
         		template: {
-        			metadata: { 
-        				labels: app: context.name
-        				if parameter.functionalGate != _|_ {
-        					annotations: {
-        						color: parameter.functionalGate.extraArgs
-        					}
-        				}
-        			}
+              metadata: { 
+                labels: app: context.name
+                annotations: {
+                  if parameter.functionalGate != _|_ {
+                    color: parameter.functionalGate.extraArgs
+                  }
+                  replicas: "\(parameter.replicas)"
+                }
+              }
         			spec: containers: [{
         				image:           parameter.image
         				imagePullPolicy: "Always"
@@ -286,22 +289,96 @@ spec:
         					provider: job: spec: {
         						template: spec: {
         							containers: [
-        								{
-        									name:  "test"
-        									image: parameter.performanceGate.image
-        									command: ["sh"]
-        									args: [
-        										"-c",
-        										"RESULT=$(ab -n 1000 -c 10 http://\(previewService):\(parameter.port)\(parameter.appPath)/ 2>/dev/null | grep -o 'Time per request:[^[]*' | head -1 | awk '{print int($4)}'); [ $RESULT -lt \(parameter.performanceGate.extraArgs) ] && exit 0 || exit 1"
-        									]
+        								if strings.Contains(context.name, "java") {
+        									{
+        										name:  "test"
+        										image: parameter.performanceGate.image
+        										command: ["sh"]
+        										args: [
+        											"-c",
+        											"RESULT=$(ab -n 1000 -c 10 http://\(previewService):\(parameter.port)\(parameter.appPath)/ 2>/dev/null | grep -o 'Time per request:[^[]*' | head -1 | awk '{print int($4)}'); [ $RESULT -lt \(parameter.performanceGate.extraArgs) ] && exit 0 || exit 1"
+        										]
+        									}
+        								},
+        								if strings.Contains(context.name, "rust") {
+        									{
+        										name:  "test"
+        										image: parameter.performanceGate.image
+        										command: ["run"]
+        										args: [
+        											"run",
+        											"-t",
+                              "http://\(previewService):\(parameter.port)",
+                              "/benchmark.yaml" 
+        										]
+        										volumeMounts: [{
+        											name: "benchmark-config"
+        											mountPath: "/benchmark.yaml"
+        											subPath: "benchmark.yaml"
+        										}]
+        									}
         								},
         							]
+        							if strings.Contains(context.name, "rust") {
+        								volumes: [{
+        									name: "benchmark-config"
+        									configMap: name: "benchmark-config-\(context.name)"
+        								}]
+        							}
         							restartPolicy: "Never"
         						}
         						backoffLimit: 0
         					}
         				},
         			]
+        		}
+        	}
+        	if parameter.performanceGate != _|_ && strings.Contains(context.name, "rust") {
+        		"benchmark-configmap": {
+        			apiVersion: "v1"
+        			kind: "ConfigMap"
+        			metadata: name: "benchmark-config-\(context.name)"
+        			data: {
+        				"benchmark.yaml": """
+        					config:
+        					  target: "http://127.0.0.1:80"
+        					  phases:
+        					    - duration: 5
+        					      arrivalRate: 1
+        					      rampTo: 10
+        					      name: Warm up
+        					    - duration: 10
+        					      arrivalRate: 10
+        					      rampTo: 100
+        					      name: Burn
+        					    - duration: 10
+        					      arrivalRate: 100
+        					      name: End
+
+        					  plugins:
+        					    ensure: {}
+        					    apdex: {}
+        					    metrics-by-endpoint: {}
+        					  apdex:
+        					    threshold: 100
+        					  ensure:
+        					    thresholds:
+        					      - http.response_time.p99: 6000
+        					      - http.response_time.p95: 6000
+
+        					scenarios:
+        					  - name: "Navigate Menus"
+        					    flow:
+        					      - get:
+        					          url: "/collection/FRONT_PAGE"
+        					      - post:
+        					          url: "/products/"
+        					          json: "Shirt"
+        					      - post:
+        					          url: "/products/"
+        					          json: "Keyboard"
+        					"""
+        			}
         		}
         	}
         }

--- a/platform/infra/terraform/common/locals.tf
+++ b/platform/infra/terraform/common/locals.tf
@@ -20,6 +20,7 @@ locals {
   hub_subnet_ids          = data.aws_eks_cluster.clusters[local.hub_cluster_key].vpc_config[0].subnet_ids
   spoke_clusters          = { for k, v in var.clusters : k => v if v.environment != "control-plane" }
   cluster_vpc_ids         = { for k, v in var.clusters : v.name => data.aws_eks_cluster.clusters[k].vpc_config[0].vpc_id }
+  cluster_oidc_issuers    = { for k, v in var.clusters : v.name => replace(data.aws_eks_cluster.clusters[k].identity[0].oidc[0].issuer, "https://", "") }
   argocd_namespace        = "argocd"
   ingress_name            = { for k, v in var.clusters : v.name => "${v.name}-ingress" }
   ingress_security_groups = { for k, v in var.clusters : v.name => "${aws_security_group.ingress_http[k].id},${aws_security_group.ingress_https[k].id}" }
@@ -127,6 +128,7 @@ locals {
         aws_cluster_name = v.name
         aws_region       = v.region
         aws_account_id   = data.aws_caller_identity.current.account_id
+        eks_oidc_issuer  = local.cluster_oidc_issuers[v.name]
         aws_vpc_id       = local.cluster_vpc_ids[v.name]
         aws_grafana_url  = module.managed_grafana.workspace_endpoint
         resource_prefix  = var.resource_prefix


### PR DESCRIPTION
*Issue #, if available:*

Need to use IRSA as Argo Rollouts' metrics provider with AMP does not support Pod Identity. Ref: https://github.com/argoproj/argo-rollouts/issues/4536

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
