### PR TITLE
feat(app-exposure): enable addon on hub + path-mode routing for CloudFront workshop-studio

### DIFF
--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -884,8 +884,62 @@ tasks:
         printf '    ingress_domain_name = %s\n' "{{.EDGE_DOMAIN}}"
         printf '    exposure_mode       = %s\n' "{{.EXPOSURE_MODE}}"
         printf '    alb_listener_arn    = %s\n' "{{.ALB_LISTENER_ARN}}"
+      # Idempotent seed: create full secret on first run, patch only managed fields on re-run.
+      # Rationale: other controllers (e.g. KRO RGDs, addon registries) may add labels like
+      # enable_<addon>=true to the same secret. A blanket `kubectl apply` of the full manifest
+      # would clobber any label/annotation not present in our template. Splitting create vs.
+      # update keeps the task re-runnable without trampling third-party metadata.
       - |
-        cat <<'EOF' | sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g; s|CLUSTER_ARN|{{.CLUSTER_ARN}}|g; s|ARGOCD_ROLE_ARN|{{.ARGOCD_ROLE_ARN}}|g; s|REPO_URL|{{.REPO_URL}}|g; s|REPO_REVISION|{{.REPO_REVISION}}|g; s|REPO_BASEPATH|{{.REPO_BASEPATH}}/|g; s|EXPOSURE_MODE|{{.EXPOSURE_MODE}}|g; s|EDGE_DOMAIN|{{.EDGE_DOMAIN}}|g; s|ALB_LISTENER_ARN|{{.ALB_LISTENER_ARN}}|g; s|VPC_ID_VAL|{{.VPC_ID}}|g; s|AWS_REGION_VAL|{{.AWS_REGION}}|g; s|AWS_ACCOUNT_ID_VAL|{{.AWS_ACCOUNT_ID}}|g; s|RESOURCE_PREFIX_VAL|{{.RESOURCE_PREFIX}}|g; s|INGRESS_SECURITY_GROUPS_VAL|{{.INGRESS_SECURITY_GROUPS}}|g; s|ADMIN_ROLE_NAME_VAL|{{.ADMIN_ROLE_NAME}}|g" | KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl apply -f -
+        export KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig
+        if kubectl -n argocd get secret {{.HUB_CLUSTER_NAME}} >/dev/null 2>&1; then
+          printf '{{.C_INFO}}  Secret {{.HUB_CLUSTER_NAME}} exists — patching managed fields only (preserving foreign labels/annotations){{.C_RESET}}\n'
+
+          # Annotations owned by this task (gitops-bridge contract + PeEKS exposure metadata).
+          # --overwrite updates these specific keys; foreign annotations are untouched.
+          kubectl -n argocd annotate secret {{.HUB_CLUSTER_NAME}} --overwrite \
+            addonsRepoURL="{{.REPO_URL}}" \
+            addonsRepoRevision="{{.REPO_REVISION}}" \
+            addonsRepoBasepath="{{.REPO_BASEPATH}}/" \
+            fleetRepoURL="{{.REPO_URL}}" \
+            fleetRepoRevision="{{.REPO_REVISION}}" \
+            fleetRepoBasepath="{{.REPO_BASEPATH}}/" \
+            aws_cluster_name="{{.HUB_CLUSTER_NAME}}" \
+            aws_account_id="{{.AWS_ACCOUNT_ID}}" \
+            aws_region="{{.AWS_REGION}}" \
+            aws_vpc_id="{{.VPC_ID}}" \
+            admin_role_name="{{.ADMIN_ROLE_NAME}}" \
+            resource_prefix="{{.RESOURCE_PREFIX}}" \
+            ingress_domain_name="{{.EDGE_DOMAIN}}" \
+            ingress_name="{{.RESOURCE_PREFIX}}-hub-ingress" \
+            ingress_security_groups="{{.INGRESS_SECURITY_GROUPS}}" \
+            alb_controller_mode="oss" \
+            exposure_mode="{{.EXPOSURE_MODE}}" \
+            alb_listener_arn="{{.ALB_LISTENER_ARN}}"
+
+          # Labels owned by this task. NOTE: enable_* labels are deliberately NOT managed
+          # here — they are owned by the KRO eks-cluster RGD (rg-eks.yaml argocdSecret resource)
+          # and/or addon registries. Touching them here would create a tug-of-war.
+          kubectl -n argocd label secret {{.HUB_CLUSTER_NAME}} --overwrite \
+            argocd.argoproj.io/secret-type=cluster \
+            environment=control-plane \
+            fleet_member=control-plane \
+            enable_kroack_abstractions=true \
+            exposure_mode="{{.EXPOSURE_MODE}}"
+
+          # Refresh stringData (server/config may change if ARGOCD_ROLE_ARN evolves).
+          kubectl -n argocd patch secret {{.HUB_CLUSTER_NAME}} --type=merge -p "$(cat <<EOF
+        {
+          "stringData": {
+            "name": "{{.HUB_CLUSTER_NAME}}",
+            "server": "{{.CLUSTER_ARN}}",
+            "config": "{\"awsAuthConfig\":{\"clusterName\":\"{{.HUB_CLUSTER_NAME}}\",\"roleARN\":\"{{.ARGOCD_ROLE_ARN}}\"},\"tlsClientConfig\":{\"insecure\":false}}"
+          }
+        }
+        EOF
+        )"
+        else
+          printf '{{.C_INFO}}  Secret {{.HUB_CLUSTER_NAME}} absent — creating from full manifest{{.C_RESET}}\n'
+          cat <<'EOF' | sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g; s|CLUSTER_ARN|{{.CLUSTER_ARN}}|g; s|ARGOCD_ROLE_ARN|{{.ARGOCD_ROLE_ARN}}|g; s|REPO_URL|{{.REPO_URL}}|g; s|REPO_REVISION|{{.REPO_REVISION}}|g; s|REPO_BASEPATH|{{.REPO_BASEPATH}}/|g; s|EXPOSURE_MODE|{{.EXPOSURE_MODE}}|g; s|EDGE_DOMAIN|{{.EDGE_DOMAIN}}|g; s|ALB_LISTENER_ARN|{{.ALB_LISTENER_ARN}}|g; s|VPC_ID_VAL|{{.VPC_ID}}|g; s|AWS_REGION_VAL|{{.AWS_REGION}}|g; s|AWS_ACCOUNT_ID_VAL|{{.AWS_ACCOUNT_ID}}|g; s|RESOURCE_PREFIX_VAL|{{.RESOURCE_PREFIX}}|g; s|INGRESS_SECURITY_GROUPS_VAL|{{.INGRESS_SECURITY_GROUPS}}|g; s|ADMIN_ROLE_NAME_VAL|{{.ADMIN_ROLE_NAME}}|g" | kubectl apply -f -
         apiVersion: v1
         kind: Secret
         type: Opaque
