### PR TITLE
Fix: CloudFront VPC Origin retry failures & ArgoCD default AppProject

### DIFF
--- a/platform/infra/terraform/common/gitlab_infra/main.tf
+++ b/platform/infra/terraform/common/gitlab_infra/main.tf
@@ -119,6 +119,9 @@ resource "aws_cloudfront_vpc_origin" "gitlab" {
     replace_triggered_by = [
       kubernetes_service.gitlab_nlb.id
     ]
+    ignore_changes = [
+      vpc_origin_endpoint_config[0].arn
+    ]
   }
 }
 

--- a/platform/infra/terraform/scripts/0-init.sh
+++ b/platform/infra/terraform/scripts/0-init.sh
@@ -205,6 +205,32 @@ main() {
         fi
     fi
 
+    # Ensure the default AppProject exists (EKS ArgoCD Capability may not create it automatically)
+    if ! kubectl get appproject default -n argocd >/dev/null 2>&1; then
+        print_status "WARNING" "default AppProject not found, creating it..."
+        kubectl apply -f - <<'APPPROJ'
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: argocd
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceNamespaces:
+  - argocd
+  sourceRepos:
+  - '*'
+APPPROJ
+        print_status "SUCCESS" "default AppProject created"
+    else
+        print_status "INFO" "default AppProject already exists"
+    fi
+
     # ---------------------------------------------------------------------------
     # Phase: Configure IAM Identity Center + retrieve ArgoCD auth token
     # ---------------------------------------------------------------------------

--- a/platform/infra/terraform/scripts/argocd-utils.sh
+++ b/platform/infra/terraform/scripts/argocd-utils.sh
@@ -310,28 +310,43 @@ refresh_keycloak_dependent_apps() {
         print_warning "Some ExternalSecrets still syncing after ${timeout}s, forcing refresh anyway"
     fi
     
-    # Now refresh the applications
+    # Only refresh apps that are not already Healthy
     print_info "Refreshing apps that depend on Keycloak secrets..."
     
+    local needs_refresh=false
     for app in $dependent_apps; do
         local app_name="${app}-${RESOURCE_PREFIX}-hub"
         if kubectl get application "$app_name" -n argocd >/dev/null 2>&1; then
-            print_info "  Refreshing $app_name..."
+            local health=$(kubectl get application "$app_name" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null)
+            local sync=$(kubectl get application "$app_name" -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null)
+            local op_phase=$(kubectl get application "$app_name" -n argocd -o jsonpath='{.status.operationState.phase}' 2>/dev/null)
+            if [ "$health" = "Healthy" ] && { [ "$sync" = "Synced" ] || [ "$op_phase" = "Succeeded" ]; }; then
+                print_success "  $app_name already Healthy ($sync), skipping"
+                continue
+            fi
+            print_info "  Refreshing $app_name (health=$health, sync=$sync)..."
             kubectl annotate application "$app_name" -n argocd argocd.argoproj.io/refresh=hard --overwrite 2>/dev/null || true
+            needs_refresh=true
             sleep 1
         fi
     done
     
+    if [ "$needs_refresh" = false ]; then
+        print_success "All Keycloak-dependent apps already healthy, no refresh needed"
+        return 0
+    fi
+    
     # Give apps a moment to start syncing
     sleep 5
     
-    # Trigger sync for apps that are OutOfSync
+    # Trigger sync for apps that are OutOfSync and not Healthy
     print_info "Triggering sync for OutOfSync dependent apps..."
     for app in $dependent_apps; do
         local app_name="${app}-${RESOURCE_PREFIX}-hub"
         if kubectl get application "$app_name" -n argocd >/dev/null 2>&1; then
+            local health=$(kubectl get application "$app_name" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null)
             local sync_status=$(kubectl get application "$app_name" -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null)
-            if [ "$sync_status" = "OutOfSync" ]; then
+            if [ "$sync_status" = "OutOfSync" ] && [ "$health" != "Healthy" ]; then
                 print_info "  Syncing $app_name..."
                 sync_argocd_app "$app_name" || true
             fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

deployments intermittently fail or deploy in a broken state due to two issues:

1. CloudFront VPC Origin update failures on Terraform retry

When the GitLab Helm chart times out on first deploy (cold cluster, slow image pulls), Terraform retries hit Error: updating CloudFront VPC Origin because the origin is stuck in a transitional state. This cascades into 
exhausting all retry attempts and failing the Bootstrap CodeBuild.

2. ArgoCD default AppProject not created by EKS Capability

The EKS ArgoCD Capability does not reliably create the default AppProject. Without it, ArgoCD cannot reconcile any Applications. The 0-init.sh script waits 15 minutes for Keycloak, times out, then reports success with 0 apps 
deployed — leaving the workshop non-functional while CloudFormation shows UPDATE_COMPLETE.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
