### PR TITLE
feat(ingress-class-alb): support multiple ingress classes via values.yaml

### DIFF
--- a/gitops/addons/charts/ingress-class-alb/templates/ingressclass.yaml
+++ b/gitops/addons/charts/ingress-class-alb/templates/ingressclass.yaml
@@ -1,22 +1,27 @@
-{{- if eq (default "auto" .Values.controllerMode) "oss" }}
+{{- $mode := default "auto" .Values.controllerMode }}
+{{- range $idx, $c := .Values.classes }}
+{{- if $idx }}
+---
+{{- end }}
+{{- if eq $mode "oss" }}
 apiVersion: elbv2.k8s.aws/v1beta1
 {{- else }}
 apiVersion: eks.amazonaws.com/v1
 {{- end }}
 kind: IngressClassParams
 metadata:
-  name: platform
+  name: {{ $c.name }}
 spec:
   group:
-    name: platform
-  scheme: internet-facing
+    name: {{ $c.group | default $c.name }}
+  scheme: {{ $c.scheme | default "internet-facing" }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  name: platform
+  name: {{ $c.name }}
 spec:
-{{- if eq (default "auto" .Values.controllerMode) "oss" }}
+{{- if eq $mode "oss" }}
   controller: ingress.k8s.aws/alb
   parameters:
     apiGroup: elbv2.k8s.aws
@@ -26,4 +31,5 @@ spec:
     apiGroup: eks.amazonaws.com
 {{- end }}
     kind: IngressClassParams
-    name: platform
+    name: {{ $c.name }}
+{{- end }}

--- a/gitops/addons/charts/ingress-class-alb/values.yaml
+++ b/gitops/addons/charts/ingress-class-alb/values.yaml
@@ -1,0 +1,22 @@
+# Mode du contrôleur ALB :
+#   - "auto" (defaut) : sélection auto par le rendu (compat existant)
+#   - "oss"  : AWS Load Balancer Controller open-source (apiGroup elbv2.k8s.aws)
+#   - "eks-auto" / autre : EKS Auto Mode (apiGroup eks.amazonaws.com)
+controllerMode: auto
+
+# Liste des IngressClass / IngressClassParams à provisionner.
+# Chaque entrée génère :
+#   - 1 IngressClassParams (nom = .name, group.name = .group, scheme = .scheme)
+#   - 1 IngressClass        (nom = .name, parameters -> IngressClassParams ci-dessus)
+#
+# Le defaut reproduit l'ancien comportement (une seule classe "platform")
+# tout en ajoutant une classe "agent" pour isoler les Ingress de la plateforme
+# agentique (group.name=agent) — évite qu'une Ingress "agent" ne pollue
+# l'ALB partagé "platform".
+classes:
+  - name: platform
+    group: platform
+    scheme: internet-facing
+  - name: agent
+    group: agent
+    scheme: internet-facing


### PR DESCRIPTION
## Problem

The `ingress-class-alb` chart hardcodes a single `IngressClass`/`IngressClassParams` named `platform`. The `IngressClassParams.platform` enforces `spec.group.name=platform`, which **overrides any `alb.ingress.kubernetes.io/group.name` annotation** set on downstream Ingress resources.

This blocks group isolation for any downstream component that wants its own ALB. Concretely, the agentgateway from [`sample-open-agentic-platform`](https://github.com/aws-samples/sample-open-agentic-platform) wants its own `agent` ALB but is forced into the shared `platform` group.

## Change

Refactor `templates/ingressclass.yaml` to loop over `.Values.classes`, and add a default `values.yaml` provisioning two classes out of the box:

| name       | group.name | scheme           |
|------------|------------|------------------|
| `platform` | `platform` | `internet-facing`|
| `agent`    | `agent`    | `internet-facing`|

Existing deployments are unaffected — the `platform` class is still rendered with the same name, group, scheme, and controller wiring.

## Verification

`helm template` renders cleanly in both `controllerMode=auto` (EKS Auto Mode, `eks.amazonaws.com/v1`) and `controllerMode=oss` (LBC OSS, `elbv2.k8s.aws/v1beta1`):

```bash
helm template ingress-class-alb ./gitops/addons/charts/ingress-class-alb \
  --set controllerMode=auto
# → 2 IngressClass + 2 IngressClassParams

helm template ingress-class-alb ./gitops/addons/charts/ingress-class-alb \
  --set controllerMode=oss
# → 2 IngressClass + 2 IngressClassParams (elbv2.k8s.aws/v1beta1)
```

Live-tested on the PeEKS DR test cluster (`hub`, eu-west-1): both `IngressClass` resources coexist; the agentgateway Ingress now lands on its own ALB (`group.name=agent`), the platform ALB is unaffected.

## Customization

Operators wanting to add classes can extend `.Values.classes` in their values overlay:

```yaml
classes:
  - name: platform
    groupName: platform
    scheme: internet-facing
  - name: agent
    groupName: agent
    scheme: internet-facing
  - name: internal
    groupName: internal
    scheme: internal
```

Targets: `feature/platform-cluster-kro-ack` (the platform-cluster KRO/ACK feature branch).
