### PR TITLE
fix: use long-lived SA token for Backstage kubernetes auth

### DIFF
--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -9,6 +9,15 @@ metadata:
   name: backstage
   namespace: backstage
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-sa-token
+  namespace: backstage
+  annotations:
+    kubernetes.io/service-account.name: backstage
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -246,9 +255,9 @@ data:
           authProvider: 'serviceAccount'
           skipTLSVerify: true
           serviceAccountToken:
-            $file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            $file: /var/run/secrets/backstage/token
           caData:
-            $file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            $file: /var/run/secrets/backstage/ca.crt
         - name: workshop
           url: K8S_SERVER
           authProvider: 'serviceAccount'
@@ -300,7 +309,7 @@ data:
           authProvider: 'serviceAccount'
           skipTLSVerify: true
           serviceAccountToken:
-            $file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            $file: /var/run/secrets/backstage/token
         - name: workshop
           url: K8S_SERVER
           authProvider: 'serviceAccount'
@@ -334,9 +343,9 @@ stringData:
         skipTLSVerify: true
         skipMetricsLookup: true
         serviceAccountToken: 
-          $file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          $file: /var/run/secrets/backstage/token
         caData: 
-          $file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          $file: /var/run/secrets/backstage/ca.crt
         # Additional configuration for Kro resources
         customResources:
           - group: 'kro.run'
@@ -527,6 +536,9 @@ spec:
             - mountPath: /app/config
               name: backstage-config
               readOnly: true
+            - mountPath: /var/run/secrets/backstage
+              name: backstage-sa-token
+              readOnly: true
       serviceAccountName: backstage
       volumes:
         - name: backstage-config
@@ -548,6 +560,9 @@ spec:
         - name: backstage-oidc-vars
           secret:
             secretName: backstage-oidc-vars
+        - name: backstage-sa-token
+          secret:
+            secretName: backstage-sa-token
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
Backstage reads $file: token references once at startup and caches them in memory. The projected SA token (expirationSeconds: 3607) expires after ~1 hour, causing kube:apply scaffolder actions to fail with 401 Unauthorized.

Fix: create a kubernetes.io/service-account-token Secret (non-expiring) and mount it at /var/run/secrets/backstage/. Update all $file: references in k8s-config, kro plugin, and kubernetesIngestor configs to use the new path.

*Issue #, if available:* Fix backstage that could not talk to kubernetes (needed recreation)

*Description of changes:*
use dedicated token

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
