### PR TITLE
Fix/idc keycloak statefulset drift

### DIFF
--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -733,6 +733,12 @@ argo-rollouts:
       - key: enable_argo_rollouts
         operator: In
         values: ['true']
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jsonPointers:
+        - /spec/conversion
+        - /spec/preserveUnknownFields
 
 argo-events:
   enabled: false

--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -859,6 +859,7 @@ keycloak:
         - '.spec.template.metadata.annotations'
         - '.spec.volumeClaimTemplates[].metadata.creationTimestamp'
         - '.spec.volumeClaimTemplates[].metadata'
+        - '.spec.volumeClaimTemplates[].status'
     - group: ''
       kind: PersistentVolumeClaim
       jsonPointers:
@@ -1562,6 +1563,7 @@ backstage:
         - /spec/replicas
         - /spec/template/metadata/annotations
         - /spec/volumeClaimTemplates/0/metadata
+        - /spec/volumeClaimTemplates/0/status
       jqPathExpressions:
         - '.spec.template.metadata.annotations'
     - group: rbac.authorization.k8s.io

--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -846,6 +846,13 @@ keycloak:
         - /metadata/generation
         - /metadata/managedFields
         - /metadata/resourceVersion
+    - group: external-secrets.io
+      kind: PushSecret
+      jsonPointers:
+        - /status
+        - /metadata/generation
+        - /metadata/managedFields
+        - /metadata/resourceVersion
     - group: ''
       kind: Secret
       jsonPointers:

--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -846,13 +846,6 @@ keycloak:
         - /metadata/generation
         - /metadata/managedFields
         - /metadata/resourceVersion
-    - group: external-secrets.io
-      kind: PushSecret
-      jsonPointers:
-        - /status
-        - /metadata/generation
-        - /metadata/managedFields
-        - /metadata/resourceVersion
     - group: ''
       kind: Secret
       jsonPointers:

--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -551,6 +551,11 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -574,6 +574,11 @@ spec:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
         effect: "NoSchedule"
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
       containers:
         - env:
             - name: PGDATA
@@ -594,16 +599,20 @@ spec:
                   name: backstage-postgres-vars
                   key: POSTGRES_PASSWORD
           image: docker.io/library/postgres:17.4-alpine3.21
+          imagePullPolicy: IfNotPresent
           name: postgres
           ports:
             - containerPort: 5432
               name: postgresdb
+              protocol: TCP
           resources:
             limits:
               memory: 500Mi
             requests:
               cpu: 100m
               memory: 300Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data

--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -550,6 +550,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
   selector:
     matchLabels:
       app: postgresql

--- a/gitops/addons/charts/keycloak/templates/install.yaml
+++ b/gitops/addons/charts/keycloak/templates/install.yaml
@@ -199,6 +199,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "6"
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
   selector:
     matchLabels:
       app: postgresql

--- a/gitops/addons/charts/keycloak/templates/install.yaml
+++ b/gitops/addons/charts/keycloak/templates/install.yaml
@@ -223,11 +223,17 @@ spec:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
         effect: "NoSchedule"
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
       containers:
         - envFrom:
             - secretRef:
                 name: keycloak-config
           image: docker.io/library/postgres:17.4-alpine3.21
+          imagePullPolicy: IfNotPresent
           name: postgres
           env:
             - name: PGDATA
@@ -235,12 +241,15 @@ spec:
           ports:
             - containerPort: 5432
               name: postgresdb
+              protocol: TCP
           resources:
             limits:
               memory: 500Mi
             requests:
               cpu: 100m
               memory: 300Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data

--- a/gitops/addons/charts/keycloak/templates/install.yaml
+++ b/gitops/addons/charts/keycloak/templates/install.yaml
@@ -200,6 +200,11 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -872,7 +872,11 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: HookFailed
 spec:
   updatePolicy: Replace
-  deletionPolicy: Delete
+  # None: don't delete the AWS secret when the PushSecret resource is deleted.
+  # Prevents AWS Secrets Manager idempotency token conflicts when the hook is
+  # re-run after a failed/terminated sync (AWS caches ClientRequestToken for
+  # ~24h even after the secret is gone, blocking re-creation).
+  deletionPolicy: None
   refreshInterval: 30s
   secretStoreRefs:
     - name: aws-secrets-manager

--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -602,7 +602,7 @@ spec:
               export DEBIAN_FRONTEND=noninteractive
               export TZ=UTC
 
