### PR TITLE
fix: replace yanked MCP servers with aws-iac-mcp-server

### DIFF
--- a/.kiro/agents/appmod-blueprints.json
+++ b/.kiro/agents/appmod-blueprints.json
@@ -22,9 +22,9 @@
       "url": "https://knowledge-mcp.global.api.aws",
       "type": "http"
     },
-    "awslabs.terraform-mcp-server": {
+    "awslabs.aws-iac-mcp-server": {
       "command": "uvx",
-      "args": ["awslabs.terraform-mcp-server@latest"],
+      "args": ["awslabs.aws-iac-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
@@ -33,7 +33,7 @@
     }
   },
   "tools": [
-    "@awslabs.terraform-mcp-server",
+    "@awslabs.aws-iac-mcp-server",
     "@eks-mcp-server",
     "@aws-knowledge-mcp-server",
     "read",

--- a/hack/.kiro/agents/peeks.json
+++ b/hack/.kiro/agents/peeks.json
@@ -19,8 +19,8 @@
       "url": "https://knowledge-mcp.global.api.aws",
       "type": "http"
     },
-    "awslabs.terraform-mcp-server": {
-      "command": "/home/ec2-user/.local/bin/awslabs.terraform-mcp-server",
+    "awslabs.aws-iac-mcp-server": {
+      "command": "/home/ec2-user/.local/bin/awslabs.aws-iac-mcp-server",
       "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
@@ -30,7 +30,7 @@
     }
   },
   "tools": [
-    "@awslabs.terraform-mcp-server",
+    "@awslabs.aws-iac-mcp-server",
     "@eks-mcp-server",
     "@aws-knowledge-mcp-server",
     "fs_read",
@@ -56,7 +56,7 @@
     "@eks-mcp-server": {
       "autoAllowReadonly": true
     },
-    "@awslabs.terraform-mcp-server": {
+    "@awslabs.aws-iac-mcp-server": {
       "autoAllowReadonly": true
     }
   },


### PR DESCRIPTION
awslabs.terraform-mcp-server was yanked from PyPI, replaced by awslabs.aws-iac-mcp-server which covers both CDK and Terraform.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
