### PR TITLE
Fix IAM policy dependency to prevent capability unhealthy state during destroy

### DIFF
--- a/platform/infra/terraform/cluster/main.tf
+++ b/platform/infra/terraform/cluster/main.tf
@@ -89,6 +89,13 @@ resource "aws_eks_capability" "argocd" {
   role_arn                  = aws_iam_role.eks_capability_argocd[each.key].arn
   delete_propagation_policy = "RETAIN"
 
+  # Ensure policies remain attached during capability cleanup
+  depends_on = [
+    aws_iam_role_policy.eks_capability_argocd_codeconnections,
+    aws_iam_role_policy_attachment.eks_capability_argocd_secrets,
+    aws_iam_role_policy_attachment.eks_capability_argocd_codecommit
+  ]
+
   configuration {
     argo_cd {
       aws_idc {
@@ -130,7 +137,12 @@ resource "aws_eks_capability" "ack" {
   role_arn                  = aws_iam_role.eks_capability_ack[each.key].arn
   delete_propagation_policy = "RETAIN"
 
-  depends_on = [module.eks]
+  # Ensure policies remain attached during capability cleanup
+  depends_on = [
+    module.eks,
+    aws_iam_role_policy.eks_capability_ack_assume_workload_roles,
+    aws_iam_role_policy.eks_capability_ack_manage_irsa_roles
+  ]
   tags = local.tags
 }
 
@@ -144,7 +156,11 @@ resource "aws_eks_capability" "kro" {
   role_arn                  = aws_iam_role.eks_capability_kro[each.key].arn
   delete_propagation_policy = "RETAIN"
 
-  depends_on = [module.eks]
+  # Ensure policies remain attached during capability cleanup
+  depends_on = [
+    module.eks,
+    aws_iam_role_policy_attachment.eks_capability_kro_cluster_admin
+  ]
   tags = local.tags
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Before this change the dependency graph looked like

```
policy depends on role
capability depends on role
```

On delete we deleted capability and policy in parallel leading the capability to become unhealthy while it was deleted.

Add an explicit dependency to make the graph look like
```
policy depends on role
capability depends on policy
capability depends on role
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
