### PR TITLE
fix(destroy-addons): dynamic addon discovery and composition deletion ordering

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -694,96 +694,160 @@ tasks:
 
   hub:destroy-addons:
     desc: Remove all addons from the hub cluster (no git changes needed)
-    vars:
-      ADDONS:
-        sh: |
-          ENABLED_LABELS=$(for f in {{.GITOPS_ROOT}}/overlays/environments/*/enabled-addons.yaml; do
-            [ -f "$f" ] && yq -r '.enabledAddons | to_entries[] | select(.value == true) | "enable_" + .key' "$f"
-          done | sort -u)
-          REGISTRY=$(yq eval-all '. as $item ireduce ({}; . * $item)' \
-            {{.GITOPS_ROOT}}/addons/registry/core.yaml \
-            {{.GITOPS_ROOT}}/addons/registry/gitops.yaml \
-            {{.GITOPS_ROOT}}/addons/registry/security.yaml \
-            {{.GITOPS_ROOT}}/addons/registry/observability.yaml \
-            {{.GITOPS_ROOT}}/addons/registry/ml.yaml \
-            {{.GITOPS_ROOT}}/addons/registry/platform.yaml)
-          echo "$REGISTRY" | yq -r 'to_entries[] | .key + " " + .value.selector.matchExpressions[0].key + " " + (.value.annotationsAppSet."argocd.argoproj.io/sync-wave" // "0")' | while read addon selector wave; do
-            if echo "$ENABLED_LABELS" | grep -qx "$selector"; then
-              echo "$wave $addon"
-            fi
-          done | sort -rn | awk '{print $2}'
     cmds:
       - task: hub:kubeconfig
       - printf '{{.C_ERR}}▸ Stopping all regeneration...{{.C_RESET}}\n'
       # 1. Delete bootstrap ApplicationSet (preserveResources) to stop recreating bootstrap App
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset bootstrap -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":true}}}' 2>/dev/null || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset bootstrap -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":true}}}' 2>&1 || true
       - sleep 3
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset bootstrap -n argocd --timeout=30s 2>/dev/null || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset bootstrap -n argocd --timeout=30s 2>&1 || true
       # 2. Delete bootstrap Application (no cascade) to stop syncing bootstrap/ directory
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application bootstrap -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application bootstrap -n argocd --wait=false 2>/dev/null || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application bootstrap -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>&1 || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application bootstrap -n argocd --wait=false 2>&1 || true
       # 3. Delete cluster-addons ApplicationSet (preserveResources) to stop generating addon ApplicationSets
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset cluster-addons -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":true}}}' 2>/dev/null || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset cluster-addons -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":true}}}' 2>&1 || true
       - sleep 3
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset cluster-addons -n argocd --timeout=30s 2>/dev/null || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset cluster-addons -n argocd --timeout=30s 2>&1 || true
       # 4. Delete cluster-addons Application (no cascade)
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application cluster-addons -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application cluster-addons -n argocd --wait=false 2>/dev/null || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application cluster-addons -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>&1 || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application cluster-addons -n argocd --wait=false 2>&1 || true
+      # 4.5. Delete agent-platform chain (AppSet → apps → child AppSets become orphans for Phase 5)
+      - cmd: |
+          if KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applicationset agent-platform -n argocd >/dev/null 2>&1; then
+            echo "Stopping agent-platform AppSet..."
+            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset agent-platform -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":true}}}' 2>&1 || true
+            sleep 3
+            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset agent-platform -n argocd --timeout=30s 2>&1 || true
+          fi
+          APPS=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -E '^agent-platform-' || true)
+          for app in $APPS; do
+            echo "Stopping $app..."
+            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application "$app" -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>&1 || true
+            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application "$app" -n argocd --wait=false 2>&1 || true
+          done
       # 5. Delete non-Crossplane addon ApplicationSets in reverse sync-wave order
       - cmd: |
-          if [ "{{.ITEM}}" = "argocd" ] || [ "{{.ITEM}}" = "crossplane" ] || [ "{{.ITEM}}" = "crossplane-base" ] || [ "{{.ITEM}}" = "crossplane-aws" ]; then
-            echo "Skipping {{.ITEM}} (Crossplane stack — deleted after clusters)"
-          elif KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applicationset {{.ITEM}} -n argocd >/dev/null 2>&1; then
-            echo "Deleting {{.ITEM}}..."
-            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset {{.ITEM}} -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>/dev/null || true
-            sleep 3
-            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset {{.ITEM}} -n argocd --timeout=180s 2>/dev/null || true
-            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl wait --for=delete applications -n argocd -l addonName={{.ITEM}} --timeout=120s 2>/dev/null || true
-          else
-            echo "Skipping {{.ITEM}} (not found)"
-          fi
-        ignore_error: true
-        for:
-          var: ADDONS
-      # 6. Delete clusters (spoke + hub claims cleaned up before Crossplane providers are removed)
-      - printf '{{.C_ERR}}▸ Deleting clusters...{{.C_RESET}}\n'
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset clusters -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>/dev/null || true
-      - sleep 3
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset clusters -n argocd --timeout=60s 2>/dev/null || true
-      - cmd: |
-          KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl wait --for=delete applications -n argocd -l app.kubernetes.io/instance=clusters --timeout=600s 2>/dev/null || \
-          (KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application clusters -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null && \
-           KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application clusters -n argocd --wait=false 2>/dev/null) || true
-      # 7. Delete Crossplane stack in reverse wave order (providers still alive for cluster cleanup)
-      - cmd: |
-          for ADDON in crossplane-aws crossplane-base crossplane; do
-            if KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applicationset $ADDON -n argocd >/dev/null 2>&1; then
+          SKIP="argocd crossplane crossplane-base crossplane-aws pod-identities bootstrap cluster-addons agent-platform fleet-secrets hub-fleet-secret clusters abstractions"
+          ADDONS=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applicationsets -n argocd \
+            -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.metadata.annotations.argocd\.argoproj\.io/sync-wave}{"\n"}{end}' \
+          | while read name wave; do
+            [ -z "$name" ] && continue
+            wave="${wave:-0}"
+            skip=false
+            for s in $SKIP; do if [ "$name" = "$s" ]; then skip=true; break; fi; done
+            if [ "$skip" = "true" ]; then continue; fi
+            echo "$wave $name"
+          done | sort -rn | awk '{print $2}' || true)
+
+          for ADDON in $ADDONS; do
+            if KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applicationset "$ADDON" -n argocd >/dev/null 2>&1; then
               echo "Deleting $ADDON..."
-              KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset $ADDON -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>/dev/null || true
-              sleep 3
-              KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset $ADDON -n argocd --timeout=180s 2>/dev/null || true
-              KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl wait --for=delete applications -n argocd -l addonName=$ADDON --timeout=120s 2>/dev/null || true
+              KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset "$ADDON" -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>&1 || true
+              CHILDREN=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name==\"$ADDON\")]}{.metadata.name}{\"\\n\"}{end}" 2>/dev/null)
+              if [ -n "$CHILDREN" ]; then
+                ELAPSED=0
+                while [ $ELAPSED -lt 30 ]; do
+                  FINALIZERS=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                    -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name==\"$ADDON\")]}{.metadata.finalizers}{end}" 2>/dev/null)
+                  if echo "$FINALIZERS" | grep -q resources-finalizer; then break; fi
+                  sleep 2; ELAPSED=$((ELAPSED + 2))
+                done
+              fi
+              KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset "$ADDON" -n argocd --timeout=180s 2>&1 || true
+              if [ -n "$CHILDREN" ]; then
+                ELAPSED=0
+                while [ $ELAPSED -lt 120 ]; do
+                  REMAINING=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                    -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name==\"$ADDON\")]}{.metadata.name}{end}" 2>/dev/null)
+                  if [ -z "$REMAINING" ]; then break; fi
+                  sleep 5; ELAPSED=$((ELAPSED + 5))
+                done
+              fi
             fi
           done
-        ignore_error: true
+      # 6. Delete clusters (spoke + hub claims cleaned up before Crossplane providers are removed)
+      - printf '{{.C_ERR}}▸ Deleting clusters...{{.C_RESET}}\n'
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset clusters -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>&1 || true
+      - cmd: |
+          CHILDREN=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+            -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="clusters")]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+          if [ -n "$CHILDREN" ]; then
+            ELAPSED=0
+            while [ $ELAPSED -lt 30 ]; do
+              FINALIZERS=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="clusters")]}{.metadata.finalizers}{end}' 2>/dev/null)
+              if echo "$FINALIZERS" | grep -q resources-finalizer; then break; fi
+              sleep 2; ELAPSED=$((ELAPSED + 2))
+            done
+          fi
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset clusters -n argocd --timeout=60s 2>&1 || true
+      - cmd: |
+          ELAPSED=0
+          while [ $ELAPSED -lt 600 ]; do
+            REMAINING=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+              -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="clusters")]}{.metadata.name}{end}' 2>/dev/null)
+            if [ -z "$REMAINING" ]; then break; fi
+            sleep 10; ELAPSED=$((ELAPSED + 10))
+          done
+      # 7. Delete Crossplane stack in reverse wave order (providers still alive for cluster cleanup)
+      - cmd: |
+          for ADDON in abstractions pod-identities crossplane-aws crossplane-base crossplane; do
+            if KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applicationset $ADDON -n argocd >/dev/null 2>&1; then
+              echo "Deleting $ADDON..."
+              KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset $ADDON -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>&1 || true
+              CHILDREN=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name==\"$ADDON\")]}{.metadata.name}{\"\\n\"}{end}" 2>/dev/null)
+              if [ -n "$CHILDREN" ]; then
+                ELAPSED=0
+                while [ $ELAPSED -lt 30 ]; do
+                  FINALIZERS=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                    -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name==\"$ADDON\")]}{.metadata.finalizers}{end}" 2>/dev/null)
+                  if echo "$FINALIZERS" | grep -q resources-finalizer; then break; fi
+                  sleep 2; ELAPSED=$((ELAPSED + 2))
+                done
+              fi
+              KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset $ADDON -n argocd --timeout=180s 2>&1 || true
+              if [ -n "$CHILDREN" ]; then
+                ELAPSED=0
+                while [ $ELAPSED -lt 120 ]; do
+                  REMAINING=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                    -o jsonpath="{range .items[?(@.metadata.ownerReferences[0].name==\"$ADDON\")]}{.metadata.name}{end}" 2>/dev/null)
+                  if [ -z "$REMAINING" ]; then break; fi
+                  sleep 5; ELAPSED=$((ELAPSED + 5))
+                done
+              fi
+            fi
+          done
       # 8. Delete fleet-secrets
       - printf '{{.C_ERR}}▸ Deleting fleet-secrets...{{.C_RESET}}\n'
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset fleet-secrets -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>/dev/null || true
-      - sleep 3
-      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset fleet-secrets -n argocd --timeout=180s 2>/dev/null || true
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch applicationset fleet-secrets -n argocd --type merge -p '{"spec":{"syncPolicy":{"preserveResourcesOnDeletion":false}}}' 2>&1 || true
+      - cmd: |
+          CHILDREN=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+            -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="fleet-secrets")]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+          if [ -n "$CHILDREN" ]; then
+            ELAPSED=0
+            while [ $ELAPSED -lt 30 ]; do
+              FINALIZERS=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd \
+                -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="fleet-secrets")]}{.metadata.finalizers}{end}' 2>/dev/null)
+              if echo "$FINALIZERS" | grep -q resources-finalizer; then break; fi
+              sleep 2; ELAPSED=$((ELAPSED + 2))
+            done
+          fi
+      - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete applicationset fleet-secrets -n argocd --timeout=180s 2>&1 || true
       # 9. Cleanup remaining applications
       - cmd: |
-          for app in $(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+          APPS=$(KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+          for app in $APPS; do
             echo "Deleting leftover app $app..."
-            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application $app -n argocd --timeout=300s 2>/dev/null || \
+            KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application $app -n argocd --timeout=300s 2>&1 || \
             (echo "Force-deleting stuck app $app (stripping finalizers)..." && \
-             KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application $app -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null && \
-             KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application $app -n argocd --wait=false 2>/dev/null) || true
+             KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl patch application $app -n argocd --type merge -p '{"metadata":{"finalizers":[]}}' 2>&1 && \
+             KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl delete application $app -n argocd --wait=false 2>&1) || true
           done
-        ignore_error: true
       - printf '{{.C_ERR}}▸ Cleaning up AWS resources...{{.C_RESET}}\n'
-      - aws secretsmanager delete-secret --secret-id {{.HUB_CLUSTER_NAME}}/config --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>/dev/null || true
-      - aws secretsmanager delete-secret --secret-id {{.HUB_CLUSTER_NAME}}/keycloak --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>/dev/null || true
-      - aws secretsmanager delete-secret --secret-id {{.HUB_CLUSTER_NAME}}/keycloak-clients --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>/dev/null || true
+      - aws secretsmanager delete-secret --secret-id {{.HUB_CLUSTER_NAME}}/config --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>&1 || true
+      - aws secretsmanager delete-secret --secret-id {{.HUB_CLUSTER_NAME}}/keycloak --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>&1 || true
+      - aws secretsmanager delete-secret --secret-id {{.HUB_CLUSTER_NAME}}/keycloak-clients --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>&1 || true
       - rm -f {{.ROOT_DIR}}/private/hub-kubeconfig
       - printf '{{.C_OK}}✓ Hub addons destroyed.{{.C_RESET}}\n'

--- a/gitops/abstractions/resource-groups/platform-cluster/DELETION-ORDERING.md
+++ b/gitops/abstractions/resource-groups/platform-cluster/DELETION-ORDERING.md
@@ -1,0 +1,82 @@
+# PlatformCluster Deletion Ordering
+
+## Known Issue: EIP Stuck on Deletion (NAT Gateway Dependency)
+
+When a PlatformCluster composite is deleted, Crossplane fires delete on all composed resources **in parallel**. This causes a race condition between the NAT Gateway and its associated EIP:
+
+1. Crossplane deletes NATGateway and EIP simultaneously
+2. EIP deletion calls `DisassociateAddress` → fails because NAT Gateway still holds the association
+3. AWS returns `AuthFailure` (misleading — actually means "operation not valid while NAT Gateway exists")
+4. NAT Gateway MR may disappear from the cluster (upjet async delete removes finalizer after initiating delete) while the AWS resource is still being deleted
+5. EIP retries indefinitely until the NAT Gateway is fully gone in AWS
+
+### Root Cause
+
+Crossplane compositions do not support delete ordering. Unlike Terraform's dependency graph, all composed resources are deleted concurrently via Kubernetes garbage collection (`foregroundDeletion`). The upjet-based providers use async deletion — they remove the managed resource finalizer after **initiating** the cloud delete, not after **confirming** the resource is gone.
+
+### Impact
+
+- EIP gets stuck in `CannotDeleteExternalResource` state for 2-5 minutes (until NAT Gateway finishes deleting in AWS)
+- If the provider loses credentials during this window (e.g., PodIdentityAssociation deleted), the EIP becomes permanently stuck
+- In worst case, the NATGateway MR is removed from the cluster while the AWS NAT Gateway persists → orphaned cloud resource
+
+### Fix: Usage Resource for Deletion Ordering
+
+Add a `Usage` resource to the composition that declares "NATGateway uses EIP", blocking EIP deletion until the NAT Gateway is gone:
+
+```yaml
+- name: natgw-uses-eip
+  base:
+    apiVersion: protection.crossplane.io/v1beta1
+    kind: Usage
+    spec:
+      replayDeletion: true
+      of:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: EIP
+        resourceSelector:
+          matchControllerRef: true
+      by:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: NATGateway
+        resourceSelector:
+          matchControllerRef: true
+```
+
+With `replayDeletion: true`, once the NATGateway is deleted, the Usage is removed and Crossplane replays the EIP deletion — avoiding the garbage collector backoff delay.
+
+### Implemented Usage Resources
+
+All added to `templates/composition.yaml`:
+
+| Name | Protected (of) | Used By (by) | Reason |
+|---|---|---|---|
+| `natgw-uses-eip` | EIP | NATGateway | Cannot disassociate EIP while NAT GW exists |
+| `route-uses-igw` | InternetGateway | Route | Cannot detach IGW while routes reference it |
+| `route-uses-natgw` | NATGateway | Route | Cannot delete NAT GW while private route references it |
+| `rta-uses-rt` | RouteTable | RouteTableAssociation | Cannot delete RT with active associations |
+| `cluster-uses-subnets` | Subnet | EKS Cluster | Cluster ENIs hold subnet references |
+| `cluster-uses-vpc` | VPC | EKS Cluster | Cannot delete VPC with attached cluster |
+
+### Deletion Order (enforced by Usages)
+
+```
+RouteTableAssociations → RouteTables
+Routes → InternetGateway
+Routes → NATGateway → EIP
+EKS Cluster → Subnets → VPC
+EKS Cluster → VPC
+```
+
+### Workaround (Without Usage)
+
+If Usage resources are not available (requires Crossplane 1.14+), the EIP will eventually self-heal once the NAT Gateway finishes deleting in AWS (~2-5 minutes). Ensure the Crossplane EC2 provider retains its credentials (PodIdentityAssociation) throughout the entire deletion process.
+
+## References
+
+- [Crossplane Deletion Pitfalls](https://www.cecg.io/blog/crossplane-deletion-management) — Comprehensive guide on deletion policies and Usage resources
+- [Composition Dependency and Ordered Creation (Issue #2072)](https://github.com/crossplane/crossplane/issues/2072) — Original issue requesting dependency ordering
+- [Dependencies handling on composite deletion (Issue #2212)](https://github.com/crossplane/crossplane/issues/2212) — Multi-provider deletion ordering
+- [Introduce Usage type for ordered deletion (Issue #3393)](https://github.com/crossplane/crossplane/issues/3393) — Usage resource design
+- [Crossplane Usage Docs](https://docs.crossplane.io/latest/managed-resources/usages/) — Official Usage API reference
+- [Crossplane Deletion Policies](https://oneuptime.com/blog/post/2026-02-09-crossplane-deletion-policies/view) — Configuring deletion behavior

--- a/gitops/abstractions/resource-groups/platform-cluster/templates/composition.yaml
+++ b/gitops/abstractions/resource-groups/platform-cluster/templates/composition.yaml
@@ -288,6 +288,78 @@ spec:
               - type: PatchSet
                 patchSetName: tags
 
+          # Usage: block EIP deletion until NAT Gateway is gone
+          - name: natgw-uses-eip
+            base:
+              apiVersion: protection.crossplane.io/v1beta1
+              kind: Usage
+              spec:
+                replayDeletion: true
+                of:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: EIP
+                  resourceSelector:
+                    matchControllerRef: true
+                by:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: NATGateway
+                  resourceSelector:
+                    matchControllerRef: true
+
+          # Usage: block InternetGateway deletion until Routes are gone
+          - name: route-uses-igw
+            base:
+              apiVersion: protection.crossplane.io/v1beta1
+              kind: Usage
+              spec:
+                replayDeletion: true
+                of:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: InternetGateway
+                  resourceSelector:
+                    matchControllerRef: true
+                by:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: Route
+                  resourceSelector:
+                    matchControllerRef: true
+
+          # Usage: block NATGateway deletion until Routes are gone
+          - name: route-uses-natgw
+            base:
+              apiVersion: protection.crossplane.io/v1beta1
+              kind: Usage
+              spec:
+                replayDeletion: true
+                of:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: NATGateway
+                  resourceSelector:
+                    matchControllerRef: true
+                by:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: Route
+                  resourceSelector:
+                    matchControllerRef: true
+
+          # Usage: block RouteTables deletion until RouteTableAssociations are gone
+          - name: rta-uses-rt
+            base:
+              apiVersion: protection.crossplane.io/v1beta1
+              kind: Usage
+              spec:
+                replayDeletion: true
+                of:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: RouteTable
+                  resourceSelector:
+                    matchControllerRef: true
+                by:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: RouteTableAssociation
+                  resourceSelector:
+                    matchControllerRef: true
+
           # Public Route Table + Route
           - name: public-rt
             base:
@@ -770,6 +842,42 @@ spec:
                 toFieldPath: status.oidcIssuer
 
           # ===== EKS MANAGED ADD-ONS (required for managed node group nodes) =====
+
+          # Usage: block Subnet deletion until EKS Cluster is gone (ENIs hold subnets)
+          - name: cluster-uses-subnets
+            base:
+              apiVersion: protection.crossplane.io/v1beta1
+              kind: Usage
+              spec:
+                replayDeletion: true
+                of:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: Subnet
+                  resourceSelector:
+                    matchControllerRef: true
+                by:
+                  apiVersion: eks.aws.upbound.io/v1beta2
+                  kind: Cluster
+                  resourceSelector:
+                    matchControllerRef: true
+
+          # Usage: block VPC deletion until EKS Cluster is gone
+          - name: cluster-uses-vpc
+            base:
+              apiVersion: protection.crossplane.io/v1beta1
+              kind: Usage
+              spec:
+                replayDeletion: true
+                of:
+                  apiVersion: ec2.aws.upbound.io/v1beta1
+                  kind: VPC
+                  resourceSelector:
+                    matchControllerRef: true
+                by:
+                  apiVersion: eks.aws.upbound.io/v1beta2
+                  kind: Cluster
+                  resourceSelector:
+                    matchControllerRef: true
 
           - name: addon-vpc-cni
             base:

--- a/gitops/addons/registry/core.yaml
+++ b/gitops/addons/registry/core.yaml
@@ -264,6 +264,22 @@ external-dns:
       timeoutSeconds: 10
     serviceAccount:
       name: external-dns-sa
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: http
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 5
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 5
   additionalResources:
     - path: '{{.metadata.annotations.addonsRepoBasepath}}addons/charts/pod-identity-restart-hook'
       helm:

--- a/gitops/bootstrap/abstractions.yaml
+++ b/gitops/bootstrap/abstractions.yaml
@@ -22,6 +22,8 @@ spec:
               revision: '{{ .metadata.annotations.addonsRepoRevision }}'
               directories:
                 - path: '{{ .metadata.annotations.addonsRepoBasepath }}abstractions/resource-groups/*'
+                - path: '{{ .metadata.annotations.addonsRepoBasepath }}abstractions/resource-groups/aws-resources'
+                  exclude: true
   template:
     metadata:
       name: '{{ .path.basename }}-{{ .name }}'


### PR DESCRIPTION
## Summary

- Rewrites `hub:destroy-addons` to dynamically query ApplicationSets from the hub cluster instead of computing from local registry files, ensuring agent-platform addons (kagent, litellm, langfuse, jaeger, agentgateway, etc.) are properly cleaned up
- Adds Usage resources to PlatformCluster composition to enforce correct deletion ordering and prevent orphaned AWS resources (EIP/NAT Gateway race condition)

## Changes

### Taskfile (`hub:destroy-addons`)
- Replace static `vars.ADDONS` block with inline kubectl query + sync-wave sorting
- Add Phase 4.5: delete `agent-platform` AppSet (preserveResources) then orphan child apps before Phase 5
- Use ownerReference-based child app detection (handles unlabeled apps from remote repos)
- Skip finalizer/deletion wait loops when no child apps exist
- Remove all `ignore_error: true` — handle benign exits inline
- Change `2>/dev/null` to `2>&1` on action commands for error visibility
- Fix shell compatibility with Go Task `set: [errexit, pipefail]`

### Composition (Usage resources)
- `natgw-uses-eip` — block EIP deletion until NAT Gateway is gone
- `route-uses-igw` — block IGW deletion until Routes are gone
- `route-uses-natgw` — block NAT GW deletion until private Route is gone
- `rta-uses-rt` — block RouteTable deletion until associations are gone
- `cluster-uses-subnets` — block Subnet deletion until EKS Cluster is gone
- `cluster-uses-vpc` — block VPC deletion until EKS Cluster is gone

### Documentation
- `DELETION-ORDERING.md` documenting the root cause, Usage fix, and references

## Test plan

- [ ] Run `task hub:destroy-addons` — verify Phase 5 lists all addon AppSets dynamically
- [ ] Verify agent-platform AppSets (kagent, litellm, etc.) are deleted without regeneration
- [ ] Verify no 30s timeouts on addons without child apps (e.g. disabled addons)
- [ ] Verify errors (not-found, timeout) are visible in output
- [ ] Deploy composition with Usage resources and test spoke cluster deletion ordering