### PR TITLE
fix(spoke-lbc): publish vpcId from Composition to cluster Secret

### DIFF
--- a/gitops/abstractions/resource-groups/platform-cluster/templates/composition.yaml
+++ b/gitops/abstractions/resource-groups/platform-cluster/templates/composition.yaml
@@ -769,6 +769,42 @@ spec:
                 fromFieldPath: status.atProvider.identity[0].oidc[0].issuer
                 toFieldPath: status.oidcIssuer
 
+          # Publish status.vpcId onto the ArgoCD cluster Secret (argocd/<clusterName>).
+          # Composition is the source of truth for VPC id; this annotation is consumed
+          # by addon ApplicationSets (e.g. aws-load-balancer-controller --vpc-id).
+          # Uses provider-kubernetes Object with Observe+Update so the Secret must
+          # already exist (created by the fleet-secret Helm chart) — the Object only
+          # patches the single annotation via Server-Side Apply.
+          - name: cluster-secret-vpc-annotation
+            base:
+              apiVersion: kubernetes.crossplane.io/v1alpha2
+              kind: Object
+              spec:
+                managementPolicies: ["Observe", "Update"]
+                providerConfigRef:
+                  name: default
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: Secret
+                    metadata:
+                      name: ""
+                      namespace: argocd
+                      annotations:
+                        aws_vpc_id: ""
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.clusterName
+                toFieldPath: metadata.annotations[crossplane.io/external-name]
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.clusterName
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: status.vpcId
+                toFieldPath: spec.forProvider.manifest.metadata.annotations[aws_vpc_id]
+                policy:
+                  fromFieldPath: Required
+
           # ===== EKS MANAGED ADD-ONS (required for managed node group nodes) =====
 
           - name: addon-vpc-cni

--- a/gitops/addons/charts/crossplane-base/templates/provider-kubernetes.yaml
+++ b/gitops/addons/charts/crossplane-base/templates/provider-kubernetes.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.providers.kubernetes.version }}
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:{{ .Values.providers.kubernetes.version }}
+  runtimeConfigRef:
+    name: kubernetes-drc
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  credentials:
+    source: InjectedIdentity
+---
+# RBAC: provider-kubernetes patches ArgoCD cluster Secrets to publish
+# Composition-derived facts (e.g. aws_vpc_id) onto the spoke Secret used by
+# ApplicationSets. Scoped to argocd-namespace Secrets only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: provider-kubernetes-cluster-secret-writer
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "4"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: provider-kubernetes-cluster-secret-writer
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "4"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: provider-kubernetes-cluster-secret-writer
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.providers.kubernetes.serviceAccount }}
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/gitops/addons/charts/crossplane-base/values.yaml
+++ b/gitops/addons/charts/crossplane-base/values.yaml
@@ -57,5 +57,9 @@ providers:
     serviceAccount: provider-aws-secretsmanager
     roleName: CrossplaneSecretsManagerProviderRole
     createIdentity: true
+  kubernetes:
+    version: ""
+    serviceAccount: provider-kubernetes
+    createIdentity: false
 
 namespace: crossplane-system

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -58,6 +58,8 @@ crossplane-base:
       eks:
         version: "v2.5.3"
         createIdentity: false
+      kubernetes:
+        version: "v0.18.1"
   ignoreDifferences:
     - group: pkg.crossplane.io
       kind: Provider
@@ -67,6 +69,12 @@ crossplane-base:
         - /metadata/managedFields
     - group: pkg.crossplane.io
       kind: Function
+      jsonPointers:
+        - /status
+        - /metadata/generation
+        - /metadata/managedFields
+    - group: kubernetes.crossplane.io
+      kind: ProviderConfig
       jsonPointers:
         - /status
         - /metadata/generation

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -59,7 +59,7 @@ crossplane-base:
         version: "v2.5.3"
         createIdentity: false
       kubernetes:
-        version: "v0.18.1"
+        version: "v1.2.1"
   ignoreDifferences:
     - group: pkg.crossplane.io
       kind: Provider

--- a/gitops/bootstrap/fleet-secrets.yaml
+++ b/gitops/bootstrap/fleet-secrets.yaml
@@ -65,3 +65,11 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+      # The aws_vpc_id annotation on the spoke cluster Secret is owned by the
+      # platform-cluster Crossplane Composition (sourced from XR status.vpcId).
+      # Ignore drift on that single field so selfHeal does not strip it.
+      ignoreDifferences:
+        - group: ''
+          kind: Secret
+          jqPathExpressions:
+            - '.metadata.annotations.aws_vpc_id'


### PR DESCRIPTION
## Summary

Spoke LBC pods CrashLoopBackOff with `failed to fetch VPC ID from instance metadata` because EKS Auto Mode blocks pod IMDS access and `--vpc-id` arg is empty.

The hub gets VPC id via Secrets Manager seed + `externalSecret` mode. Spokes use `direct` mode and `gitops/fleet/members/<spoke>/values.yaml` doesn't carry `vpcId` — so the addon ApplicationSet's `{{.metadata.annotations.aws_vpc_id}}` renders empty.

Crossplane already exposes `status.vpcId` on the `XPlatformCluster` XR (set by the Composition at `composition.yaml:62`). This change consumes it instead of round-tripping through Secrets Manager.

- Add `provider-kubernetes` (v0.18.1) + `ProviderConfig` + namespaced `Role`/`RoleBinding` (Secrets-only, `argocd` namespace) to `crossplane-base` chart.
- Add `cluster-secret-vpc-annotation` Object resource to `platform-cluster` Composition with `managementPolicies: [Observe, Update]`, sourcing `aws_vpc_id` from `status.vpcId` via `FromCompositeFieldPath` (Required policy).
- `ignoreDifferences` on `.metadata.annotations.aws_vpc_id` in `fleet-secrets` ApplicationSet template so ArgoCD selfHeal doesn't strip the Composition-owned annotation.

## Why this approach

Crossplane is now the single source of truth for VPC id (consistent with how the Composition already owns subnets, OIDC, etc.). No reseeding needed if a spoke is rebuilt — the Composition reconciles and re-publishes. Pattern is reusable for any other XR-derived field that addon ApplicationSets need (subnet IDs, OIDC issuer, etc.).

Considered and rejected:
- Hardcoding VPC IDs in `gitops/fleet/members/<spoke>/values.yaml` — breaks on fresh deploys in any other account.
- Mirroring hub's Secrets Manager pattern for spokes — round-trips data Crossplane already has, per peer review.
- Post-deploy Job in `fleet-secret` chart — imperative, doesn't re-run on VPC changes.

## Test plan

- [ ] `task install` in a fresh account: spoke LBC pods reach `Running` without manual intervention.
- [ ] Verify spoke cluster Secret has `aws_vpc_id` annotation matching the live VPC.
- [ ] Verify spoke LBC Deployment has `--vpc-id=vpc-xxxxx` in args.
- [ ] Delete the annotation manually and confirm Composition re-publishes it within reconcile interval (selfHeal-safe).
- [ ] Confirm cascading apps recover: `metrics-server-spoke-prod`, `cert-manager-spoke-prod`, etc. (they fail when LBC webhook is unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)