### PR TITLE
fix(pod-identities): orphan AWS resources on prune

### DIFF
--- a/gitops/addons/charts/crossplane-pod-identity/templates/pod-identity-association.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/templates/pod-identity-association.yaml
@@ -9,6 +9,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-1"
 spec:
+  # Orphan the underlying EKS PodIdentityAssociation on prune. The association
+  # may be Terraform-managed on the same SA (e.g. hub ESO) and pruning here
+  # must never tear it down.
+  deletionPolicy: Orphan
   forProvider:
     clusterName: {{ $.Values.aws.clusterName }}
     namespace: {{ $identity.namespace }}

--- a/gitops/addons/charts/crossplane-pod-identity/templates/policy-attachment.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/templates/policy-attachment.yaml
@@ -9,6 +9,9 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-2"
 spec:
+  # Orphan the underlying attachment on prune. Avoids breaking Terraform-managed
+  # PodIdentityAssociations that share the same Role/Policy.
+  deletionPolicy: Orphan
   forProvider:
     policyArnRef:
       name: {{ $.Values.aws.clusterName }}-{{ $name }}-pod-identity-policy

--- a/gitops/addons/charts/crossplane-pod-identity/templates/policy.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/templates/policy.yaml
@@ -10,6 +10,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-3"
 spec:
+  # Orphan, do not delete, the underlying IAM Policy on prune. The policy may
+  # be referenced by Terraform-managed roles on the same cluster and pruning
+  # here must never break ESO/LBC/etc.
+  deletionPolicy: Orphan
   forProvider:
     policy: |
 {{ $identity.policy.document | indent 6 }}

--- a/gitops/addons/charts/crossplane-pod-identity/templates/role.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/templates/role.yaml
@@ -12,6 +12,10 @@ metadata:
   labels:
     platform.gitops.io/role: {{ $.Values.aws.clusterName }}-{{ $name }}-pod-identity
 spec:
+  # Orphan, do not delete, the underlying IAM Role on prune. The role may be
+  # shared with Terraform-managed PodIdentityAssociations on the same cluster
+  # and pruning here must never break ESO/LBC/etc.
+  deletionPolicy: Orphan
   forProvider:
     assumeRolePolicy: |
       {


### PR DESCRIPTION
## Summary
Hardens the `crossplane-pod-identity` chart so that pruning a Crossplane CR can never tear down the underlying AWS resource. Adds `deletionPolicy: Orphan` to all four template kinds: `Role`, `Policy`, `RolePolicyAttachment`, `PodIdentityAssociation`.

## What happened (the regression that prompted this PR)
After #648 disabled the eso identity for control-plane and Argo pruned the four `hub-eso-pod-identity-*` Crossplane CRs, Crossplane proceeded to delete the underlying AWS resources too:

- `iam:Role/hub-ESOPodIdentityRole`
- `iam:Policy/hub-ESOSecretsManagerPolicy`
- The role-policy attachment
- The EKS PodIdentityAssociation `a-ayvkpec62xdkrnmzf`

But Terraform had also provisioned `hub-ESOPodIdentityRole` and an association on the same SA — the chart and Terraform shared the external name. Once Crossplane deleted the role out from under it, ESO immediately failed:

```
AccessDeniedException: Unauthorized Exception! EKS does not have
permissions to assume the associated role.
```

All four ExternalSecrets went into `SecretSyncedError`, taking down `keycloak-hub`, `argo-workflows-hub`, `fleet-secret-hub`, and the entire ESO authentication path until the IAM role/policy were recreated manually.

## Root cause
Crossplane's default `deletionPolicy` is `Delete`. When a chart shares external names with another provisioner (Terraform on hub, Crossplane on spokes) — or is disabled mid-flight — pruning the CR leaks into infra owned by something else. The chart was implicitly assuming Crossplane was the sole owner of every external name it touched.

## Fix
Set `deletionPolicy: Orphan` on all four templates. Pruning the CRs removes the Kubernetes records; the AWS resources are left untouched. This means:

- Disabling an identity (or removing a cluster from the ApplicationSet) can never break ESO/LBC/etc.
- The trade-off is that intentionally retiring an identity now leaves AWS leftovers that need a manual cleanup. That's a much cheaper bill than another midnight outage.

## Files
- `gitops/addons/charts/crossplane-pod-identity/templates/role.yaml`
- `gitops/addons/charts/crossplane-pod-identity/templates/policy.yaml`
- `gitops/addons/charts/crossplane-pod-identity/templates/policy-attachment.yaml`
- `gitops/addons/charts/crossplane-pod-identity/templates/pod-identity-association.yaml`

## Verification
Helm-rendered output now includes `deletionPolicy: Orphan` on all four kinds:

```
$ helm template pod-identities gitops/addons/charts/crossplane-pod-identity \
    --set aws.clusterName=hub --set identities.lbc.enabled=true | grep deletionPolicy
  deletionPolicy: Orphan      # Role
  deletionPolicy: Orphan      # PodIdentityAssociation
  deletionPolicy: Orphan      # Policy
  deletionPolicy: Orphan      # RolePolicyAttachment
```

## Test plan
- [ ] Merge and let Argo apply the patch to existing managed resources
- [ ] Verify each spoke's eso/lbc/external-dns/litellm CRs now show `spec.deletionPolicy: Orphan`
- [ ] (No live destructive test — that's the whole point of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)