### PR TITLE
fix: argocd token refresh systemd timer not firing

### DIFF
--- a/platform/infra/terraform/scripts/0-init.sh
+++ b/platform/infra/terraform/scripts/0-init.sh
@@ -422,13 +422,14 @@ Description=Refresh ArgoCD auth token
 Type=oneshot
 User=ec2-user
 Environment=HOME=/home/ec2-user
-ExecStart=/bin/bash -lc "source ~/.bashrc.d/platform.sh && argocd-refresh-token"
+ExecStart=/bin/bash -lc "source ~/.bashrc.d/ssm-setup-ide-logs.sh && source ~/.bashrc.d/platform.sh && argocd-refresh-token"
 SVCEOF
     sudo tee /etc/systemd/system/argocd-refresh-token.timer >/dev/null <<TMREOF
 [Unit]
 Description=Refresh ArgoCD token every 4 hours
 
 [Timer]
+OnBootSec=5min
 OnUnitActiveSec=4h
 
 [Install]


### PR DESCRIPTION
## Problem

The ArgoCD token refresh systemd timer never fires because:

1. `ExecStart` sources `platform.sh` but `argocd-refresh-token` is defined in `ssm-setup-ide-logs.sh` → `command not found`
2. `OnUnitActiveSec=4h` requires a prior successful execution to start counting — since the service fails on first run, the timer never triggers again

The token expires overnight (~15h) leaving the ArgoCD CLI unusable.

## Fix

- Source `ssm-setup-ide-logs.sh` in `ExecStart` before `platform.sh`
- Add `OnBootSec=5min` so the timer fires 5 minutes after boot regardless of prior execution