### PR TITLE
fix(cluster/destroy): drain nodes before terraform destroy to prevent degraded nodes

### DIFF
--- a/platform/infra/terraform/cluster/destroy.sh
+++ b/platform/infra/terraform/cluster/destroy.sh
@@ -45,6 +45,33 @@ main() {
   fi
   cd -
 
+  # Drain nodes before terraform destroy. Terraform deletes VPC routes concurrently
+  # with EKS cluster deletion, which can strand nodes without network connectivity.
+  # Disabling built-in nodepools ensures nodes are terminated before VPC teardown.
+  log "Disabling built-in nodepools and draining nodes from all clusters..."
+  for cluster_name in "${CLUSTER_NAMES[@]}"; do
+    log "Disabling built-in nodepools for cluster: $cluster_name"
+    aws eks update-cluster-config \
+      --name "$cluster_name" \
+      --region "${AWS_REGION}" \
+      --compute-config '{"enabled":true,"nodePools":[]}' 2>&1 || log_warning "Failed to disable nodepools for $cluster_name"
+    log "Waiting for cluster update to complete: $cluster_name"
+    aws eks wait cluster-active --name "$cluster_name" --region "${AWS_REGION}" 2>&1 || log_warning "Wait timed out for $cluster_name"
+
+    # Delete any remaining nodepools (custom/GitOps-managed) via kubectl.
+    if configure_kubectl_with_fallback "$cluster_name"; then
+      log "Deleting any remaining nodepools from cluster: $cluster_name"
+      kubectl delete nodepool --all \
+        --context "$cluster_name" \
+        --wait=true \
+        --timeout=300s 2>&1 || log_warning "Failed to delete nodepools from $cluster_name (may already be empty)"
+      log_success "Node drain complete for cluster: $cluster_name"
+    else
+      log_warning "Could not configure kubectl for $cluster_name, skipping remaining nodepool cleanup"
+    fi
+  done
+  log "Pre-destroy node drain complete"
+
   # Destroy Terraform resources
   log "Destroying clusters stack..."
   if ! terraform -chdir=$DEPLOY_SCRIPTDIR destroy \


### PR DESCRIPTION
During cluster teardown, `terraform destroy` deletes VPC route table entries concurrently with EKS cluster deletion. The clusters take several minutes to fully delete, but routes are removed instantly — so nodes lose outbound connectivity to the control plane and go degraded in the interim.

This happens because Terraform only tracks explicit resource references. `module.eks` references `module.vpc.private_subnets`, so subnets wait for EKS. But routes, NAT gateways, and route table associations have no such reference, so they get torn down immediately.

This PR adds a pre-destroy step to `cluster/destroy.sh` that:

1. Disables the built-in Auto Mode nodepools via `aws eks update-cluster-config` (sets `nodePools` to `[]`), per the [EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/set-builtin-node-pools.html), so EKS cleanly removes them and won't recreate them
2. Waits for the cluster update to complete
3. Deletes any remaining custom nodepools (e.g. deployed via ArgoCD) with `kubectl delete nodepool --all --wait=true`

Only after all nodes are gone does `terraform destroy` run. This follows the same pattern as `common/destroy.sh`, which cleans up Kubernetes resources before Terraform teardown.

Tested end-to-end: deployed 3 EKS Auto Mode clusters, confirmed nodes were running, ran the fixed destroy, and verified no degraded nodes appeared during the entire teardown window.

*Issue #, if available:*

*Description of changes:*
Pre-destroy nodepool cleanup in `cluster/destroy.sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.