### PR TITLE
feat(kro-rgds): BackupPolicy RGD with gold/silver/bronze tiers

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
@@ -1,4 +1,4 @@
-# BackupPolicy RGD (peeks DR Pattern B)
+# BackupPolicy RGD
 
 Kro `ResourceGraphDefinition` that exposes a single `BackupPolicy` custom resource
 and expands it into an ACK-managed AWS Backup stack:
@@ -6,6 +6,37 @@ and expands it into an ACK-managed AWS Backup stack:
 - `BackupVault` (created in the policy's region)
 - `BackupPlan` with tier-specific lifecycle & schedule
 - `BackupSelection` that matches resources by AWS tag
+
+## Why AWS Backup in a GitOps platform
+
+The platform uses GitOps (Argo CD + kro + ACK) as the source of truth for the
+**control plane** — cluster shape, capabilities, IAM, workload manifests — and
+AWS Backup as the source of truth for the **data plane** — persistent volumes
+and any Kubernetes kind that cannot be reconstructed from Git.
+
+This split enables three concrete use cases that share the same primitive:
+
+- **Disaster Recovery (cross-region)** — a spoke in `eu-west-1` is destroyed;
+  kro + ACK recreates an equivalent spoke in `eu-west-3` via the normal
+  `SpokeCluster` path, Argo CD re-syncs every workload from Git, and AWS Backup
+  restores the PVs from cross-region copies (produced by the `gold`/`silver`
+  plans defined here). The DR spoke is never "adopted post-facto" — it is born
+  through the standard provisioning path with its data rehydrated on top.
+
+- **Blue/green cluster migrations** — stand up a new spoke alongside the live
+  one, restore data from the latest backup into the new spoke, flip traffic
+  when workloads report ready, decommission the old spoke. Same mechanism as
+  DR, planned instead of reactive.
+
+- **Environment cloning** — clone a stateful environment (prod snapshot into a
+  staging/dev spoke) for testing, without a bespoke export/import pipeline.
+  AWS Backup restore jobs target the destination spoke in `existingCluster`
+  mode; Argo CD already deployed the empty workload shells.
+
+In all three cases, the `BackupPlan` and `BackupSelection` produced by this
+RGD are what makes a snapshot available at the moment it is needed. Retention
+and copy policy are chosen per-tier to match the recovery objective of each
+workload class, not a one-size-fits-all vault.
 
 ## Tiers
 
@@ -16,12 +47,15 @@ and expands it into an ACK-managed AWS Backup stack:
 | bronze | `cron(0 3 * * ? *)`    | 24 h | 7 d       | no           | no                |
 
 Gold and silver require `copyDestinationRegion` and `copyDestinationVaultARN`
-(a BackupVault pre-created in the DR region). Bronze stays same-region.
+(a BackupVault pre-created in the DR region). Bronze stays same-region — it
+covers workloads whose recovery policy is "redeploy fresh if the region is
+lost", not full geo-DR.
 
 ## Usage
 
 The expected pattern is **one `BackupPolicy` instance per tier per spoke**
-(3 instances max per spoke, typically declared by the `SpokeCluster` RGD).
+(3 instances max per spoke, typically declared by the `SpokeCluster` RGD so
+the platform team doesn't hand-roll them).
 
 ```yaml
 apiVersion: kro.run/v1alpha1
@@ -47,12 +81,32 @@ A workload opts into backup by putting the right tags on its resources:
 The recommended way on EKS is to label the namespace or the PVC; the EBS CSI
 driver propagates those tags onto the underlying EBS volumes, and the
 `BackupSelection.conditions.stringEquals` block matches them. No central
-ConfigMap or platform-team ticket needed.
+ConfigMap or platform-team ticket needed — opt-in is visible in the app's Git
+manifests and auditable with a single `kubectl get ns -l peeks.io/backup-tier=<tier>`.
 
 Included resource ARNs (for the selection):
 
 - `arn:aws:ec2:*:*:volume/*` — EBS volumes
 - `arn:aws:eks:*:*:cluster/*` — EKS add-on backup
+
+## What this RGD does NOT cover
+
+Documented explicitly because the boundary matters for DR correctness:
+
+- **Secrets** — handled by External Secrets Operator (source of truth: AWS
+  Secrets Manager, replicated cross-region). Never restored from a K8s-level
+  snapshot.
+- **Anything derivable from Git** — Deployments, Services, ConfigMaps,
+  Ingresses, PVC templates. Argo CD re-syncs them on the recovery spoke.
+- **Heavy stateful workloads (Postgres, Kafka)** — AWS Backup gives a
+  crash-consistent filesystem snapshot, not a logically consistent database
+  backup. Those workloads need an application-level backup on top
+  (`pg_basebackup` + WAL archiving to S3, Kafka tiered storage, etc.) — see
+  task 2.2 in the DR plan.
+- **PVC restore targeting** — the actual mechanism that attaches restored
+  volumes to the new pods in an `existingCluster` restore is handled by a
+  separate RGD (`RestoreSelection`, task 2.1), not here. This RGD only
+  produces the backups; restoring them is a different concern.
 
 ## Validation
 
@@ -66,17 +120,18 @@ kubectl --context hub apply --dry-run=server -f rgd-backup-policy.yaml
 # apply & check
 kubectl --context hub apply -f rgd-backup-policy.yaml
 kubectl --context hub get rgd backuppolicy.kro.run
+
+# end-to-end: instance expands into BackupVault + BackupPlan + BackupSelection
+kubectl --context hub apply -f examples/instance-bronze.yaml
+kubectl --context hub get backupvault,backupplan,backupselection -A
 ```
 
 ## Known limits (v1)
 
 - No KMS key rotation / custom encryption — uses the default vault key.
 - Heavy PVCs (e.g. Postgres on large EBS) need an app-level snapshot workflow
-  in addition to AWS Backup; covered in task 2.2.
+  in addition to AWS Backup.
 - `copyDestinationVaultARN` must be pre-provisioned in the DR region. A future
   iteration could nest that vault in the same RGD.
-
-## Related
-
-- ADR — PeEKS DR Pattern B (GitOps control plane + AWS Backup data plane):
-  https://github.com/allamand/peeks-veille/blob/main/blogs/analyses/adr-peeks-dr-pattern-b.md
+- Restore side (how the PVs land in a target cluster) is the responsibility of
+  a separate `RestoreSelection` RGD — not in this directory.

--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
@@ -1,3 +1,22 @@
+> ## ⚠️ DEPRECATED — do not use this branch
+>
+> This branch (`feat/peeks-backup-policy-rgd`) was forked from `main` and
+> is **99 commits behind** `feature/platform-cluster-kro-ack`. The
+> BackupPolicy RGD work has been re-homed onto the upstream
+> [PR #642 family](https://github.com/aws-samples/appmod-blueprints/pull/642)
+> on a dedicated branch:
+>
+> **→ Use `feat/peeks-backup-policy-rgd-on-pr642` instead.**
+>
+> Key differences on the active branch:
+> - StorageClass moved into `gitops/addons/charts/platform-manifests-bootstrap/templates/peeks-storageclass.yaml` (consolidated with the platform bootstrap chart) instead of a standalone `storageclass-resources/` chart.
+> - DR-aware tier StorageClasses (`peeks-gold-gp3` / `peeks-silver-gp3` / `peeks-bronze-gp3`) emit the `peeks.io/backup-tier` tag matched by the BackupSelection.
+> - Targets `feature/platform-cluster-kro-ack` (PR #642), not `main`.
+>
+> Kept here only for historical reference. No new commits will land here.
+>
+> ---
+
 # BackupPolicy RGD
 
 Kro `ResourceGraphDefinition` that exposes a single `BackupPolicy` custom resource

--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
@@ -104,9 +104,9 @@ Documented explicitly because the boundary matters for DR correctness:
   (`pg_basebackup` + WAL archiving to S3, Kafka tiered storage, etc.) — see
   task 2.2 in the DR plan.
 - **PVC restore targeting** — the actual mechanism that attaches restored
-  volumes to the new pods in an `existingCluster` restore is handled by a
-  separate RGD (`RestoreSelection`, task 2.1), not here. This RGD only
-  produces the backups; restoring them is a different concern.
+  volumes to the new pods in an `existingCluster` restore is handled by the
+  companion `RestoreSelection` RGD (same DR kit, separate concern). This RGD
+  only produces the backups; restoring them lives next to this directory.
 
 ## Validation
 
@@ -134,4 +134,5 @@ kubectl --context hub get backupvault,backupplan,backupselection -A
 - `copyDestinationVaultARN` must be pre-provisioned in the DR region. A future
   iteration could nest that vault in the same RGD.
 - Restore side (how the PVs land in a target cluster) is the responsibility of
-  a separate `RestoreSelection` RGD — not in this directory.
+  the companion `RestoreSelection` RGD — shipped alongside this one as part of
+  the same DR kit.

--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/README.md
@@ -1,0 +1,82 @@
+# BackupPolicy RGD (peeks DR Pattern B)
+
+Kro `ResourceGraphDefinition` that exposes a single `BackupPolicy` custom resource
+and expands it into an ACK-managed AWS Backup stack:
+
+- `BackupVault` (created in the policy's region)
+- `BackupPlan` with tier-specific lifecycle & schedule
+- `BackupSelection` that matches resources by AWS tag
+
+## Tiers
+
+| Tier   | Schedule               | RPO  | Retention | Cold storage | Cross-region copy |
+| ------ | ---------------------- | ---- | --------- | ------------ | ----------------- |
+| gold   | `cron(0 */1 * * ? *)`  | 1 h  | 30 d      | after 90 d   | yes               |
+| silver | `cron(0 2 * * ? *)`    | 24 h | 14 d      | no           | yes               |
+| bronze | `cron(0 3 * * ? *)`    | 24 h | 7 d       | no           | no                |
+
+Gold and silver require `copyDestinationRegion` and `copyDestinationVaultARN`
+(a BackupVault pre-created in the DR region). Bronze stays same-region.
+
+## Usage
+
+The expected pattern is **one `BackupPolicy` instance per tier per spoke**
+(3 instances max per spoke, typically declared by the `SpokeCluster` RGD).
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: spoke-prod-euw1-bronze
+spec:
+  tier: bronze
+  spokeName: spoke-prod-euw1
+  region: eu-west-1
+  iamRoleARN: arn:aws:iam::<acct>:role/AWSBackupDefaultServiceRole
+```
+
+See `examples/instance-{gold,silver,bronze}.yaml`.
+
+## Developer contract
+
+A workload opts into backup by putting the right tags on its resources:
+
+- `peeks.io/backup-tier=<tier>` (gold | silver | bronze)
+- `peeks.io/spoke=<spokeName>`
+
+The recommended way on EKS is to label the namespace or the PVC; the EBS CSI
+driver propagates those tags onto the underlying EBS volumes, and the
+`BackupSelection.conditions.stringEquals` block matches them. No central
+ConfigMap or platform-team ticket needed.
+
+Included resource ARNs (for the selection):
+
+- `arn:aws:ec2:*:*:volume/*` — EBS volumes
+- `arn:aws:eks:*:*:cluster/*` — EKS add-on backup
+
+## Validation
+
+```sh
+# syntax
+yq eval '.' rgd-backup-policy.yaml
+
+# kro server-side validation
+kubectl --context hub apply --dry-run=server -f rgd-backup-policy.yaml
+
+# apply & check
+kubectl --context hub apply -f rgd-backup-policy.yaml
+kubectl --context hub get rgd backuppolicy.kro.run
+```
+
+## Known limits (v1)
+
+- No KMS key rotation / custom encryption — uses the default vault key.
+- Heavy PVCs (e.g. Postgres on large EBS) need an app-level snapshot workflow
+  in addition to AWS Backup; covered in task 2.2.
+- `copyDestinationVaultARN` must be pre-provisioned in the DR region. A future
+  iteration could nest that vault in the same RGD.
+
+## Related
+
+- ADR — PeEKS DR Pattern B (GitOps control plane + AWS Backup data plane):
+  https://github.com/allamand/peeks-veille/blob/main/blogs/analyses/adr-peeks-dr-pattern-b.md

--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/examples/instance-bronze.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/examples/instance-bronze.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kro.run/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: spoke-prod-euw1-bronze
+  namespace: default
+spec:
+  tier: bronze
+  spokeName: spoke-prod-euw1
+  region: eu-west-1
+  # bronze = same-region only, no copyDestinationRegion / copyDestinationVaultARN
+  iamRoleARN: arn:aws:iam::000000000000:role/AWSBackupDefaultServiceRole

--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/examples/instance-gold.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/examples/instance-gold.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kro.run/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: spoke-prod-euw1-gold
+  namespace: default
+spec:
+  tier: gold
+  spokeName: spoke-prod-euw1
+  region: eu-west-1
+  copyDestinationRegion: eu-west-3
+  # Pre-created destination vault ARN in eu-west-3 for cross-region copy
+  copyDestinationVaultARN: arn:aws:backup:eu-west-3:000000000000:backup-vault:peeks-spoke-prod-euw1-gold-dr
+  # Pre-created AWS Backup service role
+  iamRoleARN: arn:aws:iam::000000000000:role/AWSBackupDefaultServiceRole

--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/examples/instance-silver.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/examples/instance-silver.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kro.run/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: spoke-prod-euw1-silver
+  namespace: default
+spec:
+  tier: silver
+  spokeName: spoke-prod-euw1
+  region: eu-west-1
+  copyDestinationRegion: eu-west-3
+  copyDestinationVaultARN: arn:aws:backup:eu-west-3:000000000000:backup-vault:peeks-spoke-prod-euw1-silver-dr
+  iamRoleARN: arn:aws:iam::000000000000:role/AWSBackupDefaultServiceRole

--- a/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/rgd-backup-policy.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/backup-policy/rgd-backup-policy.yaml
@@ -1,0 +1,236 @@
+# yamllint disable rule:line-length
+---
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: backuppolicy.kro.run
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: BackupPolicy
+    spec:
+      # Tier of the backup policy: gold | silver | bronze
+      tier: string | required=true enum="gold,silver,bronze"
+      # Name of the spoke cluster this policy targets (used for naming & tag matching)
+      spokeName: string | required=true
+      # AWS region where the BackupVault / BackupPlan are created
+      region: string | required=true
+      # Name of the BackupVault (defaults to peeks-<spoke>-<tier>)
+      backupVaultName: string | default=""
+      # Destination region for cross-region copy (required for gold & silver)
+      copyDestinationRegion: string | default=""
+      # ARN of the destination BackupVault (required for gold & silver cross-region copy)
+      copyDestinationVaultARN: string | default=""
+      # ARN of the IAM role used by AWS Backup for BackupSelection
+      iamRoleARN: string | required=true
+    status:
+      vaultStatus: ${backupvault.status.conditions}
+  resources:
+    # -----------------------------------------------------------------------
+    # BackupVault - created for every tier
+    # -----------------------------------------------------------------------
+    - id: backupvault
+      readyWhen:
+        - ${backupvault.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}
+      template:
+        apiVersion: backup.services.k8s.aws/v1alpha1
+        kind: BackupVault
+        metadata:
+          name: '${schema.spec.backupVaultName != "" ? schema.spec.backupVaultName : "peeks-" + schema.spec.spokeName + "-" + schema.spec.tier}'
+        spec:
+          name: '${schema.spec.backupVaultName != "" ? schema.spec.backupVaultName : "peeks-" + schema.spec.spokeName + "-" + schema.spec.tier}'
+          tags:
+            peeks-dr-test: "true"
+            peeks.io/spoke: ${schema.spec.spokeName}
+            peeks.io/tier: ${schema.spec.tier}
+
+    # -----------------------------------------------------------------------
+    # BackupPlan - GOLD tier: RPO 1h, retention 30d, cold 90d, cross-region copy
+    # -----------------------------------------------------------------------
+    - id: backupplangold
+      includeWhen:
+        - ${schema.spec.tier == "gold"}
+      readyWhen:
+        - ${backupplangold.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}
+      template:
+        apiVersion: backup.services.k8s.aws/v1alpha1
+        kind: BackupPlan
+        metadata:
+          name: peeks-${schema.spec.spokeName}-gold
+        spec:
+          name: peeks-${schema.spec.spokeName}-gold
+          tags:
+            peeks-dr-test: "true"
+            peeks.io/spoke: ${schema.spec.spokeName}
+            peeks.io/tier: gold
+          rules:
+            - ruleName: gold-hourly
+              targetBackupVaultName: ${backupvault.spec.name}
+              scheduleExpression: cron(0 */1 * * ? *)
+              startWindowMinutes: 60
+              completionWindowMinutes: 180
+              lifecycle:
+                deleteAfterDays: 30
+                moveToColdStorageAfterDays: 90
+              copyActions:
+                - destinationBackupVaultARN: ${schema.spec.copyDestinationVaultARN}
+                  lifecycle:
+                    deleteAfterDays: 30
+                    moveToColdStorageAfterDays: 90
+              recoveryPointTags:
+                peeks-dr-test: "true"
+                peeks.io/spoke: ${schema.spec.spokeName}
+                peeks.io/tier: gold
+
+    # -----------------------------------------------------------------------
+    # BackupPlan - SILVER tier: RPO 24h, retention 14d, cross-region copy
+    # -----------------------------------------------------------------------
+    - id: backupplansilver
+      includeWhen:
+        - ${schema.spec.tier == "silver"}
+      readyWhen:
+        - ${backupplansilver.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}
+      template:
+        apiVersion: backup.services.k8s.aws/v1alpha1
+        kind: BackupPlan
+        metadata:
+          name: peeks-${schema.spec.spokeName}-silver
+        spec:
+          name: peeks-${schema.spec.spokeName}-silver
+          tags:
+            peeks-dr-test: "true"
+            peeks.io/spoke: ${schema.spec.spokeName}
+            peeks.io/tier: silver
+          rules:
+            - ruleName: silver-daily
+              targetBackupVaultName: ${backupvault.spec.name}
+              scheduleExpression: cron(0 2 * * ? *)
+              startWindowMinutes: 60
+              completionWindowMinutes: 360
+              lifecycle:
+                deleteAfterDays: 14
+              copyActions:
+                - destinationBackupVaultARN: ${schema.spec.copyDestinationVaultARN}
+                  lifecycle:
+                    deleteAfterDays: 14
+              recoveryPointTags:
+                peeks-dr-test: "true"
+                peeks.io/spoke: ${schema.spec.spokeName}
+                peeks.io/tier: silver
+
+    # -----------------------------------------------------------------------
+    # BackupPlan - BRONZE tier: RPO 24h, retention 7d, same-region only
+    # -----------------------------------------------------------------------
+    - id: backupplanbronze
+      includeWhen:
+        - ${schema.spec.tier == "bronze"}
+      readyWhen:
+        - ${backupplanbronze.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}
+      template:
+        apiVersion: backup.services.k8s.aws/v1alpha1
+        kind: BackupPlan
+        metadata:
+          name: peeks-${schema.spec.spokeName}-bronze
+        spec:
+          name: peeks-${schema.spec.spokeName}-bronze
+          tags:
+            peeks-dr-test: "true"
+            peeks.io/spoke: ${schema.spec.spokeName}
+            peeks.io/tier: bronze
+          rules:
+            - ruleName: bronze-daily
+              targetBackupVaultName: ${backupvault.spec.name}
+              scheduleExpression: cron(0 3 * * ? *)
+              startWindowMinutes: 60
+              completionWindowMinutes: 360
+              lifecycle:
+                deleteAfterDays: 7
+              recoveryPointTags:
+                peeks-dr-test: "true"
+                peeks.io/spoke: ${schema.spec.spokeName}
+                peeks.io/tier: bronze
+
+    # -----------------------------------------------------------------------
+    # BackupSelection - one per tier (variant activated via includeWhen)
+    # Matches resources tagged with peeks.io/backup-tier + peeks.io/spoke.
+    # -----------------------------------------------------------------------
+    - id: backupselectiongold
+      includeWhen:
+        - ${schema.spec.tier == "gold"}
+      readyWhen:
+        - ${backupselectiongold.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}
+      template:
+        apiVersion: backup.services.k8s.aws/v1alpha1
+        kind: BackupSelection
+        metadata:
+          name: peeks-${schema.spec.spokeName}-gold-sel
+        spec:
+          name: peeks-${schema.spec.spokeName}-gold-sel
+          backupPlanRef:
+            from:
+              name: peeks-${schema.spec.spokeName}-gold
+          iamRoleARN: ${schema.spec.iamRoleARN}
+          resources:
+            - "arn:aws:ec2:*:*:volume/*"
+            - "arn:aws:eks:*:*:cluster/*"
+          conditions:
+            stringEquals:
+              - conditionKey: "aws:ResourceTag/peeks.io/backup-tier"
+                conditionValue: gold
+              - conditionKey: "aws:ResourceTag/peeks.io/spoke"
+                conditionValue: ${schema.spec.spokeName}
+
+    - id: backupselectionsilver
+      includeWhen:
+        - ${schema.spec.tier == "silver"}
+      readyWhen:
+        - ${backupselectionsilver.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}
+      template:
+        apiVersion: backup.services.k8s.aws/v1alpha1
+        kind: BackupSelection
+        metadata:
+          name: peeks-${schema.spec.spokeName}-silver-sel
+        spec:
+          name: peeks-${schema.spec.spokeName}-silver-sel
+          backupPlanRef:
+            from:
+              name: peeks-${schema.spec.spokeName}-silver
+          iamRoleARN: ${schema.spec.iamRoleARN}
+          resources:
+            - "arn:aws:ec2:*:*:volume/*"
+            - "arn:aws:eks:*:*:cluster/*"
+          conditions:
+            stringEquals:
+              - conditionKey: "aws:ResourceTag/peeks.io/backup-tier"
+                conditionValue: silver
+              - conditionKey: "aws:ResourceTag/peeks.io/spoke"
+                conditionValue: ${schema.spec.spokeName}
+
+    - id: backupselectionbronze
+      includeWhen:
+        - ${schema.spec.tier == "bronze"}
+      readyWhen:
+        - ${backupselectionbronze.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}
+      template:
+        apiVersion: backup.services.k8s.aws/v1alpha1
+        kind: BackupSelection
+        metadata:
+          name: peeks-${schema.spec.spokeName}-bronze-sel
+        spec:
+          name: peeks-${schema.spec.spokeName}-bronze-sel
+          backupPlanRef:
+            from:
+              name: peeks-${schema.spec.spokeName}-bronze
+          iamRoleARN: ${schema.spec.iamRoleARN}
+          resources:
+            - "arn:aws:ec2:*:*:volume/*"
+            - "arn:aws:eks:*:*:cluster/*"
+          conditions:
+            stringEquals:
+              - conditionKey: "aws:ResourceTag/peeks.io/backup-tier"
+                conditionValue: bronze
+              - conditionKey: "aws:ResourceTag/peeks.io/spoke"
+                conditionValue: ${schema.spec.spokeName}

--- a/gitops/addons/charts/storageclass-resources/README.md
+++ b/gitops/addons/charts/storageclass-resources/README.md
@@ -1,0 +1,85 @@
+# storageclass-resources
+
+Helm chart that provisions cluster `StorageClass` resources, both EFS and EBS.
+
+## What's new — Peeks DR-aware EBS StorageClasses
+
+Three EBS StorageClasses ship by default, one per backup tier:
+
+| StorageClass | Tier | RPO | Retention | Cross-region copy |
+|---|---|---|---|---|
+| `peeks-gold-gp3` | gold | 1 h | 30 d | yes |
+| `peeks-silver-gp3` | silver | 24 h | 14 d | yes |
+| `peeks-bronze-gp3` | bronze | 24 h | 7 d | no |
+
+Every EBS volume provisioned by one of these SCs inherits, as an AWS resource
+tag:
+
+- `peeks.io/backup-tier=<tier>`
+- `peeks.io/spoke=<spokeName>` (from the `spokeName` Helm value)
+- `peeks.io/managed-by=peeks-platform`
+
+These tags are what the `BackupSelection` resource produced by the companion
+`BackupPolicy` RGD matches on — so a workload opts into a backup tier simply
+by picking the right StorageClass in its PVC manifest. No central ConfigMap,
+no platform ticket.
+
+### Developer contract
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pgdata
+spec:
+  storageClassName: peeks-gold-gp3   # <-- declares the backup tier
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+```
+
+That's it. The EBS CSI driver stamps the volume with the three tags at
+provisioning time, the tier-level `BackupSelection` includes the volume in
+its next snapshot cycle, and everything downstream (cross-region copy,
+restore targeting) follows from there.
+
+### Why not "just label the namespace"?
+
+The EBS CSI driver's `tagSpecification_<N>` parameter only expands the
+tokens `${pvc.name}`, `${pvc.namespace}`, and `${pv.name}` — it does **not**
+propagate arbitrary namespace or PVC labels onto the underlying AWS tags.
+A mutating admission webhook could watch namespaces and inject the right
+StorageClass or rewrite tags on the fly, but that's an extra piece of
+infrastructure to operate.
+
+The per-SC strategy is the explicit contract in v1: it's visible in every
+PVC manifest, requires no custom controllers, and reviewable in a pull
+request.
+
+### Custom tags per StorageClass
+
+Any EBS SC can carry arbitrary tags via the `tags:` map:
+
+```yaml
+storageClasses:
+  ebs:
+    my-custom-sc:
+      volumeType: gp3
+      reclaimPolicy: Retain
+      tags:
+        cost-center: "1234"
+        env: prod
+```
+
+These are rendered as `tagSpecification_<N>` on the SC's `parameters`.
+The `peeks.io/spoke` tag from `spokeName` is merged in automatically.
+
+## Usage
+
+```sh
+helm template . --set spokeName=spoke-prod-euw1 | kubectl apply -f -
+```
+
+Or, in a gitops context, set `spokeName` via the Argo CD ApplicationSet
+parameter so each spoke gets its own tag value.

--- a/gitops/addons/charts/storageclass-resources/templates/storageclass.yaml
+++ b/gitops/addons/charts/storageclass-resources/templates/storageclass.yaml
@@ -29,6 +29,24 @@ parameters:
   fsType: ext4
   iopsPerGiB: "{{ $storageClass.iops | default "3000" }}"
   throughput: "{{ $storageClass.throughput | default "125" }}"
+{{- /*
+     Tag propagation: any tag declared under a StorageClass's `tags:` map is
+     rendered as a `tagSpecification_<N>` parameter. The EBS CSI driver
+     translates these into AWS tags applied to every volume provisioned by
+     this StorageClass. Combined with `peeks.io/backup-tier` and
+     `peeks.io/spoke` tags, this lets an AWS Backup `BackupSelection`
+     match volumes by tag without any central ConfigMap.
+*/}}
+{{- $defaultTags := dict }}
+{{- if $.Values.spokeName }}
+  {{- $_ := set $defaultTags "peeks.io/spoke" $.Values.spokeName }}
+{{- end }}
+{{- $scTags := merge (dict) ($storageClass.tags | default dict) $defaultTags }}
+{{- $idx := 1 }}
+{{- range $tagKey, $tagValue := $scTags }}
+  tagSpecification_{{ $idx }}: "{{ $tagKey }}={{ $tagValue }}"
+  {{- $idx = add $idx 1 }}
+{{- end }}
 {{- end }}
 reclaimPolicy: {{ $storageClass.reclaimPolicy | default "Delete" }}
 allowVolumeExpansion: true

--- a/gitops/addons/charts/storageclass-resources/values.yaml
+++ b/gitops/addons/charts/storageclass-resources/values.yaml
@@ -1,7 +1,6 @@
-# Set `spokeName` at install time (e.g. via ApplicationSet parameter) so that
-# every EBS StorageClass below bakes `peeks.io/spoke=<spokeName>` as a tag on
-# every volume it provisions. This is what AWS Backup `BackupSelection` matches
-# on (see kro-rgds/manifests/backup-policy).
+# Optional `spokeName` is rendered as a `peeks.io/spoke=<spokeName>` AWS tag
+# on every volume provisioned by the EBS StorageClasses below. Useful for
+# cost attribution and inventory.
 #
 # spokeName: spoke-prod-euw1
 
@@ -24,38 +23,15 @@ storageClasses:
       iops: 3000
       throughput: 125
 
-    # Peeks DR-aware StorageClasses — one per backup tier.
-    # Workloads declare their recovery requirement by choosing the right SC
-    # in their PVC manifest. Every volume provisioned by these SCs inherits
-    # the `peeks.io/backup-tier=<tier>` AWS tag, which AWS Backup's
-    # `BackupSelection` matches on — no central ConfigMap, no platform ticket.
-    #
-    # Native EBS CSI label-propagation from namespace → volume tag is NOT
-    # supported (the driver's `tagSpecification_<N>` only expands
-    # ${pvc.name}/${pvc.namespace}/${pv.name}, not arbitrary labels). A per-SC
-    # strategy is therefore the explicit contract; a mutating webhook could
-    # achieve automatic propagation but is out of scope for v1.
-    peeks-gold-gp3:
+    # PeEKS default StorageClass — single SC, performance-tuned only.
+    # Backup protection is decided at the cluster/namespace level by the
+    # AWS Backup for EKS resource selection (cluster ARN + namespace filter),
+    # not at the StorageClass level. Tier semantics (gold/silver/bronze) live
+    # on the BackupPolicy, not on the SC.
+    peeks-gp3:
       reclaimPolicy: Retain
       volumeType: gp3
       iops: 3000
       throughput: 125
       tags:
-        peeks.io/backup-tier: gold
-        peeks.io/managed-by: peeks-platform
-    peeks-silver-gp3:
-      reclaimPolicy: Retain
-      volumeType: gp3
-      iops: 3000
-      throughput: 125
-      tags:
-        peeks.io/backup-tier: silver
-        peeks.io/managed-by: peeks-platform
-    peeks-bronze-gp3:
-      reclaimPolicy: Delete
-      volumeType: gp3
-      iops: 3000
-      throughput: 125
-      tags:
-        peeks.io/backup-tier: bronze
         peeks.io/managed-by: peeks-platform

--- a/gitops/addons/charts/storageclass-resources/values.yaml
+++ b/gitops/addons/charts/storageclass-resources/values.yaml
@@ -1,17 +1,61 @@
+# Set `spokeName` at install time (e.g. via ApplicationSet parameter) so that
+# every EBS StorageClass below bakes `peeks.io/spoke=<spokeName>` as a tag on
+# every volume it provisions. This is what AWS Backup `BackupSelection` matches
+# on (see kro-rgds/manifests/backup-policy).
+#
+# spokeName: spoke-prod-euw1
+
 storageClasses:
   # efs:
-    # fileSystemId: fs-12345678 
+    # fileSystemId: fs-12345678
     # efs-sc:
-    #   reclaimPolicy: Delete  
-    #   directoryPerms: "700"  
-    #   basePath: /data  
+    #   reclaimPolicy: Delete
+    #   directoryPerms: "700"
+    #   basePath: /data
     #   mountOptions:
     #     - nfsvers=4.1
 
   ebs:
+    # Legacy default — unchanged, kept for backwards compatibility.
     ebs-sc-gp3:
       reclaimPolicy: Retain
-      volumeType: gp3 
+      volumeType: gp3
       size: 20Gi
       iops: 3000
       throughput: 125
+
+    # Peeks DR-aware StorageClasses — one per backup tier.
+    # Workloads declare their recovery requirement by choosing the right SC
+    # in their PVC manifest. Every volume provisioned by these SCs inherits
+    # the `peeks.io/backup-tier=<tier>` AWS tag, which AWS Backup's
+    # `BackupSelection` matches on — no central ConfigMap, no platform ticket.
+    #
+    # Native EBS CSI label-propagation from namespace → volume tag is NOT
+    # supported (the driver's `tagSpecification_<N>` only expands
+    # ${pvc.name}/${pvc.namespace}/${pv.name}, not arbitrary labels). A per-SC
+    # strategy is therefore the explicit contract; a mutating webhook could
+    # achieve automatic propagation but is out of scope for v1.
+    peeks-gold-gp3:
+      reclaimPolicy: Retain
+      volumeType: gp3
+      iops: 3000
+      throughput: 125
+      tags:
+        peeks.io/backup-tier: gold
+        peeks.io/managed-by: peeks-platform
+    peeks-silver-gp3:
+      reclaimPolicy: Retain
+      volumeType: gp3
+      iops: 3000
+      throughput: 125
+      tags:
+        peeks.io/backup-tier: silver
+        peeks.io/managed-by: peeks-platform
+    peeks-bronze-gp3:
+      reclaimPolicy: Delete
+      volumeType: gp3
+      iops: 3000
+      throughput: 125
+      tags:
+        peeks.io/backup-tier: bronze
+        peeks.io/managed-by: peeks-platform


### PR DESCRIPTION
## Summary

Introduces a kro `ResourceGraphDefinition` (`BackupPolicy`) that expands into an ACK-managed AWS Backup stack (BackupVault + BackupPlan + BackupSelection), parameterized by backup tier.

Enables AWS Backup as the **data-plane source of truth** alongside GitOps for control plane — used for **cross-region DR**, **blue/green cluster migrations**, and **environment cloning** (all three share the same BackupPlan/BackupSelection primitive).

## Tiers

| Tier | RPO | Retention | Cross-region copy | Cold storage |
|------|-----|-----------|-------------------|--------------|
| gold | 1h | 30d | ✅ | 90d |
| silver | 24h | 14d | ✅ | — |
| bronze | 24h | 7d | — | — |

## Design

- **Platform team** declares 3 BackupPolicy instances per spoke (one per tier) — typically via the `SpokeCluster` RGD in a follow-up
- **Developers opt in** via namespace/PVC label `peeks.io/backup-tier=<tier>` — BackupSelection matches via propagated EBS volume tags
- No central ConfigMap to maintain — opt-in is declarative in app manifests and auditable with `kubectl get ns -l peeks.io/backup-tier=<tier>`

## What this RGD does NOT cover (documented explicitly in README)

- Secrets → handled by External Secrets Operator
- Anything derivable from Git → Argo CD re-syncs
- Heavy stateful (Postgres, Kafka) → needs application-level backup on top
- PVC restore targeting into a recovery cluster → separate `RestoreSelection` RGD (future PR)

## Validation

- [x] `kubectl apply --dry-run=server` passes
- [x] RGD applied on hub cluster, status Active/Ready
- [x] `instance-bronze.yaml` expands into BackupVault + BackupPlan + BackupSelection
- [x] Delete cascades properly (all expanded resources removed)

## Files

- `rgd-backup-policy.yaml` — the ResourceGraphDefinition
- `examples/instance-{gold,silver,bronze}.yaml` — per-tier example instances
- `README.md` — use cases (DR, blue/green, cloning), tiers, developer contract, boundaries
