### PR TITLE
fix: Update GitLab personal access token expiration to 2026-12-31

### DIFF
--- a/platform/infra/terraform/common/gitlab.tf
+++ b/platform/infra/terraform/common/gitlab.tf
@@ -8,7 +8,7 @@ data "gitlab_user" "workshop" {
 resource "gitlab_personal_access_token" "workshop" {
   user_id    = data.gitlab_user.workshop.id
   name       = "Workshop Personal access token for ${var.git_username}"
-  expires_at = "2025-12-31"
+  expires_at = "2026-12-31"
 
   scopes = ["api", "read_api","read_repository", "write_repository"]
 }


### PR DESCRIPTION
- Updates token expiration from 2025-12-31 to 2026-12-31
- Critical fix for 2026 operations to prevent token expiration issues

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
