### PR TITLE
fix: add missing resource types to ray-serve AppProject whitelists

### DIFF
--- a/platform/backstage/templates/ray-serve-cpu/template-ray-serve.yaml
+++ b/platform/backstage/templates/ray-serve-cpu/template-ray-serve.yaml
@@ -189,6 +189,9 @@ spec:
               - https://${{ steps['fetchSystem'].output.entity.spec.gitlab_hostname }}/${{ steps['fetchSystem'].output.entity.spec.gituser }}/${{parameters.name}}-ray-service.git
             sourceNamespaces:
               - argocd
+            clusterResourceWhitelist:
+              - group: ""
+                kind: PersistentVolume
             namespaceResourceWhitelist:
               - group: ""
                 kind: Namespace
@@ -198,6 +201,8 @@ spec:
                 kind: ConfigMap
               - group: ""
                 kind: Secret
+              - group: ""
+                kind: PersistentVolumeClaim
               - group: apps
                 kind: Deployment
               - group: kro.run
@@ -208,6 +213,8 @@ spec:
                 kind: RayCluster
               - group: networking.k8s.io
                 kind: Ingress
+              - group: policy
+                kind: PodDisruptionBudget
             roles:
               - name: admin
                 policies:

--- a/platform/backstage/templates/ray-serve-cpu/template.yaml
+++ b/platform/backstage/templates/ray-serve-cpu/template.yaml
@@ -180,6 +180,9 @@ spec:
               - https://${{ steps['fetchSystem'].output.entity.spec.gitlab_hostname }}/${{ steps['fetchSystem'].output.entity.spec.gituser }}/${{parameters.name}}-ray-service.git
             sourceNamespaces:
               - argocd
+            clusterResourceWhitelist:
+              - group: ""
+                kind: PersistentVolume
             namespaceResourceWhitelist:
               - group: ""
                 kind: Namespace
@@ -189,10 +192,20 @@ spec:
                 kind: ConfigMap
               - group: ""
                 kind: Secret
+              - group: ""
+                kind: PersistentVolumeClaim
               - group: apps
                 kind: Deployment
               - group: kro.run
                 kind: RayService
+              - group: ray.io
+                kind: RayService
+              - group: ray.io
+                kind: RayCluster
+              - group: networking.k8s.io
+                kind: Ingress
+              - group: policy
+                kind: PodDisruptionBudget
 
     - id: create-argocd-app
       name: Create ArgoCD Application

--- a/platform/backstage/templates/ray-serve-gpu/template-ray-serve.yaml
+++ b/platform/backstage/templates/ray-serve-gpu/template-ray-serve.yaml
@@ -189,6 +189,9 @@ spec:
               - https://${{ steps['fetchSystem'].output.entity.spec.gitlab_hostname }}/${{ steps['fetchSystem'].output.entity.spec.gituser }}/${{parameters.name}}-ray-service.git
             sourceNamespaces:
               - argocd
+            clusterResourceWhitelist:
+              - group: ""
+                kind: PersistentVolume
             namespaceResourceWhitelist:
               - group: ""
                 kind: Namespace
@@ -198,6 +201,8 @@ spec:
                 kind: ConfigMap
               - group: ""
                 kind: Secret
+              - group: ""
+                kind: PersistentVolumeClaim
               - group: apps
                 kind: Deployment
               - group: kro.run
@@ -208,6 +213,8 @@ spec:
                 kind: RayCluster
               - group: networking.k8s.io
                 kind: Ingress
+              - group: policy
+                kind: PodDisruptionBudget
             roles:
               - name: admin
                 policies:

--- a/platform/backstage/templates/ray-serve-gpu/template.yaml
+++ b/platform/backstage/templates/ray-serve-gpu/template.yaml
@@ -186,6 +186,9 @@ spec:
               - https://${{ steps['fetchSystem'].output.entity.spec.gitlab_hostname }}/${{ steps['fetchSystem'].output.entity.spec.gituser }}/${{parameters.name}}-ray-service.git
             sourceNamespaces:
               - argocd
