### PR TITLE
feat(kind-kro-ack): bootstrap UX improvements (path resolution, BYO IdC, EKS gate, profile-first creds)

### DIFF
--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -131,23 +131,34 @@ tasks:
       - kubectl create namespace {{.ACK_NAMESPACE}} --dry-run=client -o yaml | kubectl apply -f -
       - |
         set -e
-        TOKEN=$(curl -s -m 2 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null || true)
-        if [ -n "$TOKEN" ]; then
-          ROLE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/)
-          CREDS=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE)
-          AKI=$(echo "$CREDS" | jq -r .AccessKeyId)
-          SAK=$(echo "$CREDS" | jq -r .SecretAccessKey)
-          ST=$(echo  "$CREDS" | jq -r .Token)
-        else
-          AWS_PROFILE_NAME=$(yq '.aws.profile // ""' {{.CONFIG_FILE}})
-          if [ -n "$AWS_PROFILE_NAME" ]; then
-            EXPORTED=$(AWS_PROFILE=$AWS_PROFILE_NAME aws configure export-credentials --format env-no-export)
-          else
-            EXPORTED=$(aws configure export-credentials --format env-no-export)
-          fi
+        # Prefer explicit aws.profile from config — IMDS only used as fallback when no profile
+        # is set (or set to "default"). Without this, EC2-hosted runners (Cloud9, Workshop Studio,
+        # any EC2-based bootstrap host) silently override the user's intended account by reading
+        # the instance role from IMDS, causing ACK controllers to provision in the wrong account.
+        AWS_PROFILE_NAME=$(yq '.aws.profile // ""' {{.CONFIG_FILE}})
+        AKI=""; SAK=""; ST=""
+        if [ -n "$AWS_PROFILE_NAME" ] && [ "$AWS_PROFILE_NAME" != "default" ]; then
+          printf '  Using AWS profile from config: %s\n' "$AWS_PROFILE_NAME"
+          EXPORTED=$(aws configure export-credentials --profile "$AWS_PROFILE_NAME" --format env-no-export)
           AKI=$(echo "$EXPORTED" | sed -n 's/^AWS_ACCESS_KEY_ID=//p')
           SAK=$(echo "$EXPORTED" | sed -n 's/^AWS_SECRET_ACCESS_KEY=//p')
           ST=$(echo  "$EXPORTED" | sed -n 's/^AWS_SESSION_TOKEN=//p')
+        else
+          TOKEN=$(curl -s -m 2 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null || true)
+          if [ -n "$TOKEN" ]; then
+            printf '  Using EC2 instance role credentials (IMDS)\n'
+            ROLE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/)
+            CREDS=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE)
+            AKI=$(echo "$CREDS" | jq -r .AccessKeyId)
+            SAK=$(echo "$CREDS" | jq -r .SecretAccessKey)
+            ST=$(echo  "$CREDS" | jq -r .Token)
+          else
+            printf '  Using AWS default profile\n'
+            EXPORTED=$(aws configure export-credentials --profile default --format env-no-export)
+            AKI=$(echo "$EXPORTED" | sed -n 's/^AWS_ACCESS_KEY_ID=//p')
+            SAK=$(echo "$EXPORTED" | sed -n 's/^AWS_SECRET_ACCESS_KEY=//p')
+            ST=$(echo  "$EXPORTED" | sed -n 's/^AWS_SESSION_TOKEN=//p')
+          fi
         fi
         [ -z "$AKI" ] || [ -z "$SAK" ] && echo "ERROR: empty credentials" && exit 1
         rm -f {{.ROOT_DIR}}/private/aws-creds.ini

--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -7,7 +7,7 @@ env:
   AWS_PAGER: ""
 
 vars:
-  GITOPS_ROOT: "{{.ROOT_DIR}}/../../gitops"
+  GITOPS_ROOT: "{{.ROOT_DIR}}/gitops"
   REQUIRED_CLIS: [kind, kubectl, helm, yq, aws]
   HUB_CLUSTER_NAME:
     sh: yq '.hub.clusterName' {{.CONFIG_FILE}}
