### PR TITLE
Feat/rollout

### DIFF
--- a/applications/java/deployment/dev/application.yaml
+++ b/applications/java/deployment/dev/application.yaml
@@ -16,11 +16,11 @@ spec:
           - name: APP_ENV
             value: "DEV"
         # functionalGate:
-        #   pause: "10s"
+        #   pause: "30s"
         #   image: "httpd:alpine"
         #   extraArgs: "red"
         # performanceGate:
-        #   pause: "10s"
+        #   pause: "30s"
         #   image: "httpd:alpine"
         #   extraArgs: "160"
       traits:

--- a/applications/java/deployment/prod/application.yaml
+++ b/applications/java/deployment/prod/application.yaml
@@ -16,12 +16,12 @@ spec:
           - name: APP_ENV
             value: "PROD"
         functionalGate:
-          pause: "10s"
+          pause: "30s"
           image: "httpd:alpine"
           extraArgs: "orange"
         # Skip performance gate in production to avoid affecting real user traffic
         # performanceGate:
-        #   pause: "10s"
+        #   pause: "30s"
         #   image: "httpd:alpine"
         #   extraArgs: "160"
       traits:

--- a/applications/java/kargo/stages.yaml
+++ b/applications/java/kargo/stages.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: java-app-kargo
   annotations:
     kargo.akuity.io/color: green
+    kargo.akuity.io/auto-promotion: "false"
 spec:
   requestedFreight:
   - origin:
@@ -31,8 +32,9 @@ spec:
       kind: Warehouse
       name: java-app
     sources:
-      stages:
-      - dev
+      direct: true
+      #stages:
+      #- dev
   promotionTemplate:
     spec:
       steps:

--- a/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
+++ b/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
@@ -123,6 +123,7 @@ spec:
                     color: parameter.functionalGate.extraArgs
                   }
                   replicas: "\(parameter.replicas)"
+                  "rollout.argoproj.io/revision": parameter.image
                 }
               }
         			spec: containers: [{

--- a/gitops/addons/default/addons/argo-cd/values.yaml
+++ b/gitops/addons/default/addons/argo-cd/values.yaml
@@ -172,6 +172,8 @@ configs:
     # Skip TLS verification for OIDC
     oidc.tls.insecure.skip.verify: "true"
     controller.self.heal.timeout.seconds: "600"
+    # setting to short time for workshop purposes only, best practice is to use a git webhook
+    timeout.reconciliation: 30s
     # Specifies if resource health should be persisted in app CRD (default true)
     # Changing this to `false` significantly reduce number of Application CRD updates and improves controller performance.
     controller.resource.health.persist: "false"


### PR DESCRIPTION


configure progressive delivery with extended gate pauses and rollout tracking

- Increase gate pause duration from 10s to 30s in dev and prod environments
- Add rollout revision annotation for better deployment tracking
- Configure Kargo prod stage for direct promotion with auto-promotion disabled
- Reduce ArgoCD reconciliation timeout to 30s for workshop purposes"