### PR TITLE
fix: rename CI/CD template to be tool-agnostic

### DIFF
--- a/platform/backstage/templates/cicd-pipeline/GITOPS_MIGRATION.md
+++ b/platform/backstage/templates/cicd-pipeline/GITOPS_MIGRATION.md
@@ -142,7 +142,7 @@ argocd.argoproj.io/finalizer: resources-finalizer.argocd.argoproj.io
 
 ### Creating New CICDPipeline (GitOps)
 ```bash
-# User selects "Deploy CI/CD Pipeline With kro (GitOps)" template
+# User selects "Deploy CI/CD Pipeline (GitOps)" template
 # Backstage creates:
 # 1. GitLab repository with manifests
 # 2. ArgoCD project and application

--- a/platform/backstage/templates/cicd-pipeline/template-cicd-pipeline.yaml
+++ b/platform/backstage/templates/cicd-pipeline/template-cicd-pipeline.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   description: Deploy a Kro-based CI/CD Pipeline using GitOps with ArgoCD
   name: cicd-pipeline-gitops
-  title: Deploy CI/CD Pipeline With kro (GitOps)
+  title: Deploy CI/CD Pipeline (GitOps)
 spec:
   owner: guest
   type: service


### PR DESCRIPTION
Fixes from validation bot run (Issue #3):

- Rename Backstage CI/CD template from 'Deploy CI/CD Pipeline With kro (GitOps)' to 'Deploy CI/CD Pipeline (GitOps)'
- The pipeline is shared by both KubeVela and kro users, so the name should be tool-agnostic
- Updated template YAML and GITOPS_MIGRATION.md