### PR TITLE
fix(install): Grafana SAML groups mapper + providers idempotency

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -205,6 +205,7 @@ tasks:
   crossplane:providers:
     status:
       - kubectl get providers.pkg.crossplane.io provider-aws-iam -o jsonpath='{.status.conditions[?(@.type=="Healthy")].status}' 2>/dev/null | grep -q True
+      - kubectl get providerconfig.kubernetes.crossplane.io default 2>/dev/null
     vars:
       K8S_PROVIDER_VERSION:
         sh: yq '.crossplane-base.valuesObject.providers.kubernetes.version // "v1.2.1"' {{.GITOPS_ROOT}}/addons/registry/platform.yaml

--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -580,6 +580,18 @@ data:
             "attribute.nameformat": "Unspecified",
             "attribute.name": "role"
           }
+        },
+        {
+          "name": "groups",
+          "protocol": "saml",
+          "protocolMapper": "saml-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "Unspecified",
+            "attribute.name": "groups",
+            "single": "false",
+            "full.path": "false"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
Two issues that required manual intervention after a clean `task install`. Both are now codified so the next install works out of the box.

### 1. Grafana SAML login fails with Keycloak error

**Symptom:** Clicking "Sign in with SAML" on the AMG Grafana workspace redirects to Keycloak and shows a "We are sorry..." error page.

**Root cause:** The `grafana-client-payload.json` in the Keycloak config Job was missing the `groups` SAML mapper. Without it, Keycloak doesn't include group memberships in the SAML assertion, so AMG can't map users to Grafana roles and rejects the login.

**Fix:** Add `saml-group-membership-mapper` to the `protocolMappers` array in `grafana-client-payload.json`, alongside the existing `role list` and `email` mappers.

### 2. `crossplane:providers` task not idempotent for kubernetes ProviderConfig

**Symptom:** On a fresh install, `task install` fails the first time at `crossplane:providers` (kubernetes ProviderConfig CRD not ready yet — expected). Re-running `task install` skips the whole task because `provider-aws-iam Healthy=True` passes the status check — but the kubernetes ProviderConfig was never created. This leaves `platformcluster/hub` stuck at `Ready=False` indefinitely, and `hub:seed` times out after 1800s.

**Root cause:** The `status:` block only checked `provider-aws-iam Healthy=True`. The kubernetes ProviderConfig is a separate resource that the task creates after the providers are healthy, but the status check doesn't verify it exists.

**Fix:** Add a second status condition: `kubectl get providerconfig.kubernetes.crossplane.io default 2>/dev/null`. The task now re-runs until both the IAM provider is healthy AND the kubernetes ProviderConfig exists.

## Test plan
- [ ] Fresh `task install` — Keycloak config Job creates the Grafana SAML client with the groups mapper included
- [ ] Grafana SAML login works end-to-end without manual Keycloak intervention
- [ ] `task install` re-run after first-run providers failure correctly re-applies the kubernetes ProviderConfig
- [ ] `platformcluster/hub` reaches `Ready=True` without manual `kubectl apply`