### PR TITLE
fix: add download timeout to model prestage jobs

### DIFF
--- a/gitops/addons/charts/ray-operator/templates/model-prestage-job.yaml
+++ b/gitops/addons/charts/ray-operator/templates/model-prestage-job.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     model: {{ $modelName }}
 spec:
-  backoffLimit: 3
-  activeDeadlineSeconds: 7200
+  backoffLimit: 5
+  activeDeadlineSeconds: 3600
   template:
     metadata:
       labels:
@@ -32,19 +32,20 @@ spec:
         - -c
         - |
           set -e
+          DOWNLOAD_TIMEOUT=${DOWNLOAD_TIMEOUT:-1800}
           echo "Installing dependencies..."
           yum install -y python3-pip tar gzip
           pip3 install huggingface_hub
           
-          echo "Downloading {{ $modelName }} from {{ $modelConfig.repoId }}..."
-          python3 << 'PYTHON'
+          echo "Downloading {{ $modelName }} from {{ $modelConfig.repoId }} (timeout: ${DOWNLOAD_TIMEOUT}s)..."
+          timeout $DOWNLOAD_TIMEOUT python3 -c "
           from huggingface_hub import snapshot_download
           snapshot_download(
-              repo_id="{{ $modelConfig.repoId }}",
-              local_dir="/tmp/{{ $modelName }}",
+              repo_id='{{ $modelConfig.repoId }}',
+              local_dir='/tmp/{{ $modelName }}',
               local_dir_use_symlinks=False
           )
-          PYTHON
+          "
           
           echo "Uploading to S3..."
           aws s3 sync /tmp/{{ $modelName }}/ s3://{{ $.Values.modelPrestage.s3Bucket | default "peeks-ray-models" }}/models/{{ $modelName }}/ --no-progress


### PR DESCRIPTION
## Summary
Downloads from HuggingFace can stall silently when no HF_TOKEN is set (common in workshop environments). The prestage jobs hang indefinitely, keeping the ArgoCD ray-operator app in Progressing state.

## Changes
- Wrap `huggingface_hub` download with `timeout` command (30 min default)
- Increase `backoffLimit` from 3 to 5 for more retry attempts
- Reduce `activeDeadlineSeconds` from 7200 to 3600

## Testing
Verified on workshop cluster - stalled jobs now get killed and retried automatically.