### PR TITLE
fix(argocd): resolve OutOfSync drift on pod-identities and LBC

### DIFF
--- a/gitops/addons/registry/core.yaml
+++ b/gitops/addons/registry/core.yaml
@@ -173,6 +173,25 @@ aws-load-balancer-controller:
     serviceAccount:
       create: true
       name: aws-load-balancer-controller-sa
+  # The chart's cert-gen Job rotates the webhook TLS material after install,
+  # which causes Argo to see persistent OutOfSync drift on these three resources.
+  ignoreDifferences:
+    - group: ''
+      kind: Secret
+      name: aws-load-balancer-tls
+      namespace: kube-system
+      jsonPointers:
+        - /data
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      name: aws-load-balancer-webhook
+      jqPathExpressions:
+        - .webhooks[].clientConfig.caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: aws-load-balancer-webhook
+      jqPathExpressions:
+        - .webhooks[].clientConfig.caBundle
   additionalResources:
     - path: '{{.metadata.annotations.addonsRepoBasepath}}addons/charts/pod-identity-restart-hook'
       helm:

--- a/gitops/overlays/environments/control-plane/pod-identities/values.yaml
+++ b/gitops/overlays/environments/control-plane/pod-identities/values.yaml
@@ -1,0 +1,6 @@
+# Control-plane environments do not run their own ESO pod identity.
+# ESO on the hub uses the Crossplane provider role for Secrets Manager access;
+# Crossplane on the hub provisions ESO pod identities for spoke clusters.
+identities:
+  eso:
+    enabled: false


### PR DESCRIPTION
## Summary
Resolves persistent OutOfSync states observed on the hub cluster across two ApplicationSets.

### 1. `pod-identities-hub` — eso identity on control-plane
The inline Go template inside `valuesObject.identities.eso.enabled` is not re-evaluated by the Helm chart at render time, so the toggle was always interpreted as a literal template string (truthy) on the control-plane cluster. Crossplane on the hub kept creating the `hub-eso-pod-identity-*` resources only to delete them moments later, producing perpetual flapping.

Fix: add `gitops/overlays/environments/control-plane/pod-identities/values.yaml` to explicitly disable the `eso` identity for control-plane. Hub uses Crossplane's provider role for Secrets Manager; spokes get pod identities provisioned by Crossplane on the hub.

### 2. `aws-load-balancer-controller-{hub,spoke-dev,spoke-prod}` — cert rotation drift
The chart's cert-gen Job rotates the webhook TLS material and patches the `caBundle` field on the Mutating/ValidatingWebhookConfigurations after Argo applies. Argo then sees the patched fields as drift, looping all three apps in OutOfSync.

Fix: add `ignoreDifferences` to the registry entry for the TLS Secret data and the webhook caBundle fields. This is a single registry-level change; it propagates to all three Applications via the existing ApplicationSet template (`platform-charts/appset-chart`).

## Notes — apps not addressed in this PR
The following apps remain OutOfSync on hub but their sources live in `aws-samples/sample-agent-platform-on-eks` (a separate repo), so they are out of scope here:

- `agent-gateway-hub` — `HTTPRoute/mcp-servers-route` field drift
- `kagent-hub` — `Agent/argo-rollouts-conversion-agent` missing in cluster
- `langfuse-hub` — `StatefulSet/langfuse-postgres` field drift

These need an upstream PR against the agent-platform repo.

## Test plan
- [ ] Hard-refresh `pod-identities-hub` after merge and confirm Sync goes to `Synced` and the four `hub-eso-pod-identity-*` Crossplane CRs disappear
- [ ] Sync `aws-load-balancer-controller-hub`, `aws-load-balancer-controller-spoke-dev`, `aws-load-balancer-controller-spoke-prod` and confirm `Synced` after the next cert-gen rotation
- [ ] Confirm spoke clusters still get their `eso-pod-identity` resources (overlay scope is environment=control-plane only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)