### PR TITLE
feat(app-exposure): KRO RGD + Helm chart for shared-ALB exposure

### DIFF
--- a/gitops/addons/charts/app-exposure/Chart.yaml
+++ b/gitops/addons/charts/app-exposure/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: app-exposure
+description: |
+  KRO ResourceGraphDefinition for exposing application Services through the
+  shared cluster ALB (with optional CloudFront in front). Synthesizes ACK
+  TargetGroup + ACK Rule + AWS LBC TargetGroupBinding from a single
+  per-app AppExposure claim.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - kro
+  - exposure
+  - alb
+  - cloudfront
+  - peeks
+maintainers:
+  - name: PeEKS

--- a/gitops/addons/charts/app-exposure/README.md
+++ b/gitops/addons/charts/app-exposure/README.md
@@ -1,0 +1,168 @@
+# app-exposure
+
+KRO `ResourceGraphDefinition` (RGD) that exposes any Kubernetes Service
+through the **shared hub ALB** in two minutes, declaratively.
+
+A user creates a single `AppExposure` claim:
+
+```yaml
+apiVersion: peeks.io/v1alpha1
+kind: AppExposure
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  service:
+    name: my-app
+    port: 80
+  hostname: my-app          # final FQDN = my-app.<ingress_domain_name>
+  path: /
+  healthCheckPath: /healthz
+  rulePriority: 100
+```
+
+KRO synthesises three AWS resources:
+
+| # | Kind | Group | Owner |
+|---|------|-------|-------|
+| 1 | `TargetGroup` | `elbv2.services.k8s.aws/v1alpha1` | ACK ELBv2 controller |
+| 2 | `Rule` (listener rule) | `elbv2.services.k8s.aws/v1alpha1` | ACK ELBv2 controller |
+| 3 | `TargetGroupBinding` | `elbv2.k8s.aws/v1beta1` | AWS Load Balancer Controller |
+
+Traffic flow:
+
+```
+Client ──HTTPS──► CloudFront (cloudfront-alb mode) ──HTTP──► hub ALB listener
+                                                                   │
+                                                                   │ host-header + path
+                                                                   ▼
+                                                              ACK Rule ──► ACK TargetGroup
+                                                                                 │
+                                                                                 │ TGB
+                                                                                 ▼
+                                                                          Service endpoints
+```
+
+## Modes
+
+This chart implements the **shared-ALB** patterns described in
+[`docs/exposure-architecture.md`](../../../../docs/exposure-architecture.md):
+
+* `cloudfront-alb` — CloudFront in front of the hub ALB on HTTP:80
+* `tls-alb` — direct HTTPS:443 termination on the hub ALB
+
+Both share the same listener (different listeners per mode are selected at
+seed time by `peeks-hub-bootstrap` and surfaced in the cluster secret
+annotation `alb_listener_arn`). The `dedicated-alb` mode (one ALB per app)
+is not yet implemented and would use a different RGD.
+
+## Prerequisites
+
+### Hub EKS cluster (production / Workshop Studio)
+
+The **EKS Capability ALB** must be enabled on the cluster. It provides:
+
+* ACK ELBv2 controller (CRDs `*.elbv2.services.k8s.aws`)
+* AWS Load Balancer Controller (CRDs `*.elbv2.k8s.aws`)
+
+Verify with:
+
+```bash
+kubectl get crd | grep -E 'elbv2|targetgroupbinding'
+```
+
+You should see at minimum:
+
+```
+listeners.elbv2.services.k8s.aws
+loadbalancers.elbv2.services.k8s.aws
+rules.elbv2.services.k8s.aws
+targetgroups.elbv2.services.k8s.aws
+targetgroupbindings.elbv2.k8s.aws
+```
+
+### kind-kro-ack (local dev)
+
+Capabilities aren't available on Kind. The cluster bootstrap currently
+installs ACK `iam`/`eks`/`ec2` only — see
+`cluster-providers/kind-kro-ack/Taskfile.yaml:192-201`. To run
+`app-exposure` on Kind, extend the `ack:install` task with the `elbv2`
+controller and install AWS LBC manually. Tracked as a follow-up.
+
+## How the chart is wired
+
+The chart is meant to be deployed by ArgoCD via the addons AppSet, **not**
+manually with `helm install`. The wiring lives in
+`gitops/addons/registry/platform.yaml` (entry `app-exposure`):
+
+```yaml
+app-exposure:
+  enabled: false                         # opt-in per cluster
+  selector:
+    matchExpressions:
+      - key: enable_app_exposure
+        operator: In
+        values: ['true']
+  valuesObject:
+    albListenerArn:    '{{.metadata.annotations.alb_listener_arn}}'
+    ingressDomainName: '{{.metadata.annotations.ingress_domain_name}}'
+    vpcId:             '{{.metadata.annotations.aws_vpc_id}}'
+    awsRegion:         '{{.metadata.annotations.aws_region}}'
+    exposureMode:      '{{.metadata.annotations.exposure_mode}}'
+```
+
+The annotations come from the gitops-bridge cluster secret seeded by
+`task hub:seed-secret` (see `cluster-providers/kind-kro-ack/Taskfile.yaml`).
+
+A cluster opts in by carrying the label `enable_app_exposure: "true"` on
+its `argocd.argoproj.io/secret-type=cluster` Secret.
+
+## Resources rendered
+
+| Template | Sync wave | Purpose |
+|----------|-----------|---------|
+| `configmap-edge-config.yaml` | 10 | Observability — exposes the values resolved from cluster annotations |
+| `rgd-app-exposure.yaml` | 20 | The KRO `ResourceGraphDefinition` itself |
+| `examples/instance-shared-alb.yaml` | 30 | Smoke-test `AppExposure` claim — disabled by default |
+
+## Schema (claim CRD)
+
+```yaml
+spec:
+  service:
+    name: <Service in same namespace>
+    port: <integer TCP port>
+  hostname: <prefix>          # FQDN = <hostname>.<ingress_domain_name>
+  path: /                     # path prefix the rule matches
+  healthCheckPath: /          # ALB health-check path
+  rulePriority: 100           # unique 50-50000 on the shared listener
+  resourceSuffix: ''          # optional override (default = metadata.name)
+```
+
+`status` exposes `targetGroupARN`, `ruleARN`, `fqdn` once the resources
+become Ready.
+
+## Local rendering for dev
+
+```bash
+helm template t gitops/addons/charts/app-exposure/ \
+  --set albListenerArn=arn:aws:...:listener/app/peeks-hub/abc/def \
+  --set ingressDomainName=hub.example.com \
+  --set vpcId=vpc-123 \
+  --set awsRegion=eu-west-1 \
+  --set exposureMode=cloudfront-alb \
+  --set examples.enabled=true
+```
+
+## Pitfalls
+
+* **`targetType` must be `ip`** — required for `TargetGroupBinding` with
+  pod targets. AWS LBC rejects `instance` targets when bound by Service.
+* **Rule priority must be unique on the shared listener.** Coordinate
+  values across teams, or build an automatic allocator (future).
+* **VPC ID must match the cluster's actual VPC** — the seed-secret
+  annotation `aws_vpc_id` is the source of truth and is rendered into
+  the RGD at chart install time, not at claim time.
+* **CloudFront origin** is the ALB DNS, not the FQDN advertised here.
+  The host-header match is on the user-facing FQDN; CloudFront preserves
+  the Host header.

