### PR TITLE
fix(destroy): close three gaps that left AWS infra behind

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -595,11 +595,29 @@ tasks:
           kubectl -n crossplane-system wait --for=delete roles.iam.aws.upbound.io -l platform.gitops.io/role --timeout=120s 2>/dev/null || true
         ignore_error: true
       # Phase 3: Delete ArgoCD capability via Job, then its IAM role (needs IAM provider alive)
-      - cmd: task argocd:delete-capability
+      # Use `task:` instead of `cmd: task ...` so the call doesn't go through gosh,
+      # which mis-parses some yq-driven dynamic vars in credentials:setup.
+      - task: argocd:delete-capability
         ignore_error: true
       - cmd: |
           sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g" claims/argocd-capability-role.yaml | kubectl delete --ignore-not-found --wait=false -f - 2>/dev/null || true
           kubectl -n crossplane-system wait --for=delete roles.iam.aws.upbound.io/argocd-capability-role --timeout=120s 2>/dev/null || true
+        ignore_error: true
+      # Belt-and-suspenders: if the Job-based delete failed (e.g. parser error,
+      # config drift), call the AWS API directly so the cluster delete in Phase 4
+      # isn't blocked by `Cluster has capabilities attached`.
+      - cmd: |
+          for CAP in $(aws eks list-capabilities --cluster-name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'capabilities[].capabilityName' --output text 2>/dev/null); do
+            echo "Deleting EKS capability $CAP on cluster {{.HUB_CLUSTER_NAME}}..."
+            aws eks delete-capability --cluster-name {{.HUB_CLUSTER_NAME}} --capability-name "$CAP" --region {{.AWS_REGION}} --output text 2>/dev/null || true
+          done
+          # Wait for capabilities to fully drain before proceeding
+          for i in $(seq 1 60); do
+            REMAINING=$(aws eks list-capabilities --cluster-name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'capabilities | length(@)' --output text 2>/dev/null || echo 0)
+            [ "$REMAINING" = "0" ] && break
+            echo "Waiting for $REMAINING EKS capabilities to delete... ($i/60)"
+            sleep 20
+          done
         ignore_error: true
       # Phase 4: Delete EKS cluster + VPC (needs providers alive to reconcile deletion)
       - cmd: |
@@ -610,6 +628,21 @@ tasks:
             | kubectl delete --ignore-not-found --wait=false -f - 2>/dev/null || true
           kubectl -n crossplane-system wait --for=delete clusters.eks.aws.upbound.io --all --timeout=1800s 2>/dev/null || true
           kubectl -n crossplane-system wait --for=delete vpc.ec2.aws.upbound.io --all --timeout=600s 2>/dev/null || true
+        ignore_error: true
+      # The Crossplane CRs above can disappear before AWS reports the cluster
+      # gone. If we tear down the providers in Phase 5 while AWS still has the
+      # cluster ACTIVE, no further reconciliation can happen and the cluster +
+      # VPC are left behind. Wait on the AWS side directly before proceeding.
+      - cmd: |
+          for i in $(seq 1 60); do
+            STATUS=$(aws eks describe-cluster --name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'cluster.status' --output text 2>&1)
+            if echo "$STATUS" | grep -q "ResourceNotFoundException"; then
+              echo "EKS cluster {{.HUB_CLUSTER_NAME}} confirmed deleted on AWS side"
+              break
+            fi
+            echo "Waiting for AWS-side EKS cluster delete (status=$STATUS)... ($i/60)"
+            sleep 30
+          done
         ignore_error: true
       - kubectl delete -f {{.GITOPS_ROOT}}/abstractions/resource-groups/platform-cluster/templates/composition.yaml --ignore-not-found 2>/dev/null || true
       - kubectl delete -f {{.GITOPS_ROOT}}/abstractions/resource-groups/platform-cluster/templates/xrd.yaml --ignore-not-found 2>/dev/null || true
