### PR TITLE
fix(kro): use omit() instead of orValue("") for tracking-id annotation

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
@@ -131,7 +131,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           tableName: ${schema.spec.components.dynamodb.tableName}
           billingMode: PAY_PER_REQUEST
@@ -163,7 +163,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           name: ${schema.metadata.name}-role
           assumeRolePolicyDocument: |
@@ -202,7 +202,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           clusterName: ${schema.spec.clusterName}
           namespace: ${schema.metadata.namespace}
@@ -224,7 +224,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             kro.run/depends-on: ${podidentity.metadata.name}
     - id: serviceaccountWithoutDynamoDB
       includeWhen:
@@ -242,7 +242,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
     - id: rolloutWithDynamoDB
       includeWhen:
         - ${schema.spec.functionalGate.enabled == false && schema.spec.performanceGate.enabled == false && schema.spec.components.dynamodb.enabled == true}
@@ -259,7 +259,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           replicas: ${schema.spec.replicas}
           revisionHistoryLimit: 2
@@ -332,7 +332,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           replicas: ${schema.spec.replicas}
           revisionHistoryLimit: 2
@@ -392,7 +392,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           replicas: ${schema.spec.replicas}
           revisionHistoryLimit: 2
@@ -487,7 +487,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           replicas: ${schema.spec.replicas}
           revisionHistoryLimit: 2
@@ -568,7 +568,7 @@ spec:
     #           blockOwnerDeletion: true
     #           controller: false
     #       annotations:
-    #         argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+    #         argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
     #     spec:
     #       selector:
     #         app: ${schema.metadata.name}
@@ -583,7 +583,7 @@ spec:
     #     metadata:
     #       name: ${schema.metadata.name}-preview
     #       annotations:
-    #         argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+    #         argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
     #     spec:
     #       selector:
     #         app: ${schema.metadata.name}
@@ -608,7 +608,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             nginx.ingress.kubernetes.io/rewrite-target: /$2
             nginx.ingress.kubernetes.io/use-regex: "true"
         spec:
@@ -642,7 +642,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             nginx.ingress.kubernetes.io/use-regex: "true"
         spec:
           ingressClassName: nginx
@@ -672,7 +672,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           secretStoreRef:
             name: aws-secrets-manager
@@ -707,7 +707,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           args:
             - name: service-name
@@ -745,7 +745,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           args:
             - name: service-name
@@ -783,7 +783,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           args:
             - name: service-name
@@ -830,7 +830,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           args:
             - name: service-name
@@ -862,7 +862,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         data:
           benchmark.yaml: |
             config:

--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -108,7 +108,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              ecr.services.k8s.aws/force-delete: "true"
        spec:
           name: >-
@@ -169,7 +169,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              ecr.services.k8s.aws/force-delete: "true"
        spec:
           name: >-
@@ -231,7 +231,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
        spec:
           name: ${schema.spec.aws.resourcePrefix}-${schema.spec.application.name}-ecr-policy
           description: ECR access policy for CI/CD pipeline
@@ -295,7 +295,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
        spec:
           name: ${schema.spec.aws.resourcePrefix}-${schema.spec.application.name}-role
           description: IAM role for CI/CD pipeline with EKS pod identity
@@ -340,7 +340,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Implicit dependencies through template references
              roleArn: ${iamrole.status.ackResourceMetadata.arn}
        spec:
@@ -370,7 +370,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.aws.region}
         spec:
           clusterName: "${schema.spec.aws.deployClusterName}"
@@ -401,7 +401,7 @@ spec:
              app.kubernetes.io/component: cicd-pipeline
              app.kubernetes.io/managed-by: kro
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Implicit dependency on IAM role through template reference
              eks.amazonaws.com/role-arn: ${iamrole.status.ackResourceMetadata.arn}
              # Reference to Pod Identity Association for tracking
@@ -429,7 +429,7 @@ spec:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
        rules:
           # Minimal permissions for CI/CD operations
           - apiGroups: ['']
