### PR TITLE
fix: use $HOME instead of ~ in systemd ExecStart

### DIFF
--- a/platform/infra/terraform/scripts/0-init.sh
+++ b/platform/infra/terraform/scripts/0-init.sh
@@ -422,7 +422,7 @@ Description=Refresh ArgoCD auth token
 Type=oneshot
 User=ec2-user
 Environment=HOME=/home/ec2-user
-ExecStart=/bin/bash -lc "source ~/.bashrc.d/ssm-setup-ide-logs.sh && source ~/.bashrc.d/platform.sh && argocd-refresh-token"
+ExecStart=/bin/bash -lc "source $HOME/.bashrc.d/ssm-setup-ide-logs.sh && source $HOME/.bashrc.d/platform.sh && argocd-refresh-token"
 SVCEOF
     sudo tee /etc/systemd/system/argocd-refresh-token.timer >/dev/null <<TMREOF
 [Unit]


### PR DESCRIPTION
Follow-up to #634. Tilde expansion is not guaranteed in systemd ExecStart — use $HOME which is explicitly set in the unit file.