@@ -926,6 +980,7 @@ tasks:
           server: "CLUSTER_ARN"
           config: '{"awsAuthConfig":{"clusterName":"CLUSTER_NAME","roleARN":"ARGOCD_ROLE_ARN"},"tlsClientConfig":{"insecure":false}}'
         EOF
+        fi
       - rm -f {{.ROOT_DIR}}/private/hub-kubeconfig
 
   hub:apply-root-appset:

--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -118,9 +118,7 @@ tasks:
       - kind create cluster --name {{.KIND_CLUSTER_NAME}} --config kind.yaml --kubeconfig {{.KUBECONFIG}}
 
   credentials:setup:
-    desc: Create AWS credentials secret (skips if exists)
-    status:
-      - kubectl -n {{.ACK_NAMESPACE}} get secret aws-credentials 2>/dev/null
+    desc: Create or refresh AWS credentials secret (always re-runs to avoid stale STS tokens)
     cmds:
       - task: credentials:refresh
 

--- a/gitops/addons/charts/app-exposure/templates/rgd-app-exposure.yaml
+++ b/gitops/addons/charts/app-exposure/templates/rgd-app-exposure.yaml
@@ -50,12 +50,25 @@ spec:
       # Numbers below 50 are reserved for platform rules.
       rulePriority: integer | required=true description="Listener rule priority (50-50000, unique)"
 
+      # Routing mode for the listener rule:
+      #   - "host" (default): match host-header `<hostname>.<edgeDomain>` AND path
+      #     Use this when the edge presents real subdomains (prod-public, internal-only with split-horizon DNS).
+      #   - "path": match path only, no host condition
+      #     Use this when the edge presents a single shared host — typically Workshop Studio
+      #     (CloudFront single distribution) where every app shares `<cf-domain>` and routing is
+      #     differentiated by URL path (/grafana, /keycloak, ...).
+      routingMode: string | default="host" enum="host,path" description="Listener match mode - host+path or path-only"
+
       # Optional resource name suffix. Defaults to the claim's metadata.name.
       resourceSuffix: string | default="" description="Override for AWS resource names"
 
     status:
       targetGroupARN: ${targetGroup.status.ackResourceMetadata.arn}