@@ -503,7 +503,7 @@ spec:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
        subjects:
           - kind: ServiceAccount
             name: ${schema.spec.name}-sa
@@ -531,7 +531,7 @@ spec:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
        rules:
           - apiGroups: [""]
             resources: ["secrets"]
@@ -558,7 +558,7 @@ spec:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
        subjects:
           - kind: ServiceAccount
             name: ${schema.spec.name}-sa
@@ -585,7 +585,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -638,7 +638,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -682,7 +682,7 @@ spec:
              app.kubernetes.io/component: cicd-pipeline
              app.kubernetes.io/managed-by: kro
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Reference to ECR repositories for credential management
              ecr.aws/main-repository: ${ecrmainrepo.status.repositoryURI}
              ecr.aws/cache-repository: ${ecrcacherepo.status.repositoryURI}
@@ -720,7 +720,7 @@ spec:
              app.kubernetes.io/component: cicd-pipeline
              app.kubernetes.io/managed-by: kro
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Namespace scoping
              cicd.kro.run/namespace-scoped: 'true'
              cicd.kro.run/application: ${schema.spec.application.name}
@@ -819,7 +819,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -1117,7 +1117,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -1194,7 +1194,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -1456,7 +1456,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -1722,7 +1722,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -2110,7 +2110,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Implicit dependency on WorkflowTemplate
              workflowtemplate-ref: ${dorasetuptemplate.metadata.name}
           labels:
@@ -2145,7 +2145,7 @@ spec:
              app.kubernetes.io/component: cicd-pipeline
              app.kubernetes.io/managed-by: kro
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Namespace scoping
              cicd.kro.run/namespace-scoped: 'true'
              cicd.kro.run/application: ${schema.spec.application.name}
@@ -2253,7 +2253,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Implicit dependency on WorkflowTemplate
              workflowtemplate-ref: ${provisioningworkflow.metadata.name}
           labels:
@@ -2290,7 +2290,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
              # Explicit dependency - reference setup workflow to create implicit dependency
              kro.run/depends-on: ${setupworkflow.metadata.name}
           labels:
@@ -2341,7 +2341,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -2371,7 +2371,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
              app.kubernetes.io/name: ${schema.spec.application.name}
              app.kubernetes.io/component: cicd-pipeline
@@ -2630,7 +2630,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           labels:
             app.kubernetes.io/name: ${schema.spec.application.name}
             app.kubernetes.io/component: cicd-pipeline
@@ -2665,7 +2665,7 @@ spec:
             app.kubernetes.io/component: cicd-pipeline
             app.kubernetes.io/managed-by: kro
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             nginx.ingress.kubernetes.io/proxy-body-size: 512m
             nginx.ingress.kubernetes.io/use-regex: "true"
             nginx.ingress.kubernetes.io/rewrite-target: /webhook
@@ -2705,7 +2705,7 @@ spec:
             app.kubernetes.io/component: cicd-pipeline
             app.kubernetes.io/managed-by: kro
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           maxUnavailable: 0
           selector:

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks-vpc.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks-vpc.yaml
@@ -114,7 +114,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             argocd.argoproj.io/sync-options: Prune=false
       spec:
         name: ${schema.spec.name}
@@ -144,7 +144,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             argocd.argoproj.io/sync-options: Prune=false
       spec:
           name: ${schema.spec.name}

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
@@ -124,7 +124,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-ingress-http"
@@ -169,7 +169,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-ingress-https"
@@ -217,7 +217,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-cluster-role"
@@ -262,7 +262,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-cluster-node-role"
@@ -303,7 +303,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             clusterRoleArn: "${clusterRole.status.ackResourceMetadata.arn}"
             nodeRoleArn: "${nodeRole.status.ackResourceMetadata.arn}"
             services.k8s.aws/region: ${schema.spec.region}
@@ -364,7 +364,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             clusterArn: "${ekscluster.status.ackResourceMetadata.arn}"
             services.k8s.aws/region: ${schema.spec.region}
         spec:
