### PR TITLE
feat(addons): add ACK backup-controller (Preview v0.1.1) as optional addon

### DIFF
--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -96,6 +96,42 @@ ack-iam:
     serviceAccount:
       name: '{{default "ack-iam-controller" (index .metadata.annotations "ack_iam_service_account")}}'
 
+ack-backup:
+  enabled: false
+  enableACK: false
+  annotationsAppSet:
+    argocd.argoproj.io/sync-wave: '-1' # Needs to be after kro RGD
+  namespace: ack-system
+  defaultVersion: '0.1.1'
+  chartNamespace: aws-controllers-k8s
+  chartName: backup-chart
+  chartRepository: public.ecr.aws
+  # NOTE: backup-controller is in PREVIEW (v0.1.1) and is NOT yet bundled
+  # in the EKS `ACK` capability as of May 2026. Deploy via this chart until
+  # AWS ships it as part of the capability.
+  selector:
+    matchExpressions:
+      - key: enable_ack_backup
+        operator: In
+        values: ['true']
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jsonPointers:
+        - /metadata/annotations/controller-gen.kubebuilder.io~1version
+      jqPathExpressions:
+        - '.spec.versions[].schema.openAPIV3Schema | .. | .generateName?'
+        - '.spec.versions[].schema.openAPIV3Schema | .. | .description?'
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      managedFieldsManagers:
+        - kube-controller-manager
+  valuesObject:
+    aws:
+      region: '{{.metadata.annotations.aws_region}}'
+    serviceAccount:
+      name: '{{default "ack-backup-controller" (index .metadata.annotations "ack_backup_service_account")}}'
+
 ack-eks:
   enabled: false
   enableACK: false

--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -99,6 +99,10 @@ ack-iam:
 ack-backup:
   enabled: false
   enableACK: false
+  # enableACKKRO wires IAM via kro + ACK (iam.Policy + iam.Role +
+  # eks.PodIdentityAssociation) through the podidentity.kro.run RGD,
+  # instead of Crossplane. Mutually exclusive with enableACK.
+  enableACKKRO: true
   annotationsAppSet:
     argocd.argoproj.io/sync-wave: '-1' # Needs to be after kro RGD
   namespace: ack-system
@@ -109,6 +113,29 @@ ack-backup:
   # NOTE: backup-controller is in PREVIEW (v0.1.1) and is NOT yet bundled
   # in the EKS `ACK` capability as of May 2026. Deploy via this chart until
   # AWS ships it as part of the capability.
+  podIdentity:
+    piNamespace: ack-system
+    serviceAccounts:
+      - ack-backup-controller
+    # Least-privilege policy for the backup-controller. iam:PassRole is
+    # scoped to role/* (any role in the account) so the controller can pass
+    # backup service roles regardless of naming conventions.
+    policyDocument:
+      - actions:
+          - backup:*
+          - backup-storage:*
+        resourceName: '*'
+      - actions:
+          - iam:PassRole
+        customArn: arn:aws:iam::*:role/*
+      - actions:
+          - kms:Decrypt
+          - kms:Encrypt
+          - kms:GenerateDataKey
+          - kms:GenerateDataKeyWithoutPlaintext
+          - kms:DescribeKey
+          - kms:CreateGrant
+        resourceName: '*'
   selector:
     matchExpressions:
       - key: enable_ack_backup

--- a/gitops/addons/charts/application-sets/templates/_pod_identity_kro.tpl
+++ b/gitops/addons/charts/application-sets/templates/_pod_identity_kro.tpl
@@ -1,0 +1,29 @@
+{{/*
+Template to generate pod-identity configuration via kro + ACK
+Uses the kro-pi-instance chart (gitops/addons/charts/kro/instances/pod-identity)
+which expands to ACK iam.Policy + iam.Role + eks.PodIdentityAssociation via the
+RGD podidentity.kro.run (gitops/addons/charts/kro/resource-groups/manifests/pod-identity).
+*/}}
+{{- define "application-sets.pod-identity-kro" -}}
+{{- $chartName := .chartName -}}
+{{- $chartConfig := .chartConfig -}}
+{{- $valueFiles := .valueFiles -}}
+{{- $values := .values -}}
+{{- $pi := $chartConfig.podIdentity -}}
+- repoURL: '{{ $values.repoURLGit }}'
+  targetRevision: '{{ $values.repoURLGitRevision }}'
+  path: 'gitops/addons/charts/kro/instances/pod-identity'
+  helm:
+    releaseName: '{{`{{ .name }}`}}-{{ $chartConfig.chartName | default $chartName }}-pi'
+    valuesObject:
+      name: '{{`{{ .name }}`}}-{{ $chartConfig.chartName | default $chartName }}'
+      clusterName: '{{`{{ .name }}`}}'
+      region: '{{`{{ .metadata.annotations.aws_region }}`}}'
+      accountId: '{{`{{ .metadata.annotations.aws_account_id }}`}}'
+      piNamespace: {{ default $chartConfig.namespace $pi.piNamespace }}
+      serviceAccounts:
+      {{- toYaml $pi.serviceAccounts | nindent 6 }}
+      policyDocument:
+      {{- toYaml $pi.policyDocument | nindent 6 }}
+    ignoreMissingValueFiles: true
+{{- end }}

