### PR TITLE
fix(install): three remaining smooth-install gaps

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -573,7 +573,10 @@ tasks:
           exit 0
         fi
 
-        # Merge into existing secret (preserves other keys)
+        # Merge into existing secret (preserves other keys). On first run
+        # the secret doesn't exist yet — `get-secret-value` returns empty,
+        # we start from `{}`, and `put-secret-value` would fail with
+        # ResourceNotFoundException, so create-then-put.
         EXISTING=$(aws secretsmanager get-secret-value --secret-id "$SECRET_KEY" --region {{.AWS_REGION}} --query "SecretString" --output text 2>/dev/null || echo "{}")
         UPDATED=$(echo "$EXISTING" | jq \
           --arg amp_url "${AMP_ENDPOINT}api/v1/remote_write" \
@@ -582,7 +585,18 @@ tasks:
           --arg grafana_api_key "$AMG_API_KEY" \
           --arg grafana_url "$AMG_ENDPOINT" \
           '. + {amp_endpoint_url: $amp_query_url, amp_region: $amp_region, grafana_api_key: $grafana_api_key, grafana_url: $grafana_url}')
-        aws secretsmanager put-secret-value \
+        # Generate the grafana_mysql_password the grafana-dashboards
+        # ExternalSecret expects, but only if it isn't already there
+        # (so re-runs don't rotate it out from under live consumers).
+        if ! echo "$UPDATED" | jq -e 'has("grafana_mysql_password")' >/dev/null; then
+          GRAFANA_MYSQL_PASSWORD=$(openssl rand -base64 18 | tr -d '/+=' | head -c 24)
+          UPDATED=$(echo "$UPDATED" | jq --arg p "$GRAFANA_MYSQL_PASSWORD" '. + {grafana_mysql_password: $p}')
+        fi
+        aws secretsmanager create-secret \
+          --name "$SECRET_KEY" \
+          --secret-string "$UPDATED" \
+          --region {{.AWS_REGION}} 2>/dev/null \
+        || aws secretsmanager put-secret-value \
           --secret-id "$SECRET_KEY" \
           --secret-string "$UPDATED" \
           --region {{.AWS_REGION}}

--- a/gitops/abstractions/resource-groups/platform-cluster/templates/composition.yaml
+++ b/gitops/abstractions/resource-groups/platform-cluster/templates/composition.yaml
@@ -705,6 +705,48 @@ spec:
                 fromFieldPath: spec.argoCDRoleArn
                 toFieldPath: spec.forProvider.principalArn
 
+          # ArgoCD-specific access policies the EKS Capability needs to drive
+          # remote-cluster sync (AmazonEKSClusterAdminPolicy alone is not
+          # sufficient — the hub-side ArgoCD Capability fails with
+          # "failed to verify the access entry" without these two).
+          - name: argocd-cluster-access-policy
+            base:
+              apiVersion: eks.aws.upbound.io/v1beta1
+              kind: AccessPolicyAssociation
+              spec:
+                forProvider:
+                  clusterNameSelector:
+                    matchControllerRef: true
+                  policyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSArgoCDClusterPolicy
+                  accessScope:
+                    type: cluster
+            patches:
+              - type: PatchSet
+                patchSetName: common
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.argoCDRoleArn
+                toFieldPath: spec.forProvider.principalArn
+
+          - name: argocd-namespace-access-policy
+            base:
+              apiVersion: eks.aws.upbound.io/v1beta1
+              kind: AccessPolicyAssociation
+              spec:
+                forProvider:
+                  clusterNameSelector:
+                    matchControllerRef: true
+                  policyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSArgoCDPolicy
+                  accessScope:
+                    type: namespace
+                    namespaces:
+                      - argocd
+            patches:
+              - type: PatchSet
+                patchSetName: common
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.argoCDRoleArn
+                toFieldPath: spec.forProvider.principalArn
+
           # EKS Cluster with Auto Mode enabled
           - name: eks-cluster
             base:


### PR DESCRIPTION
## Summary
After three end-to-end clean installs, three issues still required manual intervention to reach 61/61 Synced+Healthy. This PR codifies all three so a fresh `task install` lands green without touching live state.

### 1. Spoke ArgoCD access entries missing two policies
The `platform-cluster` Composition only attached `AmazonEKSClusterAdminPolicy` to the hub `ArgoCDCapabilityRole` on each spoke. The EKS Capability for ArgoCD on the hub then failed to drive sync against spokes with:
```
Failed to load live state: failed to get cluster info for "...spoke-dev":
  error getting cluster: error getting cluster RESTConfig:
  failed to verify the access entry
```
Every spoke app sat in `Sync=Unknown` until I attached the missing policies by hand:
```
aws eks associate-access-policy ... --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSArgoCDClusterPolicy --access-scope type=cluster
aws eks associate-access-policy ... --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSArgoCDPolicy --access-scope type=namespace,namespaces=argocd
```

**Fix**: add both as additional `AccessPolicyAssociation` managed resources in the composition, patched with the same `argoCDRoleArn` as the existing admin attachment.

### 2. `secrets-manager:seed-observability` fails on first run
The task only does `put-secret-value` on `<hub>/secrets`. On a fresh account that secret doesn't exist yet:
```
An error occurred (ResourceNotFoundException) when calling the PutSecretValue operation:
  Secrets Manager can't find the specified secret.
task: Failed to run task "kind-crossplane:secrets-manager:seed-observability": exit status 254
```

**Fix**: switch to `create-or-put`, matching how the sibling `secrets-manager:seed` and `:seed-keycloak` tasks bootstrap their secrets.

### 3. `grafana-mysql-creds` has no source for `grafana_mysql_password`
The `grafana-dashboards` ExternalSecret reads `<hub>/secrets/grafana_mysql_password` but nothing in the install path puts a value there, so ESO sits in `SecretSyncedError` and `grafana-dashboards-hub` reports Degraded.

**Fix**: generate the password in `seed-observability` when it's absent. Idempotent — re-runs detect the existing key and don't rotate it (so live consumers don't lose access).

## Verification
Helm-renders the new MRs:
```
$ helm template platform-cluster .../platform-cluster --set clusters.hub.region=us-west-2 --set clusters.hub.clusterName=hub \
    | grep "policyArn: arn:aws:eks::aws:cluster-access-policy/"
  policyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy
  policyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSArgoCDClusterPolicy
  policyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSArgoCDPolicy
```

## Test plan
- [ ] `task destroy CLEANUP_KIND=true` (PR #653's hardened path) on a fully bootstrapped cluster
- [ ] Run `task install` end-to-end on a fresh account
- [ ] Without manual intervention, expect:
  - All spoke apps progress past `Sync=Unknown` once Crossplane creates the spoke clusters
  - `seed-observability` exits 0 on first run
  - `grafana-dashboards-hub` reaches Synced+Healthy