### PR TITLE
fix(cert-manager): bump cainjector memory 128Mi → 256Mi

### DIFF
--- a/gitops/addons/configs/cert-manager/values.yaml
+++ b/gitops/addons/configs/cert-manager/values.yaml
@@ -30,14 +30,16 @@ podDisruptionBudget:
   maxUnavailable: 1
 
 # CA Injector HA
+# memory: 256Mi — 128Mi triggers OOMKilled (exit 137) on cluster bootstrap
+# when cainjector caches all CABundle injectables across CRDs
 cainjector:
   replicaCount: 2
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
     limits:
-      memory: 128Mi
+      memory: 256Mi
   nodeSelector:
     karpenter.sh/nodepool: system
   tolerations:


### PR DESCRIPTION
## Context

`cert-manager-cainjector` was OOMKilled repeatedly on the hub cluster once a few CRDs/webhooks accumulated. The default `128Mi` request/limit is too tight for the cainjector's CRD-watch cache.

## Change

Bump `cainjector.resources.{requests,limits}.memory` from `128Mi` → `256Mi` in the cert-manager Helm values used by the platform addons chart.

## Test

- ✅ No more `OOMKilled` events on `cert-manager-cainjector` after a full hub install
- ✅ Steady-state memory observed: ~180Mi → 256Mi gives a sane headroom

## Scope

Trivial values bump, no API change.

Extracted from PeEKS branch work on top of #642.