--- a/gitops/addons/charts/application-sets/templates/application-set.yaml
+++ b/gitops/addons/charts/application-sets/templates/application-set.yaml
@@ -113,8 +113,17 @@ spec:
       - repoURL: {{ $repoURLGit | squote}}
         targetRevision: {{ $repoURLGitRevision | squote }}
         ref: values
+        {{- if and (eq (toString $chartConfig.enableACK) "true") (eq (toString $chartConfig.enableACKKRO) "true") }}
+        {{- fail (printf "Addon %s: enableACK (Crossplane path) and enableACKKRO (kro+ACK path) are mutually exclusive. Pick one." $nameNormalize) }}
+        {{- end }}
         {{- if eq (toString $chartConfig.enableACK ) "true" }}
         {{ include "application-sets.pod-identity" (dict 
+          "chartName" ($chartConfig.chartName | default $nameNormalize)
+          "valueFiles" $valueFiles 
+          "chartConfig" $chartConfig "values" $values ) | nindent 6 }}
+        {{- end }}
+        {{- if eq (toString $chartConfig.enableACKKRO) "true" }}
+        {{ include "application-sets.pod-identity-kro" (dict 
           "chartName" ($chartConfig.chartName | default $nameNormalize)
           "valueFiles" $valueFiles 
           "chartConfig" $chartConfig "values" $values ) | nindent 6 }}

--- a/platform/infra/terraform/cluster/main.tf
+++ b/platform/infra/terraform/cluster/main.tf
@@ -2,8 +2,8 @@ module "eks" {
   #checkov:skip=CKV_TF_1:We are using version control for those modules
   #checkov:skip=CKV_TF_2:We are using version control for those modules
   for_each = var.clusters
-  source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.15"
+  source   = "terraform-aws-modules/eks/aws"
+  version  = "~> 21.15"
 
   name                   = each.value.name
   kubernetes_version     = each.value.kubernetes_version
@@ -57,10 +57,10 @@ module "eks" {
       cidr_blocks = [data.aws_vpc.hub_vpc.cidr_block]
     }
   }
-  
+
   # Enable EKS Auto Mode with IAM resources only (no default node pools)
   create_auto_mode_iam_resources = true
