### PR TITLE
Optimize Backstage deployment and improve ArgoCD sync reliability

### DIFF
--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -414,7 +414,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: backstage
@@ -513,6 +513,12 @@ spec:
           ports:
             - containerPort: 7007
               name: http
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              memory: 2Gi
           startupProbe:
             httpGet:
               path: /api/auth/keycloak-oidc/start?scope=openid%20profile%20email%20groups&flow=popup&env=development


### PR DESCRIPTION
Optimize Backstage deployment and improve ArgoCD sync reliability

- Reduce Backstage replicas from 2 to 1 for resource efficiency
- Add resource requests/limits to Backstage container (200m CPU, 1Gi-2Gi memory)
- Increase ArgoCD sync wave timeout from 15 to 30 minutes
- Add automatic recovery for stuck Progressing applications in ArgoCD