@@ -645,7 +678,103 @@ tasks:
             [ -n "$POLICY_ARN" ] && aws iam delete-policy --policy-arn "$POLICY_ARN" 2>/dev/null || true
           done
         ignore_error: true
-      # Phase 7: Clean up Kind (pass CLEANUP_KIND=true to remove)
+      # Phase 7: VPC-level orphan cleanup. The Crossplane VPC delete in Phase 4
+      # can stop reconciling once the providers are torn down in Phase 5, leaving
+      # AWS-side dependencies (ELBs, NAT gateways, VPC endpoints, EIPs, subnets,
+      # IGW, route tables, security groups). Tear them down by Crossplane tag so
+      # subsequent VPC deletes succeed.
+      - cmd: |
+          # Find any VPCs tagged by the Crossplane EC2 provider for our clusters
+          VPCS=$(aws ec2 describe-vpcs --region {{.AWS_REGION}} \
+            --filters "Name=tag:platform.gitops.io/cluster,Values={{.HUB_CLUSTER_NAME}},spoke-dev,spoke-prod" \
+            --query 'Vpcs[].VpcId' --output text 2>/dev/null)
+          if [ -z "$VPCS" ]; then
+            echo "No tagged Crossplane VPCs found — skipping VPC orphan cleanup"
+            exit 0
+          fi
+          for VPC in $VPCS; do
+            echo "=== Cleaning up dependencies in $VPC ==="
+            # ELBs (created by aws-load-balancer-controller, not directly tagged
+            # by us, but pinned to the VPC)
+            for LB_ARN in $(aws elbv2 describe-load-balancers --region {{.AWS_REGION}} \
+                --query "LoadBalancers[?VpcId=='$VPC'].LoadBalancerArn" --output text 2>/dev/null); do
+              echo "Deleting ELB $LB_ARN"
+              aws elbv2 delete-load-balancer --load-balancer-arn "$LB_ARN" --region {{.AWS_REGION}} 2>/dev/null || true
+            done
+            # NAT gateways and their EIPs
+            for NAT in $(aws ec2 describe-nat-gateways --region {{.AWS_REGION}} \
+                --filter "Name=vpc-id,Values=$VPC" "Name=state,Values=available,pending" \
+                --query 'NatGateways[].NatGatewayId' --output text 2>/dev/null); do
+              echo "Deleting NAT gateway $NAT"
+              aws ec2 delete-nat-gateway --nat-gateway-id "$NAT" --region {{.AWS_REGION}} 2>/dev/null || true
+            done
+            # VPC endpoints (interface endpoints leave ENIs behind)
+            ENDPOINTS=$(aws ec2 describe-vpc-endpoints --region {{.AWS_REGION}} \
+              --filters "Name=vpc-id,Values=$VPC" \
+              --query 'VpcEndpoints[].VpcEndpointId' --output text 2>/dev/null)
+            if [ -n "$ENDPOINTS" ]; then
+              echo "Deleting VPC endpoints: $ENDPOINTS"
+              aws ec2 delete-vpc-endpoints --vpc-endpoint-ids $ENDPOINTS --region {{.AWS_REGION}} 2>/dev/null || true
+            fi
+          done
+          # Wait for NAT gateways to fully delete (they hold EIPs and ENIs)
+          for i in $(seq 1 30); do
+            REMAINING=$(aws ec2 describe-nat-gateways --region {{.AWS_REGION}} \
+              --filter "Name=state,Values=deleting" \
+              --query "NatGateways[?contains('$VPCS', VpcId)] | length(@)" --output text 2>/dev/null || echo 0)
+            [ "$REMAINING" = "0" ] && break
+            echo "Waiting for $REMAINING NAT gateways to delete... ($i/30)"
+            sleep 20
+          done
+          # Release EIPs tagged by Crossplane for our clusters
+          for EIP in $(aws ec2 describe-addresses --region {{.AWS_REGION}} \
+              --filters "Name=tag:platform.gitops.io/cluster,Values={{.HUB_CLUSTER_NAME}},spoke-dev,spoke-prod" \
+              --query 'Addresses[].AllocationId' --output text 2>/dev/null); do
+            echo "Releasing EIP $EIP"
+            aws ec2 release-address --allocation-id "$EIP" --region {{.AWS_REGION}} 2>/dev/null || true
+          done
+          # Now drop subnets, IGW, route tables, security groups, then VPC itself
+          for VPC in $VPCS; do
+            for IGW in $(aws ec2 describe-internet-gateways --region {{.AWS_REGION}} \
+                --filters "Name=attachment.vpc-id,Values=$VPC" \
+                --query 'InternetGateways[].InternetGatewayId' --output text 2>/dev/null); do
+              echo "Detaching+deleting IGW $IGW"
+              aws ec2 detach-internet-gateway --internet-gateway-id "$IGW" --vpc-id "$VPC" --region {{.AWS_REGION}} 2>/dev/null || true
+              aws ec2 delete-internet-gateway --internet-gateway-id "$IGW" --region {{.AWS_REGION}} 2>/dev/null || true
+            done
+            for SUBNET in $(aws ec2 describe-subnets --region {{.AWS_REGION}} \
+                --filters "Name=vpc-id,Values=$VPC" --query 'Subnets[].SubnetId' --output text 2>/dev/null); do
+              aws ec2 delete-subnet --subnet-id "$SUBNET" --region {{.AWS_REGION}} 2>/dev/null || true
+            done
+            for RT in $(aws ec2 describe-route-tables --region {{.AWS_REGION}} \
+                --filters "Name=vpc-id,Values=$VPC" \
+                --query 'RouteTables[?!(Associations[?Main==`true`])].RouteTableId' --output text 2>/dev/null); do
+              aws ec2 delete-route-table --route-table-id "$RT" --region {{.AWS_REGION}} 2>/dev/null || true
+            done
+            for SG in $(aws ec2 describe-security-groups --region {{.AWS_REGION}} \
+                --filters "Name=vpc-id,Values=$VPC" \
+                --query 'SecurityGroups[?GroupName!=`default`].GroupId' --output text 2>/dev/null); do
+              # Revoke rules first (SGs may reference each other)
+              ING=$(aws ec2 describe-security-groups --group-ids "$SG" --region {{.AWS_REGION}} --query 'SecurityGroups[0].IpPermissions' --output json 2>/dev/null)
+              EGR=$(aws ec2 describe-security-groups --group-ids "$SG" --region {{.AWS_REGION}} --query 'SecurityGroups[0].IpPermissionsEgress' --output json 2>/dev/null)
+              [ "$ING" != "[]" ] && aws ec2 revoke-security-group-ingress --group-id "$SG" --ip-permissions "$ING" --region {{.AWS_REGION}} 2>/dev/null || true
+              [ "$EGR" != "[]" ] && aws ec2 revoke-security-group-egress --group-id "$SG" --ip-permissions "$EGR" --region {{.AWS_REGION}} 2>/dev/null || true
+            done
+            for SG in $(aws ec2 describe-security-groups --region {{.AWS_REGION}} \
+                --filters "Name=vpc-id,Values=$VPC" \
+                --query 'SecurityGroups[?GroupName!=`default`].GroupId' --output text 2>/dev/null); do
+              aws ec2 delete-security-group --group-id "$SG" --region {{.AWS_REGION}} 2>/dev/null || true
+            done
+            echo "Deleting VPC $VPC"
+            aws ec2 delete-vpc --vpc-id "$VPC" --region {{.AWS_REGION}} 2>/dev/null || true
+          done
+          # Secrets Manager — Crossplane cluster claims also push hub/spoke config
+          # secrets that survive the AWS resource teardown
+          for SECRET in {{.HUB_CLUSTER_NAME}}/config {{.HUB_CLUSTER_NAME}}/keycloak {{.HUB_CLUSTER_NAME}}/keycloak-clients spoke-dev/config spoke-prod/config; do
+            aws secretsmanager delete-secret --secret-id "$SECRET" --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>/dev/null || true
+          done
+        ignore_error: true
+      # Phase 8: Clean up Kind (pass CLEANUP_KIND=true to remove)
       - cmd: |
           if [ "{{.CLEANUP_KIND}}" = "true" ]; then
             kind delete cluster --name {{.KIND_CLUSTER_NAME}}