@@ -70,7 +70,7 @@ vars:
   ACK_EC2_VERSION: "1.12.0"
   KRO_VERSION: "0.9.2"
   ARGOCD_VERSION:
-    sh: yq '.argocd.defaultVersion' {{.ROOT_DIR}}/../../gitops/addons/registry/core.yaml
+    sh: yq '.argocd.defaultVersion' {{.ROOT_DIR}}/gitops/addons/registry/core.yaml
   C_INFO:
     sh: printf '\033[1;36m'
   C_OK:

--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -246,6 +246,18 @@ tasks:
           exit 1
         fi
         printf '{{.C_STEP}}▸ IDC Identity Store: %s{{.C_RESET}}\n' "$STORE_ID"
+        # BYO IdC: if adminGroupId AND adminUserId are pre-populated in config,
+        # skip group/user/membership creation entirely (useful when IdC lives in
+        # a different AWS account and the bootstrap role lacks identitystore:Create* perms).
+        BYO_GROUP=$(yq '.identityCenter.adminGroupId // ""' {{.CONFIG_FILE}})
+        BYO_USER=$(yq '.identityCenter.adminUserId // ""' {{.CONFIG_FILE}})
+        if [ -n "$BYO_GROUP" ] && [ -n "$BYO_USER" ]; then
+          printf '{{.C_INFO}}  BYO IdC detected (adminGroupId + adminUserId set) — skipping group/user/membership creation{{.C_RESET}}\n'
+          printf '{{.C_OK}}✓ IDC admin group: %s{{.C_RESET}}\n' "$BYO_GROUP"
+          printf '{{.C_OK}}✓ IDC admin user:  %s{{.C_RESET}}\n' "$BYO_USER"
+          yq -i ".identityCenter.identityStoreId = \"$STORE_ID\"" {{.CONFIG_FILE}}
+          exit 0
+        fi
         # Create groups idempotently
         for GROUP_NAME in admin editor viewer; do
           EXISTING=$(aws identitystore list-groups --identity-store-id "$STORE_ID" --region {{.IDC_REGION}} \

--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -104,6 +104,7 @@ tasks:
       - task: kro:apply-rgds
       - task: idc:setup
       - task: hub:claim
+      - task: hub:wait-for-eks
       - task: hub:ingress
       - task: hub:cloudfront
       - task: hub:seed
@@ -407,6 +408,48 @@ tasks:
             external_secrets_service_account: external-secrets-sa
             amp_endpoint_url: ""
         EOF
+
+  hub:wait-for-eks:
+    desc: Wait for the EksclusterWithVpc instance to reach ACTIVE state and the EKS cluster to exist in AWS
+    vars:
+      WAIT_TIMEOUT_SEC: '{{.WAIT_TIMEOUT_SEC | default "1800"}}'
+      WAIT_INTERVAL_SEC: '{{.WAIT_INTERVAL_SEC | default "30"}}'
+    cmds:
+      - |
+        printf '{{.C_STEP}}▸ Waiting for EksclusterWithVpc/{{.HUB_CLUSTER_NAME}} to reach ACTIVE (max {{.WAIT_TIMEOUT_SEC}}s)...{{.C_RESET}}\n'
+        END=$(( $(date +%s) + {{.WAIT_TIMEOUT_SEC}} ))
+        LAST_STATE=""
+        while [ "$(date +%s)" -lt "$END" ]; do
+          STATE=$(kubectl get eksclusterwithvpc {{.HUB_CLUSTER_NAME}} -n {{.HUB_CLUSTER_NAME}} -o jsonpath='{.status.state}' 2>/dev/null || echo "")
+          if [ "$STATE" != "$LAST_STATE" ]; then
+            printf '{{.C_INFO}}  state: %s{{.C_RESET}}\n' "${STATE:-<empty>}"
+            LAST_STATE="$STATE"
+          fi
+          if [ "$STATE" = "ACTIVE" ]; then
+            break
+          fi
+          sleep {{.WAIT_INTERVAL_SEC}}
+        done
+        if [ "$STATE" != "ACTIVE" ]; then
+          printf '{{.C_ERR}}✗ EksclusterWithVpc not ACTIVE after {{.WAIT_TIMEOUT_SEC}}s (last state: %s){{.C_RESET}}\n' "$STATE"
+          kubectl get eksclusterwithvpc {{.HUB_CLUSTER_NAME}} -n {{.HUB_CLUSTER_NAME}} -o jsonpath='{.status.conditions}' 2>/dev/null || true
+          exit 1
+        fi
+        printf '{{.C_OK}}✓ EksclusterWithVpc ACTIVE{{.C_RESET}}\n'
+      - |
+        printf '{{.C_STEP}}▸ Verifying EKS cluster {{.HUB_CLUSTER_NAME}} exists in AWS...{{.C_RESET}}\n'
+        END=$(( $(date +%s) + 300 ))
+        while [ "$(date +%s)" -lt "$END" ]; do
+          EKS_STATUS=$(aws eks describe-cluster --name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'cluster.status' --output text 2>/dev/null || echo "")
+          if [ "$EKS_STATUS" = "ACTIVE" ]; then
+            printf '{{.C_OK}}✓ EKS cluster ACTIVE{{.C_RESET}}\n'
+            exit 0
+          fi
+          printf '{{.C_INFO}}  EKS status: %s{{.C_RESET}}\n' "${EKS_STATUS:-<not-found>}"
+          sleep 15
+        done
+        printf '{{.C_ERR}}✗ EKS cluster not ACTIVE in AWS after RGD reported ACTIVE{{.C_RESET}}\n'
+        exit 1
 
   hub:ingress:
     desc: Create ALB for hub ingress (waits for EKS to be ACTIVE)


### PR DESCRIPTION
## Context

Four independent UX/correctness fixes discovered while bootstrapping the `kind-kro-ack` provider from various environments (laptop, Cloud9, Workshop Studio EC2, cross-account orgs). They all touch `cluster-providers/kind-kro-ack/Taskfile.yaml` and the related config plumbing.

## Changes (4 commits)

1. **`fix: GITOPS_ROOT path resolution`** — `GITOPS_ROOT` was resolved relative to the wrong dir when `task` was invoked from a non-default location, breaking ArgoCD bootstrap.
2. **`feat: support BYO IdC (cross-account adminGroup/adminUser)`** — Allow `iam.identityCenter.{adminGroup,adminUser}` to point at an Identity Center instance in a different account than the one hosting the hub. Useful for orgs where IdC lives in the management account.
3. **`feat: add hub:wait-for-eks step to gate hub:ingress`** — The ingress task currently races EKS readiness on first bootstrap; add a small wait-for-eks step so `hub:ingress` only runs once the cluster is reachable.
4. **`fix: prefer aws.profile over IMDS when bootstrapping from EC2`** — When bootstrapping from any EC2-based runner (Cloud9, Workshop Studio, custom EC2), the previous logic silently picked the instance role via IMDS, overriding the user's intended account from `aws.profile` in the config file. The new logic uses the explicit profile when set (and not `"default"`), and only falls back to IMDS / default profile otherwise. Adds clear logging of which credential source was picked.

## Test

- ✅ Hub bootstrap from a workstation with `aws.profile: peeks-dr-test` correctly provisions in account 586794472760 (was previously using the EC2 role)
- ✅ `hub:ingress` no longer races on first bootstrap
- ✅ Cross-account IdC group resolves correctly
- ✅ `task` invoked from any cwd resolves `GITOPS_ROOT` correctly

## Scope

All commits scoped to `cluster-providers/kind-kro-ack/`. Extracted from PeEKS branch work on top of #642.

## Note on commit ordering

Commit 4 (profile-first) deliberately rewrites the credential block introduced earlier in `feature/platform-cluster-kro-ack`; the resolved version preserves IMDS as the documented fallback, with clear precedence logging.
