### PR TITLE
Add automatic terraform lock handling to deploy and destroy scripts

### DIFF
--- a/platform/infra/terraform/cluster/deploy.sh
+++ b/platform/infra/terraform/cluster/deploy.sh
@@ -33,6 +33,20 @@ main() {
   # Initialize Terraform with S3 backend
   initialize_terraform "clusters" "$DEPLOY_SCRIPTDIR"
   
+  # Check for and clear any stale locks
+  cd "$DEPLOY_SCRIPTDIR"
+  if terraform state list &>/dev/null; then
+    log "State accessible, no lock issues"
+  else
+    log_warning "State lock detected, attempting to force unlock"
+    LOCK_ID=$(terraform force-unlock -force 2>&1 | grep -oP 'Lock ID: \K[a-f0-9-]+' || echo "")
+    if [[ -n "$LOCK_ID" ]]; then
+      log "Force unlocking with ID: $LOCK_ID"
+      terraform force-unlock -force "$LOCK_ID" || log_warning "Force unlock failed, continuing anyway"
+    fi
+  fi
+  cd -
+  
   # Apply Terraform configuration
   log "Applying clusters stack..."
   if ! terraform -chdir=$DEPLOY_SCRIPTDIR apply \

--- a/platform/infra/terraform/cluster/destroy.sh
+++ b/platform/infra/terraform/cluster/destroy.sh
@@ -31,6 +31,20 @@ main() {
   # Initialize Terraform with S3 backend
   initialize_terraform "clusters" "$DEPLOY_SCRIPTDIR"
 
+  # Check for and clear any stale locks
+  cd "$DEPLOY_SCRIPTDIR"
+  if terraform state list &>/dev/null; then
+    log "State accessible, no lock issues"
+  else
+    log_warning "State lock detected, attempting to force unlock"
+    LOCK_ID=$(terraform force-unlock -force 2>&1 | grep -oP 'Lock ID: \K[a-f0-9-]+' || echo "")
+    if [[ -n "$LOCK_ID" ]]; then
+      log "Force unlocking with ID: $LOCK_ID"
+      terraform force-unlock -force "$LOCK_ID" || log_warning "Force unlock failed, continuing anyway"
+    fi
+  fi
+  cd -
+
   # Destroy Terraform resources
   log "Destroying clusters stack..."
   if ! terraform -chdir=$DEPLOY_SCRIPTDIR destroy \
@@ -40,7 +54,18 @@ main() {
     -var="resource_prefix=${RESOURCE_PREFIX}" \
     -var="workshop_participant_role_arn=${WS_PARTICIPANT_ROLE_ARN}" \
     -auto-approve; then
-    log_warning "Clusters stack destroy failed, trying again..."
+    log_warning "Clusters stack destroy failed, checking for lock issues"
+    
+    # Extract lock ID from error if present
+    cd "$DEPLOY_SCRIPTDIR"
+    LOCK_ID=$(terraform plan 2>&1 | grep -oP 'ID:\s+\K[a-f0-9-]+' | head -1 || echo "")
+    if [[ -n "$LOCK_ID" ]]; then
+      log "Forcing unlock with ID: $LOCK_ID"
+      terraform force-unlock -force "$LOCK_ID" || true
+    fi
+    cd -
+    
+    log_warning "Retrying destroy after lock handling"
     if ! terraform -chdir=$DEPLOY_SCRIPTDIR destroy \
       -var-file="${GENERATED_TFVAR_FILE}" \
       -var="hub_vpc_id=${HUB_VPC_ID}" \


### PR DESCRIPTION
- Add proactive lock detection and clearing after terraform init
- Add reactive lock recovery on apply/destroy failures
- Apply to both common and cluster terraform stacks
- Prevents failures from stale locks left by incomplete operations

*Issue #, if available:*

*Description of changes:*

When cloudformation tried to recreate the stack, sometimes, it is not working due to terraform lock.
the goal of this change is to allow the script to force unloack before trying again


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
