### PR TITLE
fix: Handle git tag detection in gitlab_repository_setup

### DIFF
--- a/platform/infra/terraform/scripts/utils.sh
+++ b/platform/infra/terraform/scripts/utils.sh
@@ -311,6 +311,12 @@ gitlab_repository_setup(){
     git remote add gitlab "https://${GIT_USERNAME}:${USER1_PASSWORD}@${GITLAB_DOMAIN}/${GIT_USERNAME}/${WORKING_REPO}.git"
   fi
   
+  # Check if we're on a tag (detached HEAD)
+  if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+    log_warning "Working from a tag, creating main branch from current state"
+    git checkout -b main 2>/dev/null || git checkout main
+  fi
+  
   if ! git diff --quiet || ! git diff --cached --quiet; then
     git add .
     git commit -m "Updated bootstrap values in Backstag template and Created spoke cluster secret files " || true


### PR DESCRIPTION
- Add tag detection using git describe --exact-match --tags HEAD
- Create main branch from tag state when working from detached HEAD
- Prevents 'cannot push from HEAD' errors when repo cloned from tag
- Ensures proper branch exists for GitLab remote push operations

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