-      ruleARN: ${listenerRule.status.ackResourceMetadata.arn}
+      # Legacy field — populated in host-mode only. Kept for CRD backward compatibility.
+      ruleARN: ${listenerRuleHost.status.ackResourceMetadata.arn}
+      # New per-mode fields. Only one is populated at runtime depending on routingMode.
+      ruleARNHost: ${listenerRuleHost.status.ackResourceMetadata.arn}
+      ruleARNPath: ${listenerRulePath.status.ackResourceMetadata.arn}
       fqdn: ${targetGroup.metadata.name}
 
   resources:
@@ -91,9 +104,11 @@ spec:
             - key: AppExposureNamespace
               value: ${schema.metadata.namespace}
 
-    # 2) ACK Rule — listener rule on the shared hub ALB. Host-header match
-    #    routes traffic for <hostname>.<edgeDomain><path> to the TargetGroup.
-    - id: listenerRule
+    # 2a) ACK Rule — host-mode: match `<hostname>.<edgeDomain>` AND path.
+    #     Used in prod-public / internal-only modes with real subdomains.
+    - id: listenerRuleHost
+      includeWhen:
+        - ${schema.spec.routingMode == "host"}
       template:
         apiVersion: elbv2.services.k8s.aws/v1alpha1
         kind: Rule
@@ -108,6 +123,35 @@ spec:
               hostHeaderConfig:
                 values:
                   - ${schema.spec.hostname}.{{ .Values.ingressDomainName }}
+            - field: path-pattern
+              pathPatternConfig:
+                values:
+                  - ${schema.spec.path}
+          actions:
+            - type: forward
+              targetGroupARN: ${targetGroup.status.ackResourceMetadata.arn}
+          tags:
+            - key: ManagedBy
+              value: kro-app-exposure
+            - key: AppExposureName
+              value: ${schema.metadata.name}
+
+    # 2b) ACK Rule — path-mode: match path only, no host condition.
+    #     Used in workshop-studio (single-domain CloudFront) where every app
+    #     shares the same edge host and routing is differentiated by URL path.
+    - id: listenerRulePath
+      includeWhen:
+        - ${schema.spec.routingMode == "path"}
+      template:
+        apiVersion: elbv2.services.k8s.aws/v1alpha1
+        kind: Rule
+        metadata:
+          name: ${schema.spec.hostname}-${schema.metadata.name}-rule
+          namespace: ${schema.metadata.namespace}
+        spec:
+          listenerARN: {{ .Values.albListenerArn | quote }}
+          priority: ${schema.spec.rulePriority}
+          conditions:
             - field: path-pattern
               pathPatternConfig:
                 values:

--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -724,21 +724,24 @@ metadata:
   name: backstage
   namespace: backstage
   annotations:
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "backstage-server"
-    nginx.ingress.kubernetes.io/session-cookie-expires: "86400"
-    nginx.ingress.kubernetes.io/session-cookie-max-age: "86400"
-    nginx.ingress.kubernetes.io/session-cookie-path: "/backstage"
+    argocd.argoproj.io/sync-wave: "10"
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    alb.ingress.kubernetes.io/healthcheck-path: /healthcheck
+    alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.global.ingress_name | default "platform" }}
+    # ALB URL rewrite (LBC v2.14+) — strip /backstage prefix before forwarding to backend.
+    # Equivalent of legacy nginx `rewrite-target: /$2` on path /backstage(/|$)(.*).
+    # Examples: /backstage -> /, /backstage/ -> /, /backstage/static/foo.png -> /static/foo.png
+    alb.ingress.kubernetes.io/transforms.backstage: |
+      [{"type":"url-rewrite","urlRewriteConfig":{"rewrites":[{"regex":"^\\/backstage\\/?(.*)$","replace":"/$1"}]}}]
 spec:
-  ingressClassName: "nginx"
+  ingressClassName: platform
   rules:
     - host: {{ .Values.ingress_domain_name }}
       http:
         paths:
-          - path: /backstage(/|$)(.*)
-            pathType: ImplementationSpecific
+          - path: /backstage
+            pathType: Prefix
             backend:
               service:
                 name: backstage