+            clusterResourceWhitelist:
+              - group: ""
+                kind: PersistentVolume
             namespaceResourceWhitelist:
               - group: ""
                 kind: Namespace
@@ -195,10 +198,20 @@ spec:
                 kind: ConfigMap
               - group: ""
                 kind: Secret
+              - group: ""
+                kind: PersistentVolumeClaim
               - group: apps
                 kind: Deployment
               - group: kro.run
                 kind: RayService
+              - group: ray.io
+                kind: RayService
+              - group: ray.io
+                kind: RayCluster
+              - group: networking.k8s.io
+                kind: Ingress
+              - group: policy
+                kind: PodDisruptionBudget
 
     - id: create-argocd-app
       name: Create ArgoCD Application

--- a/platform/backstage/templates/ray-serve-trainium/template-ray-serve.yaml
+++ b/platform/backstage/templates/ray-serve-trainium/template-ray-serve.yaml
@@ -191,6 +191,9 @@ spec:
               - https://${{ steps['fetchSystem'].output.entity.spec.gitlab_hostname }}/${{ steps['fetchSystem'].output.entity.spec.gituser }}/${{parameters.name}}-ray-service.git
             sourceNamespaces:
               - argocd
+            clusterResourceWhitelist:
+              - group: ""
+                kind: PersistentVolume
             namespaceResourceWhitelist:
               - group: ""
                 kind: Namespace
@@ -200,6 +203,8 @@ spec:
                 kind: ConfigMap
               - group: ""
                 kind: Secret
+              - group: ""
+                kind: PersistentVolumeClaim
               - group: apps
                 kind: Deployment
               - group: kro.run
@@ -210,6 +215,8 @@ spec:
                 kind: RayCluster
               - group: networking.k8s.io
                 kind: Ingress
+              - group: policy
+                kind: PodDisruptionBudget
             roles:
               - name: admin
                 policies:

--- a/platform/backstage/templates/ray-serve-trainium/template.yaml
+++ b/platform/backstage/templates/ray-serve-trainium/template.yaml
@@ -190,6 +190,9 @@ spec:
               - https://${{ steps['fetchSystem'].output.entity.spec.gitlab_hostname }}/${{ steps['fetchSystem'].output.entity.spec.gituser }}/${{parameters.name}}-ray-service.git
             sourceNamespaces:
               - argocd
+            clusterResourceWhitelist:
+              - group: ""
+                kind: PersistentVolume
             namespaceResourceWhitelist:
               - group: ""
                 kind: Namespace
@@ -199,10 +202,20 @@ spec:
                 kind: ConfigMap
               - group: ""
                 kind: Secret
+              - group: ""
+                kind: PersistentVolumeClaim
               - group: apps
                 kind: Deployment
               - group: kro.run
                 kind: RayService
+              - group: ray.io
+                kind: RayService
+              - group: ray.io
+                kind: RayCluster
+              - group: networking.k8s.io
+                kind: Ingress
+              - group: policy
+                kind: PodDisruptionBudget
 
     - id: create-argocd-app
       name: Create ArgoCD Application


### PR DESCRIPTION
## Problem

ArgoCD was not displaying KRO child resources in the application tree view for ray-serve applications. Only the parent `kro.run/RayService` was visible, while all child resources (PVC, PV, Ingress, PDB, ray.io/RayService, ray.io/RayCluster) were hidden.

## Root Cause

The AppProject `namespaceResourceWhitelist` in ray-serve Backstage templates was too restrictive — it only allowed a subset of resource types that KRO creates.

## Fix

Added missing resource types to all 6 ray-serve template files (cpu, gpu, trainium × 2 variants):

- `clusterResourceWhitelist`: `PersistentVolume`
- `namespaceResourceWhitelist`: `PersistentVolumeClaim`, `PodDisruptionBudget`
- `template.yaml` variants also needed: `ray.io/RayService`, `ray.io/RayCluster`, `networking.k8s.io/Ingress`

## Testing

Verified on a live cluster by patching the AppProject — ArgoCD immediately showed the full resource tree with all KRO child resources.