### PR TITLE
fix(pod-identities): drop broken eso conditional, use env overlays

### DIFF
--- a/gitops/addons/registry/core.yaml
+++ b/gitops/addons/registry/core.yaml
@@ -20,11 +20,11 @@ pod_identities:
       accountId: '{{.metadata.annotations.aws_account_id}}'
     identities:
       # Pod identity enablement uses cluster labels by default.
-      # The control-plane cluster runs the ESO addon but does NOT need its own pod identity
-      # because Crossplane (running on the hub) manages pod identities for spoke clusters.
-      # The hub's ESO uses the Crossplane provider's credentials instead.
-      eso:
-        enabled: '{{`{{ if eq (default "" .metadata.labels.environment) "control-plane" }}false{{ else }}{{ default "" (index .metadata.labels "enable_external_secrets") }}{{ end }}`}}'
+      # eso identity is intentionally omitted here: the ApplicationSet templater
+      # does not evaluate nested {{if}}{{else}}{{end}} forms inside valuesObject
+      # and the literal string would be treated as truthy by the chart. The hub
+      # (control-plane) reuses the Crossplane provider role for ESO, so the chart
+      # default of `false` applies; spoke clusters enable it via env overlay.
       lbc:
         enabled: '{{`{{ default "" (index .metadata.labels "enable_aws_load_balancer_controller") }}`}}'
       external-dns:

--- a/gitops/overlays/environments/dev/pod-identities/values.yaml
+++ b/gitops/overlays/environments/dev/pod-identities/values.yaml
@@ -1,0 +1,5 @@
+# Spoke dev clusters get their own ESO pod identity provisioned by
+# Crossplane on the hub (chart default is false; opt in here).
+identities:
+  eso:
+    enabled: true

--- a/gitops/overlays/environments/prod/pod-identities/values.yaml
+++ b/gitops/overlays/environments/prod/pod-identities/values.yaml
@@ -1,0 +1,5 @@
+# Spoke prod clusters get their own ESO pod identity provisioned by
+# Crossplane on the hub (chart default is false; opt in here).
+identities:
+  eso:
+    enabled: true


### PR DESCRIPTION
## Summary
Follow-up to #646 — that PR added a control-plane overlay disabling the eso identity, but it had no effect because the inline `{{if}}{{else}}{{end}}` expression in the ApplicationSet's `valuesObject` is not evaluated by Argo's templater the way single `{{ default ... }}` expressions are. The literal template string was passed through and treated as truthy by the chart, so Crossplane kept trying to create `hub-eso-pod-identity` and conflicting with the Terraform-provisioned association.

Helm value precedence (`valuesObject` > `valueFiles`) also meant the overlay file from #646 couldn't have won even if the templating worked.

## Real fix
- Remove the broken conditional from the registry `valuesObject`. The chart default `false` applies, so the hub gets no eso resources.
- Add `gitops/overlays/environments/dev/pod-identities/values.yaml` and `gitops/overlays/environments/prod/pod-identities/values.yaml` that set `identities.eso.enabled: true`. These layer in correctly via `valueFiles`.

## Why hub doesn't need its own eso pod identity
The hub's ESO controller authenticates via the Crossplane provider role to read/write Secrets Manager (this is what unblocked the cluster earlier today after the addon-removal incident). Spokes need their own pod identity, which Crossplane on the hub provisions for them.

## Verification on the hub cluster
Before this PR, after #646:
```
podidentityassociation.eks.aws.upbound.io/hub-eso-pod-identity   False    False
  Message: ResourceInUseException: Association already exists: a-ayvkpec62xdkrnmzf
```
Argo health was Degraded because Crossplane couldn't reconcile the duplicate.

After this PR, hub should have **no** `hub-eso-pod-identity-*` resources at all.

## Test plan
- [ ] After merge, hard-refresh `pod-identities-hub`. The four `hub-eso-pod-identity-*` resources should be marked for pruning (or already gone).
- [ ] Once pruned, `pod-identities-hub` health goes Healthy and Synced.
- [ ] Spoke clusters (`spoke-dev`, `spoke-prod`) still report all 4 eso resources as `Synced=True Ready=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)