### PR TITLE
Update README to indicate riv25 branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*** this riv25 branch was used for Re:Invent 2025, and is now read-only, look at [main](https://github.com/aws-samples/appmod-blueprints) for next evolutions **
+
 # Platform Engineering on Amazon EKS
 
 A comprehensive platform engineering solution that provides application modernization blueprints, GitOps patterns, and developer self-service capabilities on Amazon EKS.


### PR DESCRIPTION
Added a note about the riv25 branch being read-only and directing users to the main branch.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