--- a/gitops/addons/charts/ingress-class-alb/templates/ingressclass.yaml
+++ b/gitops/addons/charts/ingress-class-alb/templates/ingressclass.yaml
@@ -1,22 +1,27 @@
-{{- if eq (default "auto" .Values.controllerMode) "oss" }}
+{{- $mode := default "auto" .Values.controllerMode }}
+{{- range $idx, $c := .Values.classes }}
+{{- if $idx }}
+---
+{{- end }}
+{{- if eq $mode "oss" }}
 apiVersion: elbv2.k8s.aws/v1beta1
 {{- else }}
 apiVersion: eks.amazonaws.com/v1
 {{- end }}
 kind: IngressClassParams
 metadata:
-  name: platform
+  name: {{ $c.name }}
 spec:
   group:
-    name: platform
-  scheme: internet-facing
+    name: {{ $c.group | default $c.name }}
+  scheme: {{ $c.scheme | default "internet-facing" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  name: platform
+  name: {{ $c.name }}
 spec:
-{{- if eq (default "auto" .Values.controllerMode) "oss" }}
+{{- if eq $mode "oss" }}
   controller: ingress.k8s.aws/alb
   parameters:
     apiGroup: elbv2.k8s.aws
@@ -26,4 +31,5 @@ spec:
     apiGroup: eks.amazonaws.com
 {{- end }}
     kind: IngressClassParams
-    name: platform
+    name: {{ $c.name }}
+{{- end }}

--- a/gitops/addons/charts/ingress-class-alb/values.yaml
+++ b/gitops/addons/charts/ingress-class-alb/values.yaml
@@ -1,0 +1,22 @@
+# Mode du contrôleur ALB :
+#   - "auto" (defaut) : sélection auto par le rendu (compat existant)
+#   - "oss"  : AWS Load Balancer Controller open-source (apiGroup elbv2.k8s.aws)
+#   - "eks-auto" / autre : EKS Auto Mode (apiGroup eks.amazonaws.com)
+controllerMode: auto
+
+# Liste des IngressClass / IngressClassParams à provisionner.
+# Chaque entrée génère :
+#   - 1 IngressClassParams (nom = .name, group.name = .group, scheme = .scheme)
+#   - 1 IngressClass        (nom = .name, parameters -> IngressClassParams ci-dessus)
+#
+# Le defaut reproduit l'ancien comportement (une seule classe "platform")
+# tout en ajoutant une classe "agent" pour isoler les Ingress de la plateforme
+# agentique (group.name=agent) — évite qu'une Ingress "agent" ne pollue
+# l'ALB partagé "platform".
+classes:
+  - name: platform
+    group: platform
+    scheme: internet-facing
+  - name: agent
+    group: agent
+    scheme: internet-facing

--- a/gitops/addons/charts/multi-acct/templates/eks-capabilities-rbac.yaml
+++ b/gitops/addons/charts/multi-acct/templates/eks-capabilities-rbac.yaml
@@ -51,6 +51,14 @@ rules:
 - apiGroups: ["kro.run"]
   resources: ["*"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# ACK ELBv2 (TargetGroup, Rule, Listener, LoadBalancer) — required by AppExposure RGD
+- apiGroups: ["elbv2.services.k8s.aws"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# AWS Load Balancer Controller TargetGroupBinding — required by AppExposure RGD
+- apiGroups: ["elbv2.k8s.aws"]
+  resources: ["targetgroupbindings"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,6 +69,15 @@ roleRef:
   kind: ClusterRole
   name: eks-capabilities-kro
 subjects:
+# Legacy username — pre-EKS-Capabilities GA, kept for backward compatibility.
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: capabilities.eks.amazonaws.com
+{{- if and .Values.global.accountId .Values.global.resourcePrefix .Values.global.clusterName }}
+# Real runtime identity of the KRO controller — STS assumed-role session.
+# EKS access-entry maps the IAM role to: arn:aws:sts::<account>:assumed-role/<role>/{{ "{{SessionName}}" }}
+# and the controller uses session name "KRO".
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: arn:aws:sts::{{ .Values.global.accountId }}:assumed-role/{{ .Values.global.resourcePrefix }}-{{ .Values.global.clusterName }}-kro-capability-role/KRO
+{{- end }}

--- a/gitops/addons/registry/core.yaml
+++ b/gitops/addons/registry/core.yaml
@@ -158,6 +158,20 @@ ingress-class-alb:
         values: ['true']
   valuesObject:
     controllerMode: '{{default "auto" .metadata.annotations.alb_controller_mode}}'
+    classes:
+      # 'platform' class — group.name aligned on the cluster ingress_name annotation
+      # so the LBC can adopt a pre-created ALB (Taskfile hub:ingress) OR provision its
+      # own when none exists. scheme follows exposure_mode:
+      #   - exposure_mode=cloudfront-alb -> internal (ALB behind CloudFront VPC Origin)
+      #   - anything else (tls/direct)   -> internet-facing
+      - name: platform
+        group: '{{default "platform" .metadata.annotations.ingress_name}}'
+        scheme: '{{if eq (default "" .metadata.annotations.exposure_mode) "cloudfront-alb"}}internal{{else}}internet-facing{{end}}'
+      # 'agent' class — dedicated group for the agentic platform Ingresses so
+      # they don't pollute the shared 'platform' ALB.
+      - name: agent
+        group: agent
+        scheme: '{{if eq (default "" .metadata.annotations.exposure_mode) "cloudfront-alb"}}internal{{else}}internet-facing{{end}}'
 
 aws-load-balancer-controller:
   namespace: kube-system

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -216,6 +216,8 @@ multi-acct:
   valuesObject:
     global:
       clusterName: '{{.metadata.annotations.aws_cluster_name}}'
+      accountId: '{{.metadata.annotations.aws_account_id}}'
+      resourcePrefix: '{{.metadata.annotations.resource_prefix}}'
 
 kubevela:
   namespace: vela-system

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -99,6 +99,7 @@ backstage:
     global:
       aws_cluster_name: '{{.metadata.annotations.aws_cluster_name}}'
       clusterName: '{{.metadata.annotations.aws_cluster_name}}'
+      ingress_name: '{{.metadata.annotations.ingress_name}}'
   ignoreDifferences:
     - group: external-secrets.io
       kind: ExternalSecret

--- a/gitops/overlays/environments/control-plane/enabled-addons.yaml
+++ b/gitops/overlays/environments/control-plane/enabled-addons.yaml
@@ -65,3 +65,5 @@ enabledAddons:
   airflow: false
   # Agent Platform
   agent_platform: true
+  # Edge / exposure (PeEKS extension — KRO RGD synthesizing TargetGroup + ListenerRule + TargetGroupBinding)
+  app_exposure: true


### PR DESCRIPTION
## Summary

Enables the `app-exposure` addon on the hub control-plane and extends the
AppExposure RGD with a path-only routing mode required for CloudFront
single-domain edges (Workshop Studio).

## Context

PR #671 introduced AppExposure as a host-header-based RGD. On Workshop Studio
the hub is fronted by a single-domain CloudFront distribution, so every app
shares the same Host header and host-header listener rules can never match.
Apps must be differentiated by URL path only.

This PR makes AppExposure usable in that mode and turns it on by default on
the hub.

## Changes

- **`feat(kind-kro-ack)`**: make `hub:seed-secret` idempotent and
  label-preserving (don't blow away `enable_*` labels on re-run).
- **`feat(hub)`**: enable `app-exposure` addon on the control-plane
  (`enabled-addons.yaml`, `registry/platform.yaml`).
- **`feat(multi-acct)`**: grant the KRO capability the ACK ELBv2 perms it
  needs to reconcile `TargetGroup` / `Rule`, and add the STS subject for
  pod-identity assumption.
- **`feat(app-exposure)`**: add `routingMode` field (default `"host"`, enum
  `"host"|"path"`). Splits the rule into `listenerRuleHost` (host+path,
  unchanged behaviour) and `listenerRulePath` (path-only, no host
  condition) gated by `includeWhen`. New status fields
  `ruleARNHost`/`ruleARNPath`; legacy `ruleARN` preserved for CRD
  backward-compat.

## Testing

End-to-end validated on a hub cluster (KRO capability, eu-west-1):

- `AppExposure` claim with `routingMode=path`, `path=/smoke`, `priority=999`
- KRO reconciles 3 resources: ACK `TargetGroup`, ACK `Rule` (path-only),
  AWS LBC `TargetGroupBinding`
- ALB target reports healthy
- HTTPS request via the CloudFront edge reaches the backend pod — chain
  CF -> ALB -> TG -> TGB -> pod proven working

## Notes

- Backward-compatible: existing AppExposure instances without `routingMode`
  default to `"host"` and keep their previous behaviour.
- Complementary with #680 (which solves the same CloudFront single-domain
  problem for plain Helm Ingress charts). The two approaches can coexist on
  the same hub.

## Related

- Builds on #671 (AppExposure RGD)
- Shares motivation with #680 (CloudFront mode)
