### PR TITLE
fix(fleet-secret): Add agent_platform to control-plane enabledAddons

### DIFF
--- a/gitops/overlays/environments/control-plane/enabled-addons.yaml
+++ b/gitops/overlays/environments/control-plane/enabled-addons.yaml
@@ -63,3 +63,5 @@ enabledAddons:
   aws_resources: true
   # Observability AWS (AMP + AMG via Crossplane)
   observability_aws: true
+  # Agentic Platform (KAgent, LiteLLM, Langfuse, AgentGateway, etc.)
+  agent_platform: true


### PR DESCRIPTION
The hub cluster secret was missing the enable_agent_platform label because agent_platform was not listed in the control-plane enabled-addons.yaml. Without this label, the agent-platform-addons ApplicationSets globalSelectors never matched any cluster, so no agentic components were deployed.

Adding agent_platform: true ensures the fleet-secret chart generates the enable_agent_platform: 'true' label on the hub cluster secret, allowing the agentic platform ApplicationSets to target it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