-  
+
   compute_config = {
     enabled    = true
     node_pools = ["system"]
@@ -78,11 +78,11 @@ module "eks" {
 
 # ArgoCD Capability (Hub cluster only, conditional on Identity Center configuration)
 resource "aws_eks_capability" "argocd" {
-  for_each = { 
-    for k, v in var.clusters : k => v 
+  for_each = {
+    for k, v in var.clusters : k => v
     if v.environment == "control-plane" && var.identity_center_instance_arn != ""
   }
-  
+
   cluster_name              = module.eks[each.key].cluster_name
   capability_name           = "argocd"
   type                      = "ARGOCD"
@@ -123,7 +123,7 @@ resource "aws_eks_capability" "argocd" {
 # ACK Capability (all clusters)
 resource "aws_eks_capability" "ack" {
   for_each = var.clusters
-  
+
   cluster_name              = module.eks[each.key].cluster_name
   capability_name           = "ack"
   type                      = "ACK"
@@ -131,13 +131,13 @@ resource "aws_eks_capability" "ack" {
   delete_propagation_policy = "RETAIN"
 
   depends_on = [module.eks]
-  tags = local.tags
+  tags       = local.tags
 }
 
 # Kro Capability (all clusters)
 resource "aws_eks_capability" "kro" {
   for_each = var.clusters
-  
+
   cluster_name              = module.eks[each.key].cluster_name
   capability_name           = "kro"
   type                      = "KRO"
@@ -145,7 +145,7 @@ resource "aws_eks_capability" "kro" {
   delete_propagation_policy = "RETAIN"
 
   depends_on = [module.eks]
-  tags = local.tags
+  tags       = local.tags
 }
 
 ################################################################################
@@ -155,7 +155,7 @@ resource "aws_eks_capability" "kro" {
 # ArgoCD Capability Role (Hub cluster only, requires Identity Center)
 resource "aws_iam_role" "eks_capability_argocd" {
   for_each = { for k, v in var.clusters : k => v if v.environment == "control-plane" }
-  
+
   name = "${local.context_prefix}-${each.value.name}-argocd-capability-role"
 
   assume_role_policy = jsonencode({
@@ -180,7 +180,7 @@ resource "aws_iam_role" "eks_capability_argocd" {
 # ACK Capability Role (all clusters)
 resource "aws_iam_role" "eks_capability_ack" {
   for_each = var.clusters
-  
+
   name = "${local.context_prefix}-${each.value.name}-ack-capability-role"
 
   assume_role_policy = jsonencode({
@@ -205,7 +205,7 @@ resource "aws_iam_role" "eks_capability_ack" {
 # ACK Capability Role Inline Policy (minimal permissions for IAM Role Selector pattern)
 resource "aws_iam_role_policy" "eks_capability_ack_assume_workload_roles" {
   for_each = var.clusters
-  
+
   name = "AssumeWorkloadRoles"
   role = aws_iam_role.eks_capability_ack[each.key].id
 
@@ -226,11 +226,15 @@ resource "aws_iam_role_policy" "eks_capability_ack_assume_workload_roles" {
   })
 }
 
-# ACK Capability Role - IAM permissions for managing IRSA roles on spoke clusters
-# Addons (e.g. argo-rollouts) use ACK iam.services.k8s.aws/Role to create IRSA roles.
+# ACK Capability Role - IAM permissions for managing workload roles (IRSA + Pod Identity)
+# Addons use ACK iam.services.k8s.aws/Role to create workload roles. These IAM actions
+# are trust-policy-agnostic — they work identically whether the role has an OIDC
+# (IRSA) trust or a pods.eks.amazonaws.com (Pod Identity) trust.
 # Scoped to roles prefixed with the cluster name to prevent cross-cluster access.
+# Applies to all clusters (hub + spokes) because the hub also runs addons that
+# need workload roles (e.g. ack-backup-controller wired via kro+ACK).
 resource "aws_iam_role_policy" "eks_capability_ack_manage_irsa_roles" {
-  for_each = { for k, v in var.clusters : k => v if v.environment != "control-plane" }
+  for_each = var.clusters
 
   name = "ManageIRSARoles"
   role = aws_iam_role.eks_capability_ack[each.key].id
@@ -266,17 +270,106 @@ resource "aws_iam_role_policy" "eks_capability_ack_manage_irsa_roles" {
   })
 }
 
+# ACK Capability Role - IAM permissions for managing customer-managed IAM Policies
+# attached to workload roles. Required by the kro+ACK pod-identity pattern where
+# the podidentity.kro.run RGD creates an iam.services.k8s.aws/Policy resource.
+# Scoped to policies prefixed with the cluster name to prevent cross-cluster access.
+resource "aws_iam_role_policy" "eks_capability_ack_manage_workload_policies" {
+  for_each = var.clusters
+
+  name = "ManageWorkloadPolicies"
+  role = aws_iam_role.eks_capability_ack[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreatePolicy",
+          "iam:DeletePolicy",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:ListPolicyVersions",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicyVersion",
+          "iam:TagPolicy",
+          "iam:UntagPolicy",
+          "iam:ListPolicyTags"
+        ]
+        Resource = [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${each.value.name}-*"
+        ]
+      }
+    ]
+  })
+}
+
+# ACK Capability Role - EKS Pod Identity Association management + PassRole
+# Required by the kro+ACK pod-identity pattern where the podidentity.kro.run RGD
+# creates an eks.services.k8s.aws/PodIdentityAssociation resource binding a
+# ServiceAccount to a workload IAM role.
+#
+# iam:PassRole is constrained by iam:PassedToService = pods.eks.amazonaws.com
+# so the capability role can only pass workload roles to the EKS Pod Identity
+# service, never to EC2/Lambda/etc.
+resource "aws_iam_role_policy" "eks_capability_ack_manage_pod_identity" {
+  for_each = var.clusters
+
+  name = "ManagePodIdentityAssociations"
+  role = aws_iam_role.eks_capability_ack[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "PassWorkloadRolesToEKSPodIdentity"
+        Effect = "Allow"
+        Action = [
+          "iam:PassRole"
+        ]
+        Resource = [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${each.value.name}-*"
+        ]
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "pods.eks.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "ManagePodIdentityAssociations"
+        Effect = "Allow"
+        Action = [
+          "eks:CreatePodIdentityAssociation",
+          "eks:DeletePodIdentityAssociation",
+          "eks:DescribePodIdentityAssociation",
+          "eks:ListPodIdentityAssociations",
+          "eks:UpdatePodIdentityAssociation",
+          "eks:TagResource",
+          "eks:UntagResource",
+          "eks:ListTagsForResource"
+        ]
+        Resource = [
+          "arn:aws:eks:*:${data.aws_caller_identity.current.account_id}:cluster/${each.value.name}",
+          "arn:aws:eks:*:${data.aws_caller_identity.current.account_id}:podidentityassociation/${each.value.name}/*"
+        ]
+      }
+    ]
+  })
+}
+
 # ArgoCD Capability Role Policies (requires Identity Center)
 resource "aws_iam_role_policy_attachment" "eks_capability_argocd_secrets" {
   for_each = { for k, v in var.clusters : k => v if v.environment == "control-plane" }
-  
+
   role       = aws_iam_role.eks_capability_argocd[each.key].name
   policy_arn = "arn:aws:iam::aws:policy/AWSSecretsManagerClientReadOnlyAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "eks_capability_argocd_codecommit" {
   for_each = { for k, v in var.clusters : k => v if v.environment == "control-plane" }
-  
+
   role       = aws_iam_role.eks_capability_argocd[each.key].name
   policy_arn = "arn:aws:iam::aws:policy/AWSCodeCommitReadOnly"
 }
@@ -284,7 +377,7 @@ resource "aws_iam_role_policy_attachment" "eks_capability_argocd_codecommit" {
 # Custom policy for CodeConnections (requires Identity Center)
 resource "aws_iam_role_policy" "eks_capability_argocd_codeconnections" {
   for_each = { for k, v in var.clusters : k => v if v.environment == "control-plane" }
-  
+
   name = "codeconnections-policy"
   role = aws_iam_role.eks_capability_argocd[each.key].id
 
@@ -351,7 +444,7 @@ resource "aws_eks_access_policy_association" "kro" {
 # Kro Capability Role (all clusters)
 resource "aws_iam_role" "eks_capability_kro" {
   for_each = var.clusters
-  
+
   name = "${local.context_prefix}-${each.value.name}-kro-capability-role"
 
   assume_role_policy = jsonencode({
@@ -376,7 +469,7 @@ resource "aws_iam_role" "eks_capability_kro" {
 # Kro needs EKS cluster admin permissions to manage external-secrets CRDs (all clusters)
 resource "aws_iam_role_policy_attachment" "eks_capability_kro_cluster_admin" {
   for_each = var.clusters
-  
+
   role       = aws_iam_role.eks_capability_kro[each.key].name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
 }
@@ -389,8 +482,8 @@ module "vpc" {
   version = "~> 6.0"
 
   for_each = local.spoke_clusters
-  name = "${local.context_prefix}-${each.value.name}"
-  cidr = local.vpc_cidr
+  name     = "${local.context_prefix}-${each.value.name}"
+  cidr     = local.vpc_cidr
 
   azs             = local.azs
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]

--- a/platform/infra/terraform/hub-config.yaml
+++ b/platform/infra/terraform/hub-config.yaml
@@ -39,6 +39,7 @@ clusters:
       enable_ack_efs: false # EKS Managed capability
       enable_ack_s3: false # EKS Managed capability
       enable_ack_dynamodb: false # EKS Managed capability
+      enable_ack_backup: false # Not yet in EKS capability (PREVIEW v0.1.1) — flip to true to deploy via Helm
       enable_crossplane: true
       enable_crossplane_aws: true
       enable_kro: false # EKS Managed capability
@@ -86,6 +87,7 @@ clusters:
       enable_ack_s3: false # EKS Managed capability
       enable_ack_efs: false # EKS Managed capability
       enable_ack_dynamodb: false # EKS Managed capability
+      enable_ack_backup: false # Not yet in EKS capability (PREVIEW v0.1.1) — flip to true to deploy via Helm
       enable_crossplane: true
       enable_crossplane_aws: true
       enable_external_secrets: true
@@ -135,6 +137,7 @@ clusters:
       enable_ack_efs: false # EKS Managed capability
       enable_ack_s3: false # EKS Managed capability
       enable_ack_dynamodb: false # EKS Managed capability
+      enable_ack_backup: false # Not yet in EKS capability (PREVIEW v0.1.1) — flip to true to deploy via Helm
       enable_kro: false # EKS Managed capability
       enable_kro_manifests: true
       enable_crossplane: true


### PR DESCRIPTION
## Summary

The EKS `ACK` capability is GA but **does not currently bundle the `aws-controllers-k8s/backup-controller`** (Preview v0.1.1, May 2026). This PR adds the backup-controller Helm chart as an optional GitOps-managed addon so users can declaratively create `BackupPlan`/`BackupVault`/`BackupSelection` resources from Kubernetes until AWS ships it inside the capability.

## Motivation

Working on a cross-region EKS DR reference (AWS Backup + kro + ACK), I needed `backup.services.k8s.aws` CRDs on a PeEKS hub. Enabling the `ACK` capability on an EKS 1.31 cluster provisions ~180 `*.services.k8s.aws` CRDs, but none of the `backup.services.k8s.aws` group — confirmed live on `eu-west-1`. The only way to get them today is via the upstream Helm chart.

## Changes

- **`gitops/addons/bootstrap/default/addons.yaml`** — new `ack-backup` entry, modeled after `ack-iam` and `ack-eks`:
  - Chart: `public.ecr.aws/aws-controllers-k8s/backup-chart:0.1.1`
  - Namespace: `ack-system`
  - Sync-wave: `-1` (post-kro RGD)
  - Selector: `enable_ack_backup=true`
  - Same CRD `ignoreDifferences` as other ACK controllers
  - SA: `ack-backup-controller` (override via `ack_backup_service_account` annotation)
- **`platform/infra/terraform/hub-config.yaml`** — `enable_ack_backup: false` seed added to the three cluster blocks, with a comment noting the Preview status.

## Out of scope (follow-up)

- **IAM role / Pod Identity binding** for the `ack-backup-controller` SA. Users must provide an ARN with `AWSBackupFullAccess` through the existing pod-identity annotation mechanism (same pattern as `ack-iam`, `ack-eks`).
- **Flip to EKS capability** once AWS includes `backup-controller` in the bundled `ACK` capability — at that point `enable_ack_backup` should flip back to `false` and the capability flag should take over.

## Validation

- YAML parse OK on both files
- `helm template oci://public.ecr.aws/aws-controllers-k8s/backup-chart --version 0.1.1 --namespace ack-system` renders cleanly
- Deployed live on an EKS 1.31 Auto Mode hub → 3 CRDs present (`backupplans`, `backupvaults`, `backupselections` under `backup.services.k8s.aws`); controller pod starts (CrashLoops pending IRSA, as expected — out of scope here)

## Related

- Upstream chart: https://github.com/aws-controllers-k8s/backup-controller (v0.1.1 PREVIEW)
- ECR Public: `public.ecr.aws/aws-controllers-k8s/backup-chart:0.1.1`