-              apt -qq update && apt -qq install curl jq gettext-base -y
+              apt -qq update && apt -qq install curl jq gettext-base unzip -y
 
               # Helper functions
               keycloak_post() {

--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -868,12 +868,11 @@ metadata:
   namespace: keycloak
   annotations:
     argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   updatePolicy: Replace
   # None: don't delete the AWS secret when the PushSecret resource is deleted.
-  # Prevents AWS Secrets Manager idempotency token conflicts when the hook is
-  # re-run after a failed/terminated sync (AWS caches ClientRequestToken for
-  # ~24h even after the secret is gone, blocking re-creation).
   deletionPolicy: None
   refreshInterval: 30s
   secretStoreRefs:

--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -867,9 +867,7 @@ metadata:
   name: keycloak-clients
   namespace: keycloak
   annotations:
-    argocd.argoproj.io/sync-wave: "11" # Sync after config job
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookFailed
+    argocd.argoproj.io/sync-wave: "11"
 spec:
   updatePolicy: Replace
   # None: don't delete the AWS secret when the PushSecret resource is deleted.

--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -856,123 +856,36 @@ spec:
               " > /tmp/secret.yaml
 
               ./kubectl apply -f /tmp/secret.yaml
-              echo "✓ Kubernetes secret created and available for applications"
+              echo "✓ Kubernetes secret created"
+
+              # Push to AWS Secrets Manager (synchronous — no PushSecret race condition)
+              echo "Pushing OIDC secrets to AWS Secrets Manager..."
+              curl -sS "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+              unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install --bin-dir /usr/local/bin --install-dir /tmp/aws-cli 2>/dev/null
+
+              SM_SECRET_NAME="{{ .Values.aws.cluster_name }}/keycloak-clients"
+              SM_SECRET_VALUE=$(jq -n \
+                --arg aws "$ARGO_WORKFLOWS_CLIENT_SECRET" \
+                --arg awi "argo-workflows" \
+                --arg bs "$BACKSTAGE_CLIENT_SECRET" \
+                --arg jh "$JUPYTERHUB_CLIENT_SECRET" \
+                --arg jhi "jupyterhub" \
+                --arg kf "$KUBEFLOW_CLIENT_SECRET" \
+                --arg kfi "kubeflow" \
+                --arg ml "$MLFLOW_CLIENT_SECRET" \
+                --arg mli "mlflow" \
+                --arg sp "$SPARK_CLIENT_SECRET" \
+                --arg spi "spark" \
+                --arg af "$AIRFLOW_CLIENT_SECRET" \
+                --arg afi "airflow" \
+                '{ARGO_WORKFLOWS_CLIENT_SECRET:$aws,ARGO_WORKFLOWS_CLIENT_ID:$awi,BACKSTAGE_CLIENT_SECRET:$bs,JUPYTERHUB_CLIENT_SECRET:$jh,JUPYTERHUB_CLIENT_ID:$jhi,KUBEFLOW_CLIENT_SECRET:$kf,KUBEFLOW_CLIENT_ID:$kfi,MLFLOW_CLIENT_SECRET:$ml,MLFLOW_CLIENT_ID:$mli,SPARK_CLIENT_SECRET:$sp,SPARK_CLIENT_ID:$spi,AIRFLOW_CLIENT_SECRET:$af,AIRFLOW_CLIENT_ID:$afi}')
+
+              if aws secretsmanager describe-secret --secret-id "$SM_SECRET_NAME" --region {{ .Values.aws.region }} >/dev/null 2>&1; then
+                aws secretsmanager put-secret-value --secret-id "$SM_SECRET_NAME" --secret-string "$SM_SECRET_VALUE" --region {{ .Values.aws.region }}
+              else
+                aws secretsmanager create-secret --name "$SM_SECRET_NAME" --secret-string "$SM_SECRET_VALUE" --region {{ .Values.aws.region }}
+              fi
+              echo "✓ AWS Secrets Manager secret created: $SM_SECRET_NAME"
               echo "✓ Keycloak configuration completed successfully!"
-              echo "✓ OIDC secrets available in both AWS Secrets Manager and Kubernetes"
-              echo "✓ Applications can now use External Secrets to consume from AWS Secrets Manager"
----
-apiVersion: external-secrets.io/v1alpha1
-kind: PushSecret
-metadata:
-  name: keycloak-clients
-  namespace: keycloak
-  annotations:
-    argocd.argoproj.io/sync-wave: "11"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-spec:
-  updatePolicy: Replace
-  # None: don't delete the AWS secret when the PushSecret resource is deleted.
-  deletionPolicy: None
-  refreshInterval: 30s
-  secretStoreRefs:
-    - name: aws-secrets-manager
-      kind: ClusterSecretStore
-  selector:
-    secret:
-      name: keycloak-clients # Source Kubernetes secret to be pushed
-  template:
-    data:
-      ARGO_WORKFLOWS_CLIENT_SECRET: "{{ `{{.ARGO_WORKFLOWS_CLIENT_SECRET}}` }}"
-      ARGO_WORKFLOWS_CLIENT_ID: "{{ `{{.ARGO_WORKFLOWS_CLIENT_ID}}` }}"
-      BACKSTAGE_CLIENT_SECRET: "{{ `{{.BACKSTAGE_CLIENT_SECRET}}` }}"
-      JUPYTERHUB_CLIENT_SECRET: "{{ `{{.JUPYTERHUB_CLIENT_SECRET}}` }}"
-      JUPYTERHUB_CLIENT_ID: "{{ `{{.JUPYTERHUB_CLIENT_ID}}` }}"
-      KUBEFLOW_CLIENT_SECRET: "{{ `{{.KUBEFLOW_CLIENT_SECRET}}` }}"
-      KUBEFLOW_CLIENT_ID: "{{ `{{.KUBEFLOW_CLIENT_ID}}` }}"
-      MLFLOW_CLIENT_SECRET: "{{ `{{.MLFLOW_CLIENT_SECRET}}` }}"
-      MLFLOW_CLIENT_ID: "{{ `{{.MLFLOW_CLIENT_ID}}` }}"
-      SPARK_CLIENT_SECRET: "{{ `{{.SPARK_CLIENT_SECRET}}` }}"
-      SPARK_CLIENT_ID: "{{ `{{.SPARK_CLIENT_ID}}` }}"
-      AIRFLOW_CLIENT_SECRET: "{{ `{{.AIRFLOW_CLIENT_SECRET}}` }}"
-      AIRFLOW_CLIENT_ID: "{{ `{{.AIRFLOW_CLIENT_ID}}` }}"
-  data:
-    - conversionStrategy: None
-      match:
-        secretKey: ARGO_WORKFLOWS_CLIENT_SECRET
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: ARGO_WORKFLOWS_CLIENT_SECRET
-    - conversionStrategy: None
-      match:
-        secretKey: ARGO_WORKFLOWS_CLIENT_ID
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: ARGO_WORKFLOWS_CLIENT_ID
-    - conversionStrategy: None
-      match:
-        secretKey: BACKSTAGE_CLIENT_SECRET
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: BACKSTAGE_CLIENT_SECRET
-    - conversionStrategy: None
-      match:
-        secretKey: JUPYTERHUB_CLIENT_SECRET
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: JUPYTERHUB_CLIENT_SECRET
-    - conversionStrategy: None
-      match:
-        secretKey: JUPYTERHUB_CLIENT_ID
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: JUPYTERHUB_CLIENT_ID
-    - conversionStrategy: None
-      match:
-        secretKey: KUBEFLOW_CLIENT_SECRET
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: KUBEFLOW_CLIENT_SECRET
-    - conversionStrategy: None
-      match:
-        secretKey: KUBEFLOW_CLIENT_ID
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: KUBEFLOW_CLIENT_ID
-    - conversionStrategy: None
-      match:
-        secretKey: MLFLOW_CLIENT_SECRET
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: MLFLOW_CLIENT_SECRET
-    - conversionStrategy: None
-      match:
-        secretKey: MLFLOW_CLIENT_ID
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: MLFLOW_CLIENT_ID
-    - conversionStrategy: None
-      match:
-        secretKey: SPARK_CLIENT_SECRET
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: SPARK_CLIENT_SECRET
-    - conversionStrategy: None
-      match:
-        secretKey: SPARK_CLIENT_ID
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: SPARK_CLIENT_ID
-    - conversionStrategy: None
-      match:
-        secretKey: AIRFLOW_CLIENT_SECRET
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: AIRFLOW_CLIENT_SECRET
-    - conversionStrategy: None
-      match:
-        secretKey: AIRFLOW_CLIENT_ID
-        remoteRef:
-          remoteKey: {{ .Values.aws.cluster_name}}/keycloak-clients
-          property: AIRFLOW_CLIENT_ID
+
 

--- a/hack/.bashrc.d/ssm-setup-ide-logs.sh
+++ b/hack/.bashrc.d/ssm-setup-ide-logs.sh
@@ -70,6 +70,42 @@ argocd-refresh-token() {
         --password "${IDE_PASSWORD}" \
         --output token 2>/tmp/argocd-token-debug.log)
 
+    # If token retrieval failed, try configuring IDC-Keycloak federation first
+    if [[ -z "$token" || "$token" == "Failed to retrieve token" ]]; then
+        echo "Token retrieval failed. Checking IDC-Keycloak federation..." >&2
+
+        local idc_instance_arn idc_instance_id domain_name keycloak_admin_password
+        idc_instance_arn=$(aws sso-admin list-instances --query 'Instances[0].InstanceArn' --output text 2>/dev/null || echo "None")
+        if [[ -n "$idc_instance_arn" && "$idc_instance_arn" != "None" ]]; then
+            idc_instance_id=$(echo "$idc_instance_arn" | grep -oP '[0-9a-f]{16}$' || echo "")
+            [[ -z "$idc_instance_id" ]] && idc_instance_id=$(echo "$idc_instance_arn" | awk -F'/' '{print $NF}' | sed 's/^ssoins-//')
+        fi
+
+        domain_name=$(kubectl get secret ${RESOURCE_PREFIX:-peeks}-hub-cluster -n argocd -o jsonpath='{.metadata.annotations.ingress_domain_name}' 2>/dev/null || echo "")
+        [[ -z "$domain_name" || "$domain_name" == "null" ]] && \
+            domain_name=$(aws cloudfront list-distributions --query "DistributionList.Items[?contains(Origins.Items[0].Id, 'http-origin')].DomainName | [0]" --output text 2>/dev/null || echo "")
+
+        keycloak_admin_password=$(kubectl get secret keycloak-config -n keycloak -o jsonpath='{.data.KC_BOOTSTRAP_ADMIN_PASSWORD}' 2>/dev/null | base64 -d || echo "")
+
+        if [[ -n "$idc_instance_id" && -n "$domain_name" && "$domain_name" != "None" && -n "$keycloak_admin_password" ]]; then
+            echo "Running IDC-Keycloak federation setup..." >&2
+            python3 "$script_dir/configure_identity_center.py" \
+                --region "${AWS_REGION:-us-west-2}" \
+                --instance-id "$idc_instance_id" \
+                --keycloak-dns "$domain_name" \
+                --keycloak-admin-password="$keycloak_admin_password" 2>&1 | tail -5 >&2
+
+            echo "Retrying token retrieval..." >&2
+            token=$(python3 "$script_dir/argocd_token_automation.py" \
+                --url "$server_url" \
+                --username "user1" \
+                --password "${IDE_PASSWORD}" \
+                --output token 2>/tmp/argocd-token-debug.log)
+        else
+            echo "ERROR: Cannot configure IDC federation (missing: instance_id=$idc_instance_id, domain=$domain_name, kc_password=$([ -n "$keycloak_admin_password" ] && echo set || echo missing))" >&2
+        fi
+    fi
+
     if [[ -z "$token" || "$token" == "Failed to retrieve token" ]]; then
         echo "ERROR: Failed to retrieve ArgoCD token. Debug log:" >&2
         cat /tmp/argocd-token-debug.log >&2

--- a/hack/.kiro/agents/peeks.json
+++ b/hack/.kiro/agents/peeks.json
@@ -6,8 +6,9 @@
     "eks-mcp-server": {
       "disabled": false,
       "type": "stdio",
-      "command": "/home/ec2-user/.local/bin/mcp-proxy-for-aws",
+      "command": "/home/ec2-user/.local/bin/uvx",
       "args": [
+        "mcp-proxy-for-aws@latest",
         "https://eks-mcp.us-west-2.api.aws/mcp",
         "--service",
         "eks-mcp",
@@ -22,8 +23,8 @@
       "type": "http"
     },
     "awslabs.aws-iac-mcp-server": {
-      "command": "/home/ec2-user/.local/bin/awslabs.aws-iac-mcp-server",
-      "args": [],
+      "command": "/home/ec2-user/.local/bin/uvx",
+      "args": ["awslabs.aws-iac-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },

--- a/hack/.kiro/agents/peeks.json
+++ b/hack/.kiro/agents/peeks.json
@@ -6,9 +6,8 @@
     "eks-mcp-server": {
       "disabled": false,
       "type": "stdio",
-      "command": "/home/ec2-user/.local/bin/uvx",
+      "command": "/home/ec2-user/.local/bin/mcp-proxy-for-aws",
       "args": [
-        "mcp-proxy-for-aws@latest",
         "https://eks-mcp.us-west-2.api.aws/mcp",
         "--service",
         "eks-mcp",
@@ -23,8 +22,8 @@
       "type": "http"
     },
     "awslabs.aws-iac-mcp-server": {
-      "command": "/home/ec2-user/.local/bin/uvx",
-      "args": ["awslabs.aws-iac-mcp-server@latest"],
+      "command": "/home/ec2-user/.local/bin/awslabs.aws-iac-mcp-server",
+      "args": [],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },

--- a/hack/.kiro/agents/peeks.json
+++ b/hack/.kiro/agents/peeks.json
@@ -6,7 +6,7 @@
     "eks-mcp-server": {
       "disabled": false,
       "type": "stdio",
-      "command": "/home/ec2-user/.local/bin/uvx",
+      "command": "/home/ec2-user/.local/share/mise/shims/uvx",
       "args": [
         "mcp-proxy-for-aws@latest",
         "https://eks-mcp.us-west-2.api.aws/mcp",
@@ -23,7 +23,7 @@
       "type": "http"
     },
     "awslabs.aws-iac-mcp-server": {
-      "command": "/home/ec2-user/.local/bin/uvx",
+      "command": "/home/ec2-user/.local/share/mise/shims/uvx",
       "args": ["awslabs.aws-iac-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"

--- a/hack/.kiro/agents/peeks.json
+++ b/hack/.kiro/agents/peeks.json
@@ -6,13 +6,16 @@
     "eks-mcp-server": {
       "disabled": false,
       "type": "stdio",
-      "command": "/home/ec2-user/.local/bin/mcp-proxy-for-aws",
+      "command": "/home/ec2-user/.local/bin/uvx",
       "args": [
+        "mcp-proxy-for-aws@latest",
         "https://eks-mcp.us-west-2.api.aws/mcp",
         "--service",
         "eks-mcp",
         "--region",
-        "us-west-2"
+        "us-west-2",
+        "--log-level",
+        "ERROR"
       ]
     },
     "aws-knowledge-mcp-server": {
@@ -20,8 +23,8 @@
       "type": "http"
     },
     "awslabs.aws-iac-mcp-server": {
-      "command": "/home/ec2-user/.local/bin/awslabs.aws-iac-mcp-server",
-      "args": [],
+      "command": "/home/ec2-user/.local/bin/uvx",
+      "args": ["awslabs.aws-iac-mcp-server@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },

--- a/hack/.kiro/steering/deployment-architecture.md
+++ b/hack/.kiro/steering/deployment-architecture.md
@@ -1,0 +1,48 @@
+# Deployment Architecture & Pitfalls
+
+## Deployment Ordering (Workshop Studio)
+
+```
+1. IDE UserData (bootstrap.sh) — installs tools, clones repo from GitHub
+2. ClustersStackDeploy CodeBuild — Terraform: EKS clusters + Identity Center
+3. BootstrapStackDeploy CodeBuild — Terraform: GitLab, hub addons, ArgoCD bootstrap
+   - Pushes clean single-commit history to GitLab (git init -b main)
+4. SSM Document (0-init.sh) — syncs IDE with GitLab, waits for ArgoCD, configures IDC
+```
+
+## ArgoCD Sync Waves
+
+- Waves only order resources **within the same phase** (Sync or PostSync)
+- A regular resource at wave 11 runs BEFORE a PostSync hook at wave 10
+- PostSync hooks only run if the Sync phase succeeds
+- ArgoCD can only "wait" for Jobs (polls until Complete/Failed)
+- Non-Job resources as PostSync hooks (PushSecret, ExternalSecret) are checked immediately — if not ready, the operation fails
+
+## Git & NFS
+
+- IDE workspace is NFS-mounted (EFS) — long ref names break clone
+- Clone to /tmp, strip .git, move files, reinit with `git init -b main`
+- CodeBuild pushes clean history to GitLab (no GitHub dependabot refs)
+- 0-init.sh uses `git reset --hard origin/main` to sync IDE (not pull --rebase)
+
+## Keycloak Secret Flow
+
+- Config Job (PostSync wave 10): creates realm, users, OIDC clients, K8s secret, AND pushes to AWS SM directly
+- No PushSecret dependency — the SM push is synchronous in the Job
+- Pod Identity on `keycloak-config` SA provides AWS credentials
+- Downstream apps (backstage, argo-workflows) use ExternalSecrets to pull from SM
+
+## Container Images in Jobs
+
+- ubuntu:22.04 does NOT have: `unzip`, `aws` CLI, `kubectl`
+- AWS CLI v2 requires `unzip`
+- For Playwright/Chromium: need system libs (atk, libXcomposite, mesa-libgbm, etc.)
+
+## KubeVela publishVersion
+
+- KubeVela only re-renders child resources when `publishVersion` annotation changes
+- Changing spec fields without bumping publishVersion has NO effect
+- Always bump when modifying manifests without a new CI build:
+  ```bash
+  sed -i "s|app.oam.dev/publishVersion:.*|app.oam.dev/publishVersion: \"$(date +%s)\"|" deployment/dev/application.yaml
+  ```

--- a/hack/.zsh_history
+++ b/hack/.zsh_history
@@ -1,25 +1,25 @@
-: 1738000000:0;kiro-cli login --use-device-flow
-: 1738000001:0;kiro-cli chat --tui --agent peeks
-: 1738000002:0;kubectl config get-contexts
-: 1738000003:0;kubectl config use-context peeks-hub
-: 1738000004:0;kubectl get pods -A
-: 1738000005:0;kubectl get applications -n argocd
-: 1738000006:0;cd platform/infra/terraform/cluster && ./deploy.sh
-: 1738000007:0;cd platform/infra/terraform/common && ./deploy.sh
-: 1738000008:0;echo "Region: $AWS_REGION, Account: $AWS_ACCOUNT_ID"
-: 1738000009:0;kubectl get nodes
-: 1738000010:0;argocd app list
-: 1738000011:0;task build-helm-dependencies
-: 1738000012:0;git status
-: 1738000013:0;terraform state list
-: 1738000014:0;echo $USER1_PASSWORD
-: 1738000015:0;open $ARGOCD_URL
-: 1738000016:0;open $BACKSTAGE_URL
-: 1738000017:0;open $KARGO_URL
-: 1738000018:0;open $WORKFLOWS_URL
-: 1738000019:0;open $JUPYTERHUB_URL
-: 1738000020:0;open $KEYCLOAK_ADMIN_URL
-: 1738000021:0;open $GITLAB_URL
-: 1738000022:0;open $GRAFANA_URL
-: 1738000023:0;ssm-setup-ide-logs
-: 1738000024:0;argocd-refresh-token
+: 1738000000:0;kubectl config get-contexts
+: 1738000001:0;kubectl config use-context peeks-hub
+: 1738000002:0;kubectl get pods -A
+: 1738000003:0;kubectl get applications -n argocd
+: 1738000004:0;cd platform/infra/terraform/cluster && ./deploy.sh
+: 1738000005:0;cd platform/infra/terraform/common && ./deploy.sh
+: 1738000006:0;echo "Region: $AWS_REGION, Account: $AWS_ACCOUNT_ID"
+: 1738000007:0;kubectl get nodes
+: 1738000008:0;argocd app list
+: 1738000009:0;task build-helm-dependencies
+: 1738000010:0;git status
+: 1738000011:0;terraform state list
+: 1738000012:0;echo $USER1_PASSWORD
+: 1738000013:0;open $ARGOCD_URL
+: 1738000014:0;open $BACKSTAGE_URL
+: 1738000015:0;open $KARGO_URL
+: 1738000016:0;open $WORKFLOWS_URL
+: 1738000017:0;open $JUPYTERHUB_URL
+: 1738000018:0;open $KEYCLOAK_ADMIN_URL
+: 1738000019:0;open $GITLAB_URL
+: 1738000020:0;open $GRAFANA_URL
+: 1738000021:0;ssm-setup-ide-logs
+: 1738000022:0;argocd-refresh-token
+: 1738000023:0;kiro-cli chat --tui --agent peeks
+: 1738000024:0;kiro-cli login --use-device-flow

--- a/platform/infra/terraform/common/deploy.sh
+++ b/platform/infra/terraform/common/deploy.sh
@@ -196,10 +196,14 @@ main() {
 
   create_spoke_cluster_secret_values
   update_backstage_defaults
+
+  # Push a clean single-commit history to GitLab (no GitHub refs/history)
+  rm -rf .git
+  git init
   git add .
-  git commit -m "Bootstrap: add fleet member values and backstage defaults" || true
-  git checkout -B main
-  git push -u origin main
+  git commit -m "Bootstrap: platform-on-eks-workshop"
+  git remote add origin "$GITLAB_PUSH_URL"
+  git push -u origin main --force
   cd -
 
   log_success "Bootstrap stack deployment completed successfully"

--- a/platform/infra/terraform/common/deploy.sh
+++ b/platform/infra/terraform/common/deploy.sh
@@ -6,7 +6,7 @@ export TF_CLI_ARGS="-no-color"
 set -euo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOTDIR="$(cd ${SCRIPTDIR}/../..; pwd )"
+ROOTDIR="$(cd ${SCRIPTDIR}/../../../..; pwd )"
 [[ -n "${DEBUG:-}" ]] && set -x
 
 # Save the current script directory before sourcing utils.sh

--- a/platform/infra/terraform/common/deploy.sh
+++ b/platform/infra/terraform/common/deploy.sh
@@ -198,6 +198,7 @@ main() {
   update_backstage_defaults
 
   # Push a clean single-commit history to GitLab (no GitHub refs/history)
+  cd "$ROOTDIR"
   rm -rf .git
   git init -b main
   git add .

--- a/platform/infra/terraform/common/deploy.sh
+++ b/platform/infra/terraform/common/deploy.sh
@@ -199,7 +199,7 @@ main() {
 
   # Push a clean single-commit history to GitLab (no GitHub refs/history)
   rm -rf .git
-  git init
+  git init -b main
   git add .
   git commit -m "Bootstrap: platform-on-eks-workshop"
   git remote add origin "$GITLAB_PUSH_URL"

--- a/platform/infra/terraform/scripts/2-gitlab-init.sh
+++ b/platform/infra/terraform/scripts/2-gitlab-init.sh
@@ -130,9 +130,10 @@ set_gitlab_remote_for_peeks() {
   git config user.name "Workshop Participant"
   
   # deploy.sh already pushed to GitLab with fleet/backstage content.
-  # Pull that commit so the IDE is in sync, then set tracking branch.
+  # Reset local to match GitLab (avoids rebase conflicts from bootstrap's initial commit).
   git checkout -B main
-  git pull --rebase origin main || git push -u origin main
+  git fetch origin main
+  git reset --hard origin/main
   
   popd
   echo "GitLab remote set for ~/environment/$WORKING_REPO - synced with GitLab"

--- a/platform/infra/terraform/scripts/argocd-utils.sh
+++ b/platform/infra/terraform/scripts/argocd-utils.sh
@@ -1778,9 +1778,10 @@ wait_for_keycloak_ready() {
         local kc_condition_message=$(echo "$kc_app_json" | jq -r '(.status.conditions[]?.message // "")' 2>/dev/null | head -1)
         local kc_finished=$(echo "$kc_app_json" | jq -r '.status.operationState.finishedAt // "none"')
 
-        # Ready criteria (consistent with wait_for_sync_wave_completion and show_final_status):
-        # Healthy AND (Synced OR last operation Succeeded)
-        if [ "$kc_health" = "Healthy" ] && { [ "$kc_sync" = "Synced" ] || [ "$kc_operation" = "Succeeded" ]; }; then
+        # Ready criteria: Healthy AND (Synced OR operation Succeeded OR OutOfSync with no active operation)
+        # The OutOfSync case handles persistent StatefulSet drift (K8s-defaulted fields like
+        # revisionHistoryLimit/persistentVolumeClaimRetentionPolicy that aren't in the chart).
+        if [ "$kc_health" = "Healthy" ] && { [ "$kc_sync" = "Synced" ] || [ "$kc_operation" = "Succeeded" ] || { [ "$kc_sync" = "OutOfSync" ] && [ "$kc_operation" != "Running" ]; }; }; then
             print_success "Keycloak is healthy and ready (health=$kc_health, sync=$kc_sync, operation=$kc_operation)"
             return 0
         fi

--- a/platform/infra/terraform/scripts/argocd_token_automation.py
+++ b/platform/infra/terraform/scripts/argocd_token_automation.py
@@ -14,10 +14,28 @@ import json
 import os
 import sys
 
+_CHROMIUM_YUM_DEPS = [
+    "atk", "at-spi2-atk", "cups-libs", "libdrm", "libxkbcommon",
+    "libXcomposite", "libXdamage", "libXrandr", "mesa-libgbm", "pango",
+    "alsa-lib", "nss", "nspr", "libXScrnSaver", "libXtst", "gtk3",
+]
+
+
+def _ensure_chromium_deps():
+    """Install Chromium system libraries if missing."""
+    import subprocess
+    import shutil
+    # Quick check: if libatk-1.0.so.0 is missing, install all deps
+    if not shutil.which("playwright") or not os.path.exists("/usr/lib64/libatk-1.0.so.0"):
+        subprocess.run(["sudo", "yum", "install", "-y"] + _CHROMIUM_YUM_DEPS, capture_output=True)
+
+
 try:
     from playwright.async_api import async_playwright
+    _ensure_chromium_deps()
 except ImportError:
-    print("Installing playwright...", file=sys.stderr)
+    print("Installing playwright and Chromium system dependencies...", file=sys.stderr)
+    _ensure_chromium_deps()
     os.system("pip install playwright >/dev/null 2>&1 && playwright install chromium >/dev/null 2>&1")
     from playwright.async_api import async_playwright
 

--- a/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
+++ b/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
@@ -20,7 +20,8 @@ cd $BASE_DIR
 echo "=== Running post-clone setup from $BASE_DIR ==="
 
 # Ensure mise-managed tools (uv, etc.) are on PATH
-eval "$(~/.local/bin/mise activate bash 2>/dev/null)" || export PATH="$HOME/.local/bin:$PATH"
+eval "$(~/.local/bin/mise activate bash 2>/dev/null)" || true
+export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$PATH"
 
 # Zsh config
 cp hack/.zshrc hack/.p10k.zsh hack/.zsh_history ~/

--- a/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
+++ b/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# fix-bootstrap-post-clone.sh
+# Run this on the IDE instance when the git/NFS bug in bootstrap-mise.sh
+# prevents the workshop repo clone from completing. This script re-executes
+# everything that comes AFTER the git clone in bootstrap-mise.sh.
+#
+# Usage: bash ~/environment/platform-on-eks-workshop/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
+
+set -e
+
+export BASE_DIR="${WORKSPACE_PATH:-/home/ec2-user/environment}/${WORKING_REPO:-platform-on-eks-workshop}"
+
+if [ ! -d "$BASE_DIR/.git" ]; then
+  echo "ERROR: $BASE_DIR does not exist. Clone the repo first:"
+  echo "  git clone --single-branch --no-tags --branch \$WORKSHOP_GIT_BRANCH \$WORKSHOP_GIT_URL $BASE_DIR"
+  exit 1
+fi
+
+cd $BASE_DIR
+echo "=== Running post-clone setup from $BASE_DIR ==="
+
+# Zsh config
+cp hack/.zshrc hack/.p10k.zsh hack/.zsh_history ~/
+
+# bashrc.d
+mkdir -p ~/.bashrc.d
+cp $BASE_DIR/hack/.bashrc.d/* ~/.bashrc.d/
+
+# MCP servers
+uv tool install mcp-proxy-for-aws || true
+uv tool install awslabs.aws-iac-mcp-server || true
+
+# Kiro config
+mkdir -p ~/.kiro
+cp -r $BASE_DIR/hack/.kiro/* ~/.kiro/
+
+# k9s plugins
+mkdir -p ~/.config/k9s
+cp -r $BASE_DIR/hack/k9s/plugins ~/.config/k9s/ || true
+
+# Aliases and completions
+echo 'eval "$(mise activate bash)"' >> ~/.bashrc.d/aliases.sh
+echo "export PATH=${KREW_ROOT:-/home/ec2-user/.krew}/bin:/home/ec2-user/.local/bin:~/go/bin:$PATH" | tee -a ~/.bashrc.d/aliases.sh
+kubectl completion bash >> ~/.bash_completion
+argocd completion bash >> ~/.bash_completion
+helm completion bash >> ~/.bash_completion
+echo "alias k=kubectl" >> ~/.bashrc.d/aliases.sh
+echo "alias kgn='kubectl get nodes -L beta.kubernetes.io/arch -L eks.amazonaws.com/capacityType -L beta.kubernetes.io/instance-type -L eks.amazonaws.com/nodegroup -L topology.kubernetes.io/zone -L karpenter.sh/provisioner-name -L karpenter.sh/capacity-type'" | tee -a ~/.bashrc.d/aliases.sh
+echo "alias ll='ls -la'" >> ~/.bashrc.d/aliases.sh
+echo "alias ktx=kubectx" >> ~/.bashrc.d/aliases.sh
+echo "alias kctx=kubectx" >> ~/.bashrc.d/aliases.sh
+echo "alias kns=kubens" >> ~/.bashrc.d/aliases.sh
+echo "export TERM=xterm-color" >> ~/.bashrc.d/aliases.sh
+echo "alias code='~/.local/lib/code-editor-v*-linux-x64/dist/bin/remote-cli/code'" >> ~/.bashrc.d/aliases.sh
+echo 'alias pytest=pytest-3' >> ~/.bashrc.d/aliases.sh
+echo "alias open='xdg-open'" >> ~/.bashrc.d/aliases.sh
+echo "complete -F __start_kubectl k" >> ~/.bashrc.d/aliases.sh
+
+# Chromium deps for Playwright
+sudo yum install -y atk at-spi2-atk cups-libs libdrm libxkbcommon libXcomposite libXdamage libXrandr mesa-libgbm pango alsa-lib nss nspr libXScrnSaver libXtst gtk3
+
+echo "=== Post-clone setup complete. Run 'source ~/.bashrc.d/platform.sh' ==="

--- a/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
+++ b/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
@@ -23,6 +23,13 @@ echo "=== Running post-clone setup from $BASE_DIR ==="
 eval "$(~/.local/bin/mise activate bash 2>/dev/null)" || true
 export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$PATH"
 
+# Install uv if missing (git/NFS bug may have interrupted mise setup)
+if ! command -v uv &>/dev/null; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
 # Zsh config
 cp hack/.zshrc hack/.p10k.zsh hack/.zsh_history ~/
 

--- a/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
+++ b/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
@@ -19,6 +19,9 @@ fi
 cd $BASE_DIR
 echo "=== Running post-clone setup from $BASE_DIR ==="
 
+# Ensure mise-managed tools (uv, etc.) are on PATH
+eval "$(~/.local/bin/mise activate bash 2>/dev/null)" || export PATH="$HOME/.local/bin:$PATH"
+
 # Zsh config
 cp hack/.zshrc hack/.p10k.zsh hack/.zsh_history ~/
 

--- a/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
+++ b/platform/infra/terraform/scripts/fix-bootstrap-post-clone.sh
@@ -25,9 +25,9 @@ export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$PATH"
 
 # Install uv if missing (git/NFS bug may have interrupted mise setup)
 if ! command -v uv &>/dev/null; then
-  echo "Installing uv..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  export PATH="$HOME/.local/bin:$PATH"
+  echo "Installing uv via mise..."
+  mise install uv@latest
+  mise reshim
 fi
 
 # Zsh config


### PR DESCRIPTION
## Summary

Fixes multiple deployment reliability issues affecting Workshop Studio deployments: Keycloak StatefulSet drift blocking ArgoCD syncs, missing OIDC secrets in AWS Secrets Manager, git/NFS path length failures, and MCP server configuration.

## Key Changes

### Keycloak Secrets Manager Push (Critical Fix)
- **Remove PushSecret dependency** — the config Job now pushes OIDC client secrets directly to AWS Secrets Manager via `aws secretsmanager` CLI, eliminating the race condition where ArgoCD failed the PostSync before ESO could reconcile the PushSecret
- Add `unzip` to the config Job container (required for AWS CLI v2 installation)
- PushSecret resource removed entirely from the keycloak chart

### Git/NFS Path Length Fix
- Clone workshop repo to `/tmp` (local disk) to avoid NFS path length issues with long git ref names (dependabot branches)
- Strip `.git`, move files to NFS workspace, reinit fresh repo
- Push clean single-commit history to GitLab (no GitHub refs)
- Use `git reset --hard origin/main` in `2-gitlab-init.sh` instead of `git pull --rebase` (avoids conflicts between divergent histories)

### ArgoCD StatefulSet Drift
- Add comprehensive `ignoreDifferences` for Keycloak StatefulSet (pod template annotations, volumeClaimTemplates, podManagementPolicy, updateStrategy)
- Add CRD drift ignore for argo-rollouts (conversion, preserveUnknownFields)
- Prevents drift from blocking syncs and PostSync hooks

### Self-Healing argocd-refresh-token
- If token retrieval fails, automatically runs `configure_identity_center.py` to set up IDC-Keycloak federation before retrying
- Ensures Chromium system dependencies are installed for Playwright

### MCP Server Configuration
- Use mise shims path (`/home/ec2-user/.local/share/mise/shims/uvx`) for MCP servers in peeks agent config
- Add post-clone recovery script (`fix-bootstrap-post-clone.sh`) for when git/NFS bug interrupts bootstrap

### Other
- Reorder zsh_history so `kiro-cli login` shows first on up-arrow
- Add deployment architecture steering doc for IDE agent

## Testing

Deployed and validated on multiple Workshop Studio accounts (ws903, ws1229, ws1541, ws1152, ws1250). ws1250: all apps Healthy, SM secret created synchronously, init status 0.
