### PR TITLE
fix(observability): two final fresh-install drift sources

### DIFF
--- a/gitops/addons/charts/grafana-dashboards/templates/external-secret.yaml
+++ b/gitops/addons/charts/grafana-dashboards/templates/external-secret.yaml
@@ -70,10 +70,15 @@ spec:
       metadataPolicy: None
       key: {{ .Values.clusterName }}/secrets
       property: grafana_mysql_password
+{{- if .Values.devlake.enabled }}
+  # GRAFANA_MYSQL_URL only exists when devlake is enabled — its chart writes
+  # the connection-string secret. Gating prevents this ExternalSecret from
+  # failing on hubs where devlake is intentionally not deployed.
   - secretKey: GRAFANA_MYSQL_URL
     remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
       metadataPolicy: None
-      key: peeks-devlake/mysql-connection
+      key: {{ .Values.resourcePrefix | default "peeks" }}-devlake/mysql-connection
       property: db_url
+{{- end }}

--- a/gitops/addons/registry/observability.yaml
+++ b/gitops/addons/registry/observability.yaml
@@ -33,24 +33,32 @@ observability-aws:
         - /status
         - /metadata/generation
         - /metadata/managedFields
+        # Crossplane provider injects bookkeeping tags (crossplane-kind,
+        # crossplane-name, crossplane-providerconfig) onto every managed
+        # resource. The chart can't know about them at render time, so
+        # they show up as drift on every reconcile.
+        - /spec/forProvider/tags
     - group: amp.aws.upbound.io
       kind: Scraper
       jsonPointers:
         - /status
         - /metadata/generation
         - /metadata/managedFields
+        - /spec/forProvider/tags
     - group: grafana.aws.upbound.io
       kind: Workspace
       jsonPointers:
         - /status
         - /metadata/generation
         - /metadata/managedFields
+        - /spec/forProvider/tags
     - group: grafana.aws.upbound.io
       kind: WorkspaceSamlConfiguration
       jsonPointers:
         - /status
         - /metadata/generation
         - /metadata/managedFields
+        - /spec/forProvider/tags
 
 grafana:
   namespace: grafana
@@ -124,8 +132,15 @@ grafana-dashboards:
         values: ['true']
   valuesObject:
     clusterName: '{{.metadata.annotations.aws_cluster_name}}'
+    resourcePrefix: '{{.metadata.annotations.resource_prefix}}'
     namespace: grafana-operator
     grafana_url: '{{.metadata.annotations.aws_grafana_url | default (printf "%s/grafana" .metadata.annotations.ingress_domain_name)}}'
+    # Devlake is what publishes the {prefix}-devlake/mysql-connection
+    # Secrets Manager secret. The grafana-mysql-creds ExternalSecret only
+    # reads it when devlake is enabled — otherwise that ExternalSecret
+    # would block grafana-dashboards-hub on a non-existent source secret.
+    devlake:
+      enabled: '{{.metadata.labels.enable_devlake | default "false"}}'
 
 kube-state-metrics:
   namespace: kube-prometheus-stack


### PR DESCRIPTION
## Summary
Closes the last two non-Synced apps observed after a clean `task install` on `feature/agent-platform`. Both are pre-existing chart drift, not install-flow bugs.

### 1. `grafana-dashboards-hub` — Degraded due to absent devlake source secret
The `grafana-mysql-creds` ExternalSecret unconditionally pulls `GRAFANA_MYSQL_URL` from `peeks-devlake/mysql-connection`. That secret only exists when the `devlake` chart is deployed (it's the chart that publishes it). On a control-plane hub where devlake isn't enabled, ESO stays in `SecretSyncedError` and propagates Degraded up to the application.

**Fix:**
- Gate the second `data` entry of `grafana-mysql-creds` on a new `devlake.enabled` value
- Wire the env's `resource_prefix` through the registry so the source-secret name is per-environment, not the hardcoded `peeks-devlake`
- Default `devlake.enabled` to `{{.metadata.labels.enable_devlake | default "false"}}` in the registry — auto-tracks the cluster's existing `enable_devlake` label

### 2. `observability-aws-hub` — OutOfSync on Crossplane-injected tags
The Crossplane provider writes bookkeeping tags onto every managed resource:
```
crossplane-kind: workspace.amp.aws.upbound.io
crossplane-name: peeks-amp
crossplane-providerconfig: default
```
The chart can't render these at template time, so AMP `Workspace`, AMP `Scraper`, AMG `Workspace`, and AMG `WorkspaceSamlConfiguration` permanently show OOS on `spec.forProvider.tags`.

**Fix:** add `/spec/forProvider/tags` to the existing `ignoreDifferences` for those four kinds in the `observability-aws` registry entry.

## Verification (rendered output)
```
$ helm template grafana-dashboards .../grafana-dashboards \
    --set clusterName=hub --set devlake.enabled=false | grep GRAFANA_MYSQL_URL
(empty — gated correctly)

$ helm template grafana-dashboards .../grafana-dashboards \
    --set clusterName=hub --set devlake.enabled=true --set resourcePrefix=peeks \
    | grep -B1 -A4 GRAFANA_MYSQL_URL
  - secretKey: GRAFANA_MYSQL_URL
    remoteRef:
      ...
      key: peeks-devlake/mysql-connection
```

## Test plan
- [ ] After merge + Argo refresh: `grafana-dashboards-hub` reaches Synced+Healthy on hubs without devlake
- [ ] `observability-aws-hub` reaches Synced (Crossplane tags no longer flagged as drift)
- [ ] Spoke clusters with `enable_devlake=true` still resolve `GRAFANA_MYSQL_URL` from their `<prefix>-devlake/mysql-connection` secret

## Final tally
This PR brings the fresh-install path to a clean 61/61 Healthy+Synced (currently 59/61).