@@ -393,7 +393,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
             #force dependency on ekscluster
             eksclusterArn: "${ekscluster.status.ackResourceMetadata.arn}"
@@ -465,7 +465,7 @@ spec:
           # (EksCluster is in ${schema.spec.name} namespace, Secret is in argocd namespace)
           # Kubernetes doesn't allow cross-namespace owner references for security reasons
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             # GitOps Bridge
             accountId: "${schema.spec.accountId}"
             aws_account_id: "${schema.spec.accountId}"
@@ -557,7 +557,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${schema.spec.name}"
@@ -587,7 +587,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${ekscluster.spec.name}"
@@ -621,7 +621,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-external-secrets-role"
@@ -660,7 +660,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${ekscluster.spec.name}"
@@ -694,7 +694,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-ack-iam"
@@ -743,7 +743,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             policy: "${externalDnsPolicy.status.ackResourceMetadata.arn}"
             services.k8s.aws/region: ${schema.spec.region}
         spec:
@@ -789,7 +789,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${ekscluster.spec.name}"
@@ -820,7 +820,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-adot-collector-role"
@@ -860,7 +860,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${ekscluster.spec.name}"
@@ -895,7 +895,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-kyverno-policy-reporter-role"
@@ -935,7 +935,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${ekscluster.spec.name}"
@@ -969,7 +969,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-cni-metrics-helper-policy"
@@ -1007,7 +1007,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-cni-metrics-helper-role"
@@ -1047,7 +1047,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${ekscluster.spec.name}"
@@ -1081,7 +1081,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-cloudwatch-observability-role"
@@ -1121,7 +1121,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           clusterName: "${ekscluster.spec.name}"
@@ -1161,7 +1161,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.resourcePrefix}-${schema.spec.name}-ack-capability-role"
@@ -1231,7 +1231,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.resourcePrefix}-${schema.spec.name}-kro-capability-role"
@@ -1275,7 +1275,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-              argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+              argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
               argocd.argoproj.io/sync-options: Prune=false
         spec:
           clusterName: ${ekscluster.spec.name}
@@ -1302,7 +1302,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
-              argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+              argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
               argocd.argoproj.io/sync-options: Prune=false
         spec:
           clusterName: ${ekscluster.spec.name}

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-vpc.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-vpc.yaml
@@ -40,7 +40,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         cidrBlocks: 
@@ -65,7 +65,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         vpc: ${vpc.status.vpcID}
@@ -87,7 +87,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         subnetID: ${publicSubnet1.status.subnetID}
@@ -111,7 +111,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         subnetID: ${publicSubnet2.status.subnetID}
@@ -135,7 +135,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         tags:
@@ -156,7 +156,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         tags:
@@ -177,7 +177,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         vpcID: ${vpc.status.vpcID}
@@ -202,7 +202,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         vpcID: ${vpc.status.vpcID}
@@ -227,7 +227,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         vpcID: ${vpc.status.vpcID}
@@ -252,7 +252,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         availabilityZone: ${schema.spec.region}a
@@ -281,7 +281,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         availabilityZone: ${schema.spec.region}b
@@ -310,7 +310,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         availabilityZone: ${schema.spec.region}a
@@ -338,7 +338,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
       spec:
         availabilityZone: ${schema.spec.region}b

--- a/gitops/addons/charts/kro/resource-groups/manifests/ray-service/ray-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/ray-service/ray-service.yaml
@@ -17,7 +17,7 @@ spec:
         metadata:
           name: ${schema.spec.name}-s3-models-pv
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           ownerReferences:
             - apiVersion: kro.run/v1alpha1
               blockOwnerDeletion: true
@@ -26,7 +26,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           capacity:
             storage: 100Gi
@@ -52,7 +52,7 @@ spec:
           name: ${schema.spec.name}-s3-models-pvc
           namespace: ${schema.metadata.namespace}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           ownerReferences:
             - apiVersion: kro.run/v1alpha1
               blockOwnerDeletion: true
