### PR TITLE
fix(observability): guard spoke scrapers against missing/None securityGroupIds

### DIFF
--- a/gitops/addons/charts/observability-aws/templates/spoke-scrapers.yaml
+++ b/gitops/addons/charts/observability-aws/templates/spoke-scrapers.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.spokeScrapers }}
 {{- range $clusterName, $cluster := .Values.spokeScrapers }}
-{{- if $cluster.clusterArn }}
+{{- if and $cluster.clusterArn (ne (default "" $cluster.securityGroupIds) "") (ne $cluster.securityGroupIds "None") }}
 ---
 apiVersion: amp.aws.upbound.io/v1beta1
 kind: Scraper


### PR DESCRIPTION
Prevents AMP scrapers from being created with invalid security group IDs when spoke cluster annotations are not yet populated.

The template now skips scraper generation when securityGroupIds is empty or None. ArgoCD auto-sync will create the scrapers once valid values are available via the ApplicationSet annotation re-render.