### PR TITLE
fix: add secretsmanager resource policy permissions for PushSecret

### DIFF
--- a/platform/infra/terraform/common/pod-identity.tf
+++ b/platform/infra/terraform/common/pod-identity.tf
@@ -44,6 +44,11 @@ module "external_secrets_pod_identity" {
       sid       = "ecr"
       actions   = ["ecr:*"]
       resources = ["*"]
+    },
+    {
+      sid       = "secretsManagerResourcePolicy"
+      actions   = ["secretsmanager:DeleteResourcePolicy", "secretsmanager:PutResourcePolicy"]
+      resources = ["arn:aws:secretsmanager:${each.value.region}:*:secret:${local.context_prefix}*"]
     }
   ]
   # Pod Identity Associations


### PR DESCRIPTION
## Summary

Adds `secretsmanager:DeleteResourcePolicy` and `secretsmanager:PutResourcePolicy` to the External Secrets pod identity IAM policy.

## Problem

External Secrets PushSecret (used by DevLake) fails with:
```
AccessDeniedException: not authorized to perform: secretsmanager:DeleteResourcePolicy
```

## Changes

- Added a new policy statement `secretsManagerResourcePolicy` to the `external_secrets_pod_identity` module in `platform/infra/terraform/common/pod-identity.tf`

## Testing

- Verified the IAM policy update resolves the DevLake PushSecret failure

Fixes #691