### PR TITLE
fix(kro/rg-eks-vpc): use 'Ready' condition for KRO 0.9.2 compat

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks-vpc.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks-vpc.yaml
@@ -132,7 +132,7 @@ spec:
           privateSubnet2Cidr: ${schema.spec.cidr.privateSubnet2Cidr}
   - id: eks
     readyWhen:
-    - ${eks.status.conditions.exists(x, x.type == 'InstanceSynced' && x.status == "True")} # Check on kro conditions
+    - ${eks.status.conditions.exists(x, x.type == 'Ready' && x.status == "True")} # Check on kro conditions
     template:
       apiVersion: kro.run/v1alpha1
       kind: EksCluster


### PR DESCRIPTION
## Context

KRO 0.9.2 doesn't emit the `InstanceSynced` condition that earlier RGDs relied on. ArgoCD applications watching for it stay stuck in `Progressing` even after KRO has fully reconciled the resource graph.

## Change

Switch the wait/health condition on `rg-eks-vpc` to `Ready`, which KRO 0.9.2 does emit on successful instance reconciliation.

## Test

- ✅ Hub bootstrap completes without ArgoCD getting stuck on the EKS+VPC RGD claim
- ✅ Compatible with the KRO version pinned in `feature/platform-cluster-kro-ack`

## Scope

Single-line change, no breaking impact for downstream consumers — the `Ready` condition is the canonical KRO instance condition.

Extracted from PeEKS branch work on top of #642.