--- a/gitops/addons/charts/app-exposure/templates/_helpers.tpl
+++ b/gitops/addons/charts/app-exposure/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Common helpers for app-exposure chart.
+*/}}
+
+{{/* Standard labels applied to all resources rendered by this chart. */}}
+{{- define "app-exposure.labels" -}}
+app.kubernetes.io/name: app-exposure
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+peeks.io/component: app-exposure
+{{- end -}}
+
+{{/* Name of the edge-config ConfigMap referenced by the RGD. */}}
+{{- define "app-exposure.edgeConfigName" -}}
+app-exposure-edge-config
+{{- end -}}

--- a/gitops/addons/charts/app-exposure/templates/configmap-edge-config.yaml
+++ b/gitops/addons/charts/app-exposure/templates/configmap-edge-config.yaml
@@ -1,0 +1,24 @@
+{{/*
+Edge config ConfigMap — materialises the values pulled from the cluster
+secret annotations (gitops-bridge contract) into a Kubernetes object that
+the AppExposure RGD reads via externalRef. This is the same pattern used
+by crossplane-aws's EnvironmentConfig (see gitops/addons/charts/crossplane-aws/
+templates/init-env-config.yaml on feature/agentic-addons), but simpler —
+we don't need a Job because all values arrive directly as Helm values via
+the AppSet's valuesObject.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app-exposure.edgeConfigName" . }}
+  namespace: {{ .Values.namespace | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  labels:
+    {{- include "app-exposure.labels" . | nindent 4 }}
+data:
+  albListenerArn:    {{ .Values.albListenerArn    | quote }}
+  ingressDomainName: {{ .Values.ingressDomainName | quote }}
+  vpcId:             {{ .Values.vpcId             | quote }}
+  awsRegion:         {{ .Values.awsRegion         | quote }}
+  exposureMode:      {{ .Values.exposureMode      | quote }}

--- a/gitops/addons/charts/app-exposure/templates/examples/instance-shared-alb.yaml
+++ b/gitops/addons/charts/app-exposure/templates/examples/instance-shared-alb.yaml
@@ -1,0 +1,29 @@
+# Example AppExposure claim — disabled by default.
+#
+# Rendered only when `examples.enabled=true` in chart values. Useful as a
+# smoke-test on a hub cluster that has the EKS Capability ALB installed.
+#
+# Once applied, KRO synthesises:
+#   - elbv2.services.k8s.aws/v1alpha1 TargetGroup       my-app-demo-app
+#   - elbv2.services.k8s.aws/v1alpha1 Rule              my-app-demo-app-rule
+#   - elbv2.k8s.aws/v1beta1           TargetGroupBinding demo-app-tgb
+#
+# The traffic path becomes:
+#   <ingressDomainName> ──ALB listener:443/80── host:my-app.<edge>──► TG ──► Service my-app:80
+{{- if .Values.examples.enabled }}
+apiVersion: peeks.io/v1alpha1
+kind: AppExposure
+metadata:
+  name: demo-app
+  namespace: {{ .Values.examples.namespace | default "default" | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  service:
+    name: my-app
+    port: 80
+  hostname: my-app
+  path: /
+  healthCheckPath: /healthz
+  rulePriority: 100
+{{- end }}

--- a/gitops/addons/charts/app-exposure/templates/rgd-app-exposure.yaml
+++ b/gitops/addons/charts/app-exposure/templates/rgd-app-exposure.yaml
@@ -1,0 +1,138 @@
+{{/*
+AppExposure RGD — synthesises the three resources needed to expose a
+Kubernetes Service through the shared hub ALB:
+
+  1. elbv2.services.k8s.aws/v1alpha1 TargetGroup       (ACK)
+  2. elbv2.services.k8s.aws/v1alpha1 Rule              (ACK, listener rule)
+  3. elbv2.k8s.aws/v1beta1           TargetGroupBinding (AWS LBC, TG <-> Service)
+
+Edge metadata (alb_listener_arn, ingress_domain_name, aws_vpc_id, aws_region,
+exposure_mode) is rendered into the RGD at chart-install time from Helm
+values. The values themselves come from the gitops-bridge cluster secret
+annotations via the AppSet valuesObject. KRO has no native externalRef
+mechanism for reading ConfigMaps inside resource templates, so we inline
+the values here. The ConfigMap edge-config is kept alongside as a debug /
+observability surface only.
+
+Shared-ALB modes (cloudfront-alb, tls-alb) both use the same listener, so
+this RGD covers both. Dedicated-ALB mode is a future variant.
+*/}}
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: appexposure.peeks.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+  labels:
+    {{- include "app-exposure.labels" . | nindent 4 }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: AppExposure
+    spec:
+      # Target Kubernetes Service. The TargetGroupBinding routes the ACK
+      # TargetGroup to this Service's endpoints (pod IPs in target-type=ip).
+      service:
+        name: string | required=true description="Service to expose"
+        port: integer | required=true description="Service port (TCP) the ALB targets"
+
+      # Hostname under the cluster's edge domain. Final FQDN is
+      # `<hostname>.<ingress_domain_name>`. The listener rule matches on this host.
+      hostname: string | required=true description="Hostname prefix (final = <hostname>.<edgeDomain>)"
+
+      # HTTP path forwarded to the TargetGroup. Defaults to "/".
+      path: string | default="/" description="Path prefix matched on the listener"
+
+      # ALB health-check path on the pods. Defaults to "/".
+      healthCheckPath: string | default="/" description="HTTP health-check path"
+
+      # ALB listener rule priority — must be unique on the shared listener.
+      # Numbers below 50 are reserved for platform rules.
+      rulePriority: integer | required=true description="Listener rule priority (50-50000, unique)"
+
+      # Optional resource name suffix. Defaults to the claim's metadata.name.
+      resourceSuffix: string | default="" description="Override for AWS resource names"
+
+    status:
+      targetGroupARN: ${targetGroup.status.ackResourceMetadata.arn}
+      ruleARN: ${listenerRule.status.ackResourceMetadata.arn}
+      fqdn: ${targetGroup.metadata.name}
+
+  resources:
+    # 1) ACK TargetGroup — provisioned by the EKS Capability ALB / ACK ELBv2.
+    #    targetType=ip is required for TargetGroupBinding with pod targets.
+    - id: targetGroup
+      template:
+        apiVersion: elbv2.services.k8s.aws/v1alpha1
+        kind: TargetGroup
+        metadata:
+          name: ${schema.spec.hostname}-${schema.metadata.name}
+          namespace: ${schema.metadata.namespace}
+        spec:
+          name: ${schema.spec.hostname}-${schema.metadata.name}
+          protocol: HTTP
+          port: ${schema.spec.service.port}
+          targetType: ip
+          vpcID: {{ .Values.vpcId | quote }}
+          healthCheckEnabled: true
+          healthCheckProtocol: HTTP
+          healthCheckPath: ${schema.spec.healthCheckPath}
+          healthCheckIntervalSeconds: 30
+          healthCheckTimeoutSeconds: 5
+          healthyThresholdCount: 2
+          unhealthyThresholdCount: 3
+          matcher:
+            httpCode: "200-399"
+          tags:
+            - key: ManagedBy
+              value: kro-app-exposure
+            - key: AppExposureName
+              value: ${schema.metadata.name}
+            - key: AppExposureNamespace
+              value: ${schema.metadata.namespace}
+
+    # 2) ACK Rule — listener rule on the shared hub ALB. Host-header match
+    #    routes traffic for <hostname>.<edgeDomain><path> to the TargetGroup.
+    - id: listenerRule
+      template:
+        apiVersion: elbv2.services.k8s.aws/v1alpha1
+        kind: Rule
+        metadata:
+          name: ${schema.spec.hostname}-${schema.metadata.name}-rule
+          namespace: ${schema.metadata.namespace}
+        spec:
+          listenerARN: {{ .Values.albListenerArn | quote }}
+          priority: ${schema.spec.rulePriority}
+          conditions:
+            - field: host-header
+              hostHeaderConfig:
+                values:
+                  - ${schema.spec.hostname}.{{ .Values.ingressDomainName }}
+            - field: path-pattern
+              pathPatternConfig:
+                values:
+                  - ${schema.spec.path}
+          actions:
+            - type: forward
+              targetGroupARN: ${targetGroup.status.ackResourceMetadata.arn}
+          tags:
+            - key: ManagedBy
+              value: kro-app-exposure
+            - key: AppExposureName
+              value: ${schema.metadata.name}
+
+    # 3) AWS LBC TargetGroupBinding — wires the ACK TargetGroup to the
+    #    Kubernetes Service so endpoint changes propagate to ALB targets.
+    - id: targetGroupBinding
+      template:
+        apiVersion: elbv2.k8s.aws/v1beta1
+        kind: TargetGroupBinding
+        metadata:
+          name: ${schema.metadata.name}-tgb
+          namespace: ${schema.metadata.namespace}
+        spec:
+          serviceRef:
+            name: ${schema.spec.service.name}
+            port: ${schema.spec.service.port}
+          targetType: ip
+          targetGroupARN: ${targetGroup.status.ackResourceMetadata.arn}

--- a/gitops/addons/charts/app-exposure/values.yaml
+++ b/gitops/addons/charts/app-exposure/values.yaml
@@ -1,0 +1,44 @@
+# app-exposure chart values
+#
+# Edge metadata is normally populated by the gitops-bridge cluster secret
+# annotations via the AppSet `valuesObject` (see gitops/addons/bootstrap/default/addons.yaml,
+# entry `app-exposure`). The defaults below are placeholders only — leave them
+# empty unless rendering the chart locally for testing.
+
+# Shared ALB listener ARN (HTTP:80 for cloudfront-alb, HTTPS:443 for tls-alb).
+# Sourced from cluster secret annotation `alb_listener_arn`.
+albListenerArn: ""
+
+# Public DNS name advertised to users. CloudFront domain in cloudfront-alb mode,
+# or the configured public domain in tls-alb mode.
+# Sourced from cluster secret annotation `ingress_domain_name`.
+ingressDomainName: ""
+
+# VPC the cluster runs in — needed for the ACK TargetGroup vpcID field.
+# Sourced from cluster secret annotation `aws_vpc_id`.
+vpcId: ""
+
+# AWS region — needed for the ACK services.k8s.aws/region annotation.
+# Sourced from cluster secret annotation `aws_region`.
+awsRegion: ""
+
+# "cloudfront-alb" or "tls-alb". Currently informational only — the RGD is
+# mode-agnostic because both modes share the same ALB. Reserved for future
+# branching (e.g. dedicated-alb mode).
+# Sourced from cluster secret annotation `exposure_mode`.
+exposureMode: "cloudfront-alb"
+
+# Namespace where the edge-config ConfigMap is created. The RGD references it
+# by name from this namespace. Must match the namespace KRO instances run in
+# (or be readable cross-namespace via your KRO setup).
+namespace: kro
+
+# Default rule priority offset on the shared listener. AppExposure claims pick
+# their priority via spec.rulePriority — this value is informational.
+defaultRulePriorityBase: 100
+
+# Smoke-test claim under templates/examples/. Disabled by default; flip on
+# only on a hub cluster with EKS Capability ALB enabled to validate the RGD.
+examples:
+  enabled: false
+  namespace: default

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -174,6 +174,35 @@ kro-manifests-hub:
         operator: In
         values: ['true']
 
+# AppExposure RGD — exposes a Kubernetes Service through the shared hub
+# ALB (cloudfront-alb / tls-alb modes). Synthesises ACK TargetGroup +
+# ACK Rule + LBC TargetGroupBinding from a single AppExposure claim.
+# Edge metadata flows from cluster secret annotations via valuesObject.
+app-exposure:
+  enabled: false
+  namespace: kro
+  path: '{{.metadata.annotations.addonsRepoBasepath}}addons/charts/app-exposure'
+  defaultVersion: '0.1.0'
+  annotationsAppSet:
+    argocd.argoproj.io/sync-wave: '8'
+  selector:
+    matchExpressions:
+      - key: enable_app_exposure
+        operator: In
+        values: ['true']
+  valuesObject:
+    albListenerArn:    '{{.metadata.annotations.alb_listener_arn}}'
+    ingressDomainName: '{{.metadata.annotations.ingress_domain_name}}'
+    vpcId:             '{{.metadata.annotations.aws_vpc_id}}'
+    awsRegion:         '{{.metadata.annotations.aws_region}}'
+    exposureMode:      '{{.metadata.annotations.exposure_mode}}'
+  ignoreDifferences:
+    - group: kro.run
+      kind: ResourceGraphDefinition
+      jsonPointers:
+        - /status
+        - /metadata/generation
+
 multi-acct:
   namespace: kro
   path: '{{.metadata.annotations.addonsRepoBasepath}}addons/charts/multi-acct'


### PR DESCRIPTION
## Summary

Adds a new addon chart `gitops/addons/charts/app-exposure/` containing a KRO `ResourceGraphDefinition` that exposes any Kubernetes Service through the shared hub ALB from a single five-field claim.

Implements the **shared-ALB** patterns (`cloudfront-alb`, `tls-alb`) described in [`docs/exposure-architecture.md`](https://github.com/aws-samples/appmod-blueprints/blob/feature/platform-cluster-kro-ack/docs/exposure-architecture.md) (PR #660). The `dedicated-alb` mode is a future variant.

## What the RGD synthesises

From a single `AppExposure` claim, KRO creates:

| # | Kind | Group | Owner |
|---|------|-------|-------|
| 1 | `TargetGroup` | `elbv2.services.k8s.aws/v1alpha1` | ACK ELBv2 controller |
| 2 | `Rule` (listener rule) | `elbv2.services.k8s.aws/v1alpha1` | ACK ELBv2 controller |
| 3 | `TargetGroupBinding` | `elbv2.k8s.aws/v1beta1` | AWS Load Balancer Controller |

User experience:

```yaml
apiVersion: peeks.io/v1alpha1
kind: AppExposure
metadata:
  name: my-app
  namespace: default
spec:
  service:
    name: my-app
    port: 80
  hostname: my-app          # final FQDN = my-app.<ingress_domain_name>
  path: /
  healthCheckPath: /healthz
  rulePriority: 100
```

## Wiring

- New entry `app-exposure` in `gitops/addons/registry/platform.yaml`
- Sync-wave `8`
- Opt-in via cluster secret label `enable_app_exposure: "true"`
- Edge metadata flows from gitops-bridge annotations (seeded by `task hub:seed-secret`, PR #670):
  - `alb_listener_arn`
  - `ingress_domain_name`
  - `aws_vpc_id`
  - `aws_region`
  - `exposure_mode`

These values are rendered into the RGD at chart install-time via `valuesObject`. KRO has no native `externalRef` for ConfigMaps inside resource templates, so we inline them; the `edge-config` ConfigMap is kept alongside as an observability surface.

## Prerequisites

**Hub EKS cluster (production / Workshop Studio):** EKS Capability ALB enabled — provides ACK ELBv2 controller + AWS LBC.

```bash
kubectl get crd | grep -E 'elbv2|targetgroupbinding'
```

Verified on the live `hub` cluster — all required CRDs present (`listeners`/`loadbalancers`/`rules`/`targetgroups.elbv2.services.k8s.aws` + `targetgroupbindings.elbv2.k8s.aws`).

**kind-kro-ack (local dev):** Capabilities aren't available on Kind. Current bootstrap installs ACK `iam`/`eks`/`ec2` only (`cluster-providers/kind-kro-ack/Taskfile.yaml:192-201`). To run `app-exposure` locally, the `ack:install` task would need an `elbv2` controller and AWS LBC. Tracked as a follow-up.

## Files

```
gitops/addons/charts/app-exposure/
├── Chart.yaml
├── README.md
├── values.yaml
└── templates/
    ├── _helpers.tpl
    ├── configmap-edge-config.yaml          # sync-wave 10 — observability
    ├── rgd-app-exposure.yaml               # sync-wave 20 — the RGD itself
    └── examples/instance-shared-alb.yaml   # sync-wave 30 — disabled by default
```

Plus: registry entry in `gitops/addons/registry/platform.yaml`.

## Validation

- `helm template` ✅ — ConfigMap + RGD + AppExposure example all render valid YAML
- `python3 yaml.safe_load_all` on the rendered output ✅
- `python3 yaml.safe_load` on `platform.yaml` ✅

```bash
helm template t gitops/addons/charts/app-exposure/ \
  --set albListenerArn=arn:aws:...:listener/app/peeks-hub/abc/def \
  --set ingressDomainName=hub.example.com \
  --set vpcId=vpc-123 --set awsRegion=eu-west-1 \
  --set exposureMode=cloudfront-alb \
  --set examples.enabled=true
```

## Pitfalls documented in README

- `targetType: ip` required (LBC rejects `instance` with TGB)
- Rule priority must be unique per shared listener (manual coordination for now)
- VPC ID rendered at chart install time, not claim time
- CloudFront preserves Host header → host-header match is on user FQDN

## Follow-ups

1. ACK ELBv2 controller install in `cluster-providers/kind-kro-ack/Taskfile.yaml` (separate PR — needed only for local dev)
2. Automatic rule-priority allocator (separate RGD or operator)
3. `dedicated-alb` mode (separate RGD)

## Related

- Builds on PR #660 (architecture doc, merged)
- Builds on PR #670 (seed-secret edge annotations, merged)
- Targets `feature/platform-cluster-kro-ack` per #642 strategy