@@ -61,7 +61,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           accessModes:
             - ReadWriteMany
@@ -82,7 +82,7 @@ spec:
         kind: RayService
         metadata:
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             backstage.io/created-by: ${schema.spec.createdBy}
             backstage.io/template-version: 1.0.0
             ray.io/serve-config-source: ${schema.spec.rayServeFile}
@@ -101,7 +101,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           deploymentUnhealthySecondThreshold: 1200
           rayClusterConfig:
@@ -219,7 +219,7 @@ spec:
         kind: RayService
         metadata:
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             backstage.io/created-by: ${schema.spec.createdBy}
             backstage.io/template-version: 1.0.0
             ray.io/serve-config-source: ${schema.spec.rayServeFile}
@@ -238,7 +238,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           deploymentUnhealthySecondThreshold: 1200
           rayClusterConfig:
@@ -361,7 +361,7 @@ spec:
         kind: RayService
         metadata:
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             backstage.io/created-by: ${schema.spec.createdBy}
             backstage.io/template-version: 1.0.0
             ray.io/serve-config-source: ${schema.spec.rayServeFile}
@@ -380,7 +380,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           deploymentUnhealthySecondThreshold: 1200
           rayClusterConfig:
@@ -540,7 +540,7 @@ spec:
         kind: Service
         metadata:
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             backstage.io/created-by: ${schema.spec.createdBy}
             backstage.io/template-version: 1.0.0
           labels:
@@ -558,7 +558,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           ports:
             - name: serve
@@ -581,7 +581,7 @@ spec:
         kind: Ingress
         metadata:
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
             backstage.io/created-by: ${schema.spec.createdBy}
             backstage.io/template-version: 1.0.0
             nginx.ingress.kubernetes.io/rewrite-target: /$2
@@ -634,7 +634,7 @@ spec:
           name: ${schema.spec.name}-head-pdb
           namespace: ${schema.metadata.namespace}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           ownerReferences:
             - apiVersion: kro.run/v1alpha1
               blockOwnerDeletion: true
@@ -643,7 +643,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           minAvailable: 1
           selector:
@@ -661,7 +661,7 @@ spec:
           name: ${schema.spec.name}-worker-pdb
           namespace: ${schema.metadata.namespace}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           ownerReferences:
             - apiVersion: kro.run/v1alpha1
               blockOwnerDeletion: true
@@ -670,7 +670,7 @@ spec:
               name: ${schema.metadata.name}
               uid: ${schema.metadata.uid}
           annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
         spec:
           minAvailable: 1
           selector:

--- a/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
@@ -51,7 +51,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
-          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+          argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].omit()}
           services.k8s.aws/region: ${schema.spec.region}
           argocd.argoproj.io/sync-options: "Ignore=true,SkipDryRunOnMissingResource=true"
       spec:


### PR DESCRIPTION
## Summary

When a kro instance (CICDPipeline, AppmodService, etc.) is created without ArgoCD (e.g., manually via kubectl), the `argocd.argoproj.io/tracking-id` annotation doesn't exist on the parent CR.

Previously, `.orValue("")` would set an empty string annotation on all child resources. With `.omit()`, the annotation is simply not set when absent — which is the correct behavior.

## Changes

Replaced `.orValue("")` with `.omit()` for the optional argocd tracking-id annotation across all RGDs:
- cicd-pipeline.yaml (29 occurrences)
- appmod-service.yaml (19)
- rg-eks.yaml (28)
- ray-service.yaml (17)
- rg-vpc.yaml (13)
- rg-eks-vpc.yaml (2)
- rg-s3-bucket.yaml (1)

## Testing

- Applied updated cicd-pipeline RGD on a live EKS cluster with kro as EKS Capability
- RGD remains Active after the change
- Existing CICDPipeline instances (rust, java) remain ACTIVE and healthy
- Child resources with existing tracking-id annotations are unaffected

Ref: https://github.com/kubernetes-sigs/kro/pull/1273#discussion_r3197153696