### PR TITLE
fix(kind-kro-ack): remove duplicated admin_role_name in seed-secret

### DIFF
--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -911,7 +911,6 @@ tasks:
             aws_region: "AWS_REGION_VAL"
             aws_vpc_id: "VPC_ID_VAL"
             admin_role_name: "ADMIN_ROLE_NAME_VAL"
-            admin_role_name: "ADMIN_ROLE_NAME_VAL"
             resource_prefix: "RESOURCE_PREFIX_VAL"
             # Ingress / edge metadata (gitops-bridge contract — consumed by AppSets)
             ingress_domain_name: "EDGE_DOMAIN"


### PR DESCRIPTION
## Summary

One-liner cleanup. Commit 7ee9fe62 (`fix: add admin_role_name annotation to seed-secret, use missingkey=zero in abstractions-kro`) added the `admin_role_name` annotation to the `hub:seed-secret` heredoc but inserted it twice on consecutive lines.

```yaml
            aws_vpc_id: "VPC_ID_VAL"
            admin_role_name: "ADMIN_ROLE_NAME_VAL"
            admin_role_name: "ADMIN_ROLE_NAME_VAL"   # ← duplicate, drop
            resource_prefix: "RESOURCE_PREFIX_VAL"
```

YAML accepts duplicate keys silently (last wins), so this is benign at runtime — the cluster secret is rendered correctly. But:

- `yamllint` / `kubeval` / strict parsers warn or fail
- The rendered Secret carries a confusing duplicate annotation
- Future readers of the heredoc may add changes to the wrong line

This PR drops the second occurrence. No behaviour change.

## Verification

```bash
$ grep -c '^[[:space:]]*admin_role_name:' cluster-providers/kind-kro-ack/Taskfile.yaml
1   # was 2
```
