### PR TITLE
fix: remove gitlab mattermost, increase helm timeout & fix AWS provider constraint

### DIFF
--- a/gitops/addons/charts/gitlab/templates/gitlab.yaml
+++ b/gitops/addons/charts/gitlab/templates/gitlab.yaml
@@ -108,10 +108,6 @@ spec:
             redis_exporter['enable'] = false
             postgres_exporter['enable'] = false
 
-            # Disable Mattermost
-            mattermost['enable'] = false
-            mattermost_nginx['enable'] = false
-
             # Disable Kubernetes integration
             # gitlab_kas['enable'] = false
 

--- a/platform/infra/terraform/cluster/versions.tf
+++ b/platform/infra/terraform/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.42.0"
+      version = ">= 6.42.0, <= 6.46.0"
     }
   }
 

--- a/platform/infra/terraform/cluster/versions.tf
+++ b/platform/infra/terraform/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23.0, <= 6.34.0"
+      version = ">= 6.42.0"
     }
   }
 

--- a/platform/infra/terraform/common/gitlab_infra/main.tf
+++ b/platform/infra/terraform/common/gitlab_infra/main.tf
@@ -207,7 +207,7 @@ resource "helm_release" "gitlab" {
 
   name       = "gitlab"
   chart      = "${path.module}/../../../../../gitops/addons/charts/gitlab"
-  timeout    = 600
+  timeout    = 1200
   values     = [local.gitlab_values]
   create_namespace = false
   namespace  = kubernetes_namespace.gitlab.metadata[0].name

--- a/platform/infra/terraform/common/gitlab_infra/versions.tf
+++ b/platform/infra/terraform/common/gitlab_infra/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.42.0"
+      version = ">= 6.42.0, <= 6.46.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/platform/infra/terraform/common/gitlab_infra/versions.tf
+++ b/platform/infra/terraform/common/gitlab_infra/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23.0, <= 6.34.0"
+      version = ">= 6.42.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/platform/infra/terraform/common/versions.tf
+++ b/platform/infra/terraform/common/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.42.0"
+      version = ">= 6.42.0, <= 6.46.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/platform/infra/terraform/common/versions.tf
+++ b/platform/infra/terraform/common/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23.0, <= 6.34.0"
+      version = ">= 6.42.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/platform/infra/terraform/identity-center/versions.tf
+++ b/platform/infra/terraform/identity-center/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.42.0"
+      version = ">= 6.42.0, <= 6.46.0"
     }
   }
 

--- a/platform/infra/terraform/identity-center/versions.tf
+++ b/platform/infra/terraform/identity-center/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.23.0, <= 6.34.0"
+      version = ">= 6.42.0"
     }
   }
 


### PR DESCRIPTION
## Changes

### 1. Remove GitLab Mattermost
Removes unused Mattermost integration from GitLab deployment.

### 2. Increase Helm release timeout (600s → 1200s)
GitLab pod requires 180s initial delay + image pull + startup time. On fresh accounts this consistently exceeds the 600s timeout, causing `context deadline exceeded` on all 3 deploy attempts.

### 3. Fix AWS provider version constraint
**Root cause:** The EKS Terraform module `~> 21.15` resolved to version `21.22.0`, which requires `hashicorp/aws >= 6.42`. The previous constraint (`>= 6.23.0, <= 6.34.0`) was incompatible — introduced by commit `11b58c48` ("pin aws tf provider", Mar 5 2026) after the EKS module had already been bumped to `~> 21.15` in commit `a1e12024` (Feb 4 2026).

**Fix:** Updated the AWS provider constraint from `>= 6.23.0, <= 6.34.0` → `>= 6.42.0, <= 6.46.0` in all 4 files:
- `platform/infra/terraform/cluster/versions.tf`
- `platform/infra/terraform/common/versions.tf`
- `platform/infra/terraform/common/gitlab_infra/versions.tf`
- `platform/infra/terraform/identity-center/versions.tf`

The upper bound is pinned to `6.46.0` (latest available at time of fix) to maintain version stability.

## Testing
- [ ] Redeploy test event on fresh account to verify GitLab starts within 1200s timeout
- [ ] Verify `terraform init` resolves provider correctly with new constraint