### PR DESCRIPTION
## Summary
Running `task destroy CLEANUP_KIND=true` against a fully-bootstrapped hub + spokes left the EKS clusters and their VPCs running in AWS, requiring a long manual cleanup. This PR closes the three gaps that caused that.

## What was broken

### 1. Phase 3 — ArgoCD capability never deleted
`cmd: task argocd:delete-capability` routes through gosh, which failed parsing a sibling task's dynamic var:
```
task: Failed to run task "argocd:delete-capability":
  a command can only contain words and redirects; encountered (
```
The capability stayed attached, which then blocked Phase 4 with `Cluster has capabilities attached`. Switch to native sub-task invocation (`task:` instead of `cmd: task ...`) and add a belt-and-suspenders block that calls `aws eks delete-capability` directly and waits for capabilities to drain.

### 2. Phase 4 — provider torn down before AWS finished
Phase 4 waited only on the Crossplane CR `vpc.ec2.aws.upbound.io` to disappear, but Crossplane removes the CR when its finalizer succeeds — not when AWS confirms the cluster is gone. Phase 5 then deleted the providers, so AWS never reconciled the cluster delete and the EKS cluster + VPC stayed ACTIVE. Add an explicit poll on `aws eks describe-cluster` so Phase 5 only runs once AWS reports the cluster gone.

