### PR TITLE
fix: remove long-lived SA token, use in-cluster auth for Backstage

### DIFF
--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -9,15 +9,6 @@ metadata:
   name: backstage
   namespace: backstage
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: backstage-sa-token
-  namespace: backstage
-  annotations:
-    kubernetes.io/service-account.name: backstage
-type: kubernetes.io/service-account-token
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -254,10 +245,6 @@ data:
           url: https://kubernetes.default.svc.cluster.local
           authProvider: 'serviceAccount'
           skipTLSVerify: true
-          serviceAccountToken:
-            $file: /var/run/secrets/backstage/token
-          caData:
-            $file: /var/run/secrets/backstage/ca.crt
         - name: workshop
           url: K8S_SERVER
           authProvider: 'serviceAccount'
@@ -308,8 +295,6 @@ data:
           url: https://kubernetes.default.svc.cluster.local
           authProvider: 'serviceAccount'
           skipTLSVerify: true
-          serviceAccountToken:
-            $file: /var/run/secrets/backstage/token
         - name: workshop
           url: K8S_SERVER
           authProvider: 'serviceAccount'
@@ -342,10 +327,6 @@ stringData:
         authProvider: 'serviceAccount'
         skipTLSVerify: true
         skipMetricsLookup: true
-        serviceAccountToken: 
-          $file: /var/run/secrets/backstage/token
-        caData: 
-          $file: /var/run/secrets/backstage/ca.crt
         # Additional configuration for Kro resources
         customResources:
           - group: 'kro.run'
@@ -536,9 +517,6 @@ spec:
             - mountPath: /app/config
               name: backstage-config
               readOnly: true
-            - mountPath: /var/run/secrets/backstage
-              name: backstage-sa-token
-              readOnly: true
       serviceAccountName: backstage
       volumes:
         - name: backstage-config
@@ -560,9 +538,6 @@ spec:
         - name: backstage-oidc-vars
           secret:
             secretName: backstage-oidc-vars
-        - name: backstage-sa-token
-          secret:
-            secretName: backstage-sa-token
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
Remove backstage-sa-token Secret and remaining explicit serviceAccountToken $file: references. Backstage with authProvider: 'serviceAccount' and no explicit token uses InClusterConfig which re-reads the projected SA token automatically on each API call, handling rotation transparently.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
