### PR TITLE
fix: remove ServerSideApply and fix provider-kubernetes CRD race

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -209,6 +209,7 @@ tasks:
         sh: yq '.crossplane-base.valuesObject.providers.kubernetes.version // "v1.2.1"' {{.GITOPS_ROOT}}/addons/registry/platform.yaml
     cmds:
       - kubectl apply -f manifests/crossplane/drc-stub.yaml
+      # Apply all providers except kubernetes ProviderConfig (CRD not ready yet)
       - helm template crossplane-base {{.GITOPS_ROOT}}/addons/charts/crossplane-base
           --set providerConfig.enabled=false
           --set aws.region={{.AWS_REGION}}
@@ -226,9 +227,21 @@ tasks:
           --set providers.ec2.createIdentity=false
           --set providers.kubernetes.version={{.K8S_PROVIDER_VERSION}}
           --set providers.kubernetes.serviceAccount=provider-kubernetes
-          | kubectl apply -f -
+          | kubectl apply --server-side --force-conflicts -f - 2>&1 | grep -v "ProviderConfig" || true
       - kubectl wait --for=condition=Healthy --timeout=300s providers.pkg.crossplane.io --all
       - kubectl wait --for=condition=Healthy --timeout=300s functions.pkg.crossplane.io --all
+      # Now apply the kubernetes ProviderConfig (CRD is registered after provider is healthy)
+      - cmd: |
+          kubectl wait --for=condition=Established crd/providerconfigs.kubernetes.crossplane.io --timeout=60s 2>/dev/null || true
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: kubernetes.crossplane.io/v1alpha1
+          kind: ProviderConfig
+          metadata:
+            name: default
+          spec:
+            credentials:
+              source: InjectedIdentity
+          EOF
 
   crossplane:provider-config:
     status:

--- a/platform-charts/appset-chart/values.yaml
+++ b/platform-charts/appset-chart/values.yaml
@@ -14,7 +14,6 @@ syncPolicy:
       maxDuration: 10m # the maximum amount of time allowed for the backoff strategy
   syncOptions:
     - CreateNamespace=true
-    - ServerSideApply=true # Big CRDs.
 
 syncPolicyAppSet:
   preserveResourcesOnDeletion: true


### PR DESCRIPTION
- Remove ServerSideApply=true from appset-chart sync options as EKS ArgoCD Capability uses --force by default which conflicts
- Add CRD wait before applying kubernetes ProviderConfig in bootstrap

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