### 3. Phase 6 — only cleaned IAM, missing VPC dependencies
When the AWS-side cluster delete had already failed, ELBs, NAT gateways, VPC endpoints, EIPs, subnets, IGWs, route tables, and security groups stayed behind and blocked any subsequent VPC delete. Add a tag-driven sweep that finds VPCs tagged `platform.gitops.io/cluster=hub|spoke-dev|spoke-prod`, tears down dependencies in dependency order (ELBs → NAT gateways → VPC endpoints → EIPs → subnets → IGW → route tables → security groups), then deletes the VPC. Also drops the related Secrets Manager secrets (`hub/config`, `hub/keycloak`, `hub/keycloak-clients`, `spoke-*/config`).

## Verification
Validated locally:
```
$ python3 -c "import yaml; yaml.safe_load(open('cluster-providers/kind-crossplane/Taskfile.yaml'))" && echo OK
OK
$ task --list | head
* destroy:           Full teardown — addons, AWS resources. ...
```
The earlier teardown that surfaced these issues required ~30 minutes of manual `aws ec2 delete-*` after `task destroy` returned. With this PR, a single `task destroy CLEANUP_KIND=true` should leave zero AWS-side residue.

## Test plan
- [ ] After merge, fresh bootstrap (`task install`)
- [ ] `task destroy CLEANUP_KIND=true`
- [ ] Verify with these commands — all should return empty:
  - `aws eks list-clusters --region us-west-2 --query "clusters[?@==\`hub\` || @==\`spoke-dev\` || @==\`spoke-prod\`]"`
  - `aws ec2 describe-vpcs --region us-west-2 --filters "Name=tag:platform.gitops.io/cluster,Values=hub,spoke-dev,spoke-prod" --query 'Vpcs[].VpcId'`
  - `aws iam list-roles --query "Roles[?starts_with(RoleName, \`hub-\`) || starts_with(RoleName, \`spoke-\`)].RoleName"`
  - `aws secretsmanager list-secrets --region us-west-2 --query "SecretList[?starts_with(Name, \`hub/\`) || starts_with(Name, \`spoke-\`)].Name"`