### PR TITLE
feat(kind-crossplane): decouple fleet repo and fix observability cleanup

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -29,6 +29,12 @@ vars:
     sh: yq '.repo.revision' {{.CONFIG_FILE}}
   REPO_BASEPATH:
     sh: yq '.repo.basepath' {{.CONFIG_FILE}}
+  FLEET_REPO_URL:
+    sh: yq '.fleetRepo.url // .repo.url' {{.CONFIG_FILE}}
+  FLEET_REPO_REVISION:
+    sh: yq '.fleetRepo.revision // .repo.revision' {{.CONFIG_FILE}}
+  FLEET_REPO_BASEPATH:
+    sh: yq '.fleetRepo.basepath // .repo.basepath' {{.CONFIG_FILE}}
   DOMAIN:
     sh: yq '.domain' {{.CONFIG_FILE}}
   RESOURCE_PREFIX:
@@ -412,7 +418,7 @@ tasks:
       - printf '{{.C_STEP}}▸ Creating seed cluster secret on hub...{{.C_RESET}}\n'
       - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl create namespace argocd --dry-run=client -o yaml | KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl apply -f -
       - |
-        cat <<'EOF' | sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g; s|CLUSTER_ARN|{{.CLUSTER_ARN}}|g; s|REPO_URL|{{.REPO_URL}}|g; s|REPO_REVISION|{{.REPO_REVISION}}|g; s|REPO_BASEPATH|{{.REPO_BASEPATH}}|g" | KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl apply -f -
+        cat <<'EOF' | sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g; s|CLUSTER_ARN|{{.CLUSTER_ARN}}|g; s|REPO_URL|{{.REPO_URL}}|g; s|REPO_REVISION|{{.REPO_REVISION}}|g; s|REPO_BASEPATH|{{.REPO_BASEPATH}}|g; s|FLEET_REPO_URL|{{.FLEET_REPO_URL}}|g; s|FLEET_REPO_REVISION|{{.FLEET_REPO_REVISION}}|g; s|FLEET_REPO_BASEPATH|{{.FLEET_REPO_BASEPATH}}|g" | KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl apply -f -
         apiVersion: v1
         kind: Secret
         type: Opaque
@@ -423,9 +429,9 @@ tasks:
             addonsRepoURL: "REPO_URL"
             addonsRepoRevision: "REPO_REVISION"
             addonsRepoBasepath: "REPO_BASEPATH"
-            fleetRepoURL: "REPO_URL"
-            fleetRepoRevision: "REPO_REVISION"
-            fleetRepoBasepath: "REPO_BASEPATH"
+            fleetRepoURL: "FLEET_REPO_URL"
+            fleetRepoRevision: "FLEET_REPO_REVISION"
+            fleetRepoBasepath: "FLEET_REPO_BASEPATH"
             aws_cluster_name: {{.HUB_CLUSTER_NAME}}
           labels:
             argocd.argoproj.io/secret-type: cluster
@@ -590,7 +596,7 @@ tasks:
           --arg cluster_security_group_id "{{.CLUSTER_SG}}" \
           '{id: $id, subnet_ids: $subnet_ids, cluster_security_group_id: $cluster_security_group_id}' | jq -c .)
         SECRET_VALUE=$(jq -n \
-          --arg metadata '{"addonsRepoURL":"{{.REPO_URL}}","addonsRepoRevision":"{{.REPO_REVISION}}","addonsRepoBasepath":"{{.REPO_BASEPATH}}","fleetRepoURL":"{{.REPO_URL}}","fleetRepoRevision":"{{.REPO_REVISION}}","fleetRepoBasepath":"{{.REPO_BASEPATH}}","aws_region":"{{.AWS_REGION}}","aws_account_id":"{{.AWS_ACCOUNT_ID}}","aws_cluster_name":"{{.HUB_CLUSTER_NAME}}","aws_cluster_arn":"{{.CLUSTER_ARN}}","aws_vpc_id":"{{.VPC_ID}}","aws_subnet_ids":"{{.SUBNET_IDS}}","aws_private_subnet_ids":"{{.PRIVATE_SUBNET_IDS}}","aws_cluster_security_group_id":"{{.CLUSTER_SG}}","alb_controller_mode":"oss","ingress_domain_name":"{{.DOMAIN}}","ingress_name":"{{.INGRESS_NAME}}","ingress_security_groups":"{{.INGRESS_SECURITY_GROUPS}}","resource_prefix":"{{.RESOURCE_PREFIX}}"}' \
+          --arg metadata '{"addonsRepoURL":"{{.REPO_URL}}","addonsRepoRevision":"{{.REPO_REVISION}}","addonsRepoBasepath":"{{.REPO_BASEPATH}}","fleetRepoURL":"{{.FLEET_REPO_URL}}","fleetRepoRevision":"{{.FLEET_REPO_REVISION}}","fleetRepoBasepath":"{{.FLEET_REPO_BASEPATH}}","aws_region":"{{.AWS_REGION}}","aws_account_id":"{{.AWS_ACCOUNT_ID}}","aws_cluster_name":"{{.HUB_CLUSTER_NAME}}","aws_cluster_arn":"{{.CLUSTER_ARN}}","aws_vpc_id":"{{.VPC_ID}}","aws_subnet_ids":"{{.SUBNET_IDS}}","aws_private_subnet_ids":"{{.PRIVATE_SUBNET_IDS}}","aws_cluster_security_group_id":"{{.CLUSTER_SG}}","alb_controller_mode":"oss","ingress_domain_name":"{{.DOMAIN}}","ingress_name":"{{.INGRESS_NAME}}","ingress_security_groups":"{{.INGRESS_SECURITY_GROUPS}}","resource_prefix":"{{.RESOURCE_PREFIX}}"}' \
           --arg config '{"tlsClientConfig":{"insecure":false}}' \
           --arg server '{{.CLUSTER_ARN}}' \
           --arg addons '' \
@@ -639,11 +645,18 @@ tasks:
         SECRET_KEY="{{.HUB_CLUSTER_NAME}}/secrets"
 
         # Poll for AMP workspace (up to 30 min — Crossplane provisioning can take time)
+        # Use crossplane-name tag to identify the correct workspace (avoids ambiguity with duplicates)
         AMP_WORKSPACE_ID=""
         printf '{{.C_STEP}}▸ Waiting for AMP workspace...{{.C_RESET}}\n'
         for i in $(seq 1 60); do
-          AMP_WORKSPACE_ID=$(aws amp list-workspaces --region {{.AWS_REGION}} --query "workspaces[?alias=='{{.RESOURCE_PREFIX}}-observability-amp'].workspaceId" --output text 2>/dev/null)
-          if [ -n "$AMP_WORKSPACE_ID" ] && [ "$AMP_WORKSPACE_ID" != "None" ]; then
+          for WS_ID in $(aws amp list-workspaces --region {{.AWS_REGION}} --query "workspaces[?alias=='{{.RESOURCE_PREFIX}}-observability-amp'].workspaceId" --output text 2>/dev/null); do
+            TAG_VAL=$(aws amp list-tags-for-resource --resource-arn "arn:aws:aps:{{.AWS_REGION}}:{{.AWS_ACCOUNT_ID}}:workspace/$WS_ID" --region {{.AWS_REGION}} --query "tags.\"crossplane-name\"" --output text 2>/dev/null || echo "")
+            if [ "$TAG_VAL" = "{{.RESOURCE_PREFIX}}-amp" ]; then
+              AMP_WORKSPACE_ID="$WS_ID"
+              break
+            fi
+          done
+          if [ -n "$AMP_WORKSPACE_ID" ]; then
             break
           fi
           printf '  [%d/60] AMP workspace not ready yet...\n' "$i"
@@ -662,15 +675,19 @@ tasks:
         echo "Found AMP endpoint: $AMP_ENDPOINT"
 
         # Poll for AMG workspace (up to 15 min)
+        # Use crossplane-name tag to identify the correct workspace
         AMG_WORKSPACE_ID=""
         printf '{{.C_STEP}}▸ Waiting for AMG workspace...{{.C_RESET}}\n'
         for i in $(seq 1 30); do
-          AMG_WORKSPACE_ID=$(aws grafana list-workspaces --region {{.AWS_REGION}} --query "workspaces[?name=='{{.RESOURCE_PREFIX}}-observability' && status=='ACTIVE'].id | [0]" --output text 2>/dev/null)
-          if [ -n "$AMG_WORKSPACE_ID" ] && [ "$AMG_WORKSPACE_ID" != "None" ]; then
-            AMG_STATUS=$(aws grafana describe-workspace --workspace-id "$AMG_WORKSPACE_ID" --region {{.AWS_REGION}} --query "workspace.status" --output text 2>/dev/null)
-            if [ "$AMG_STATUS" = "ACTIVE" ]; then
+          for WS in $(aws grafana list-workspaces --region {{.AWS_REGION}} --query "workspaces[?name=='{{.RESOURCE_PREFIX}}-observability' && status=='ACTIVE'].id" --output text 2>/dev/null); do
+            TAG_VAL=$(aws grafana describe-workspace --workspace-id "$WS" --region {{.AWS_REGION}} --query "workspace.tags.\"crossplane-name\"" --output text 2>/dev/null || echo "")
+            if [ "$TAG_VAL" = "{{.RESOURCE_PREFIX}}-amg" ]; then
+              AMG_WORKSPACE_ID="$WS"
               break
             fi
+          done
+          if [ -n "$AMG_WORKSPACE_ID" ]; then
+            break
           fi
           printf '  [%d/30] AMG workspace not ready yet...\n' "$i"
           sleep 30
@@ -995,7 +1012,39 @@ tasks:
             [ -n "$POLICY_ARN" ] && aws iam delete-policy --policy-arn "$POLICY_ARN" 2>/dev/null || true
           done
         ignore_error: true
-      # Phase 7: VPC-level orphan cleanup. The Crossplane VPC delete in Phase 4
+      # Phase 7: Clean up observability resources (AMP scrapers, AMP workspace, AMG workspace).
+      # Scrapers hold ENIs in VPCs and must be deleted before VPC cleanup.
+      - cmd: |
+          # Delete AMP scrapers tagged by our platform
+          for SCRAPER_ID in $(aws amp list-scrapers --region {{.AWS_REGION}} --query "scrapers[?starts_with(alias,'{{.RESOURCE_PREFIX}}-')].scraperId" --output text 2>/dev/null); do
+            echo "Deleting AMP scraper $SCRAPER_ID"
+            aws amp delete-scraper --scraper-id "$SCRAPER_ID" --region {{.AWS_REGION}} 2>/dev/null || true
+          done
+          # Delete AMP workspace by crossplane-name tag
+          for WS_ID in $(aws amp list-workspaces --region {{.AWS_REGION}} --query "workspaces[].workspaceId" --output text 2>/dev/null); do
+            TAG_VAL=$(aws amp list-tags-for-resource --resource-arn "arn:aws:aps:{{.AWS_REGION}}:{{.AWS_ACCOUNT_ID}}:workspace/$WS_ID" --region {{.AWS_REGION}} --query "tags.\"crossplane-name\"" --output text 2>/dev/null || echo "")
+            if [ "$TAG_VAL" = "{{.RESOURCE_PREFIX}}-amp" ]; then
+              echo "Deleting AMP workspace $WS_ID (crossplane-name={{.RESOURCE_PREFIX}}-amp)"
+              aws amp delete-workspace --workspace-id "$WS_ID" --region {{.AWS_REGION}} 2>/dev/null || true
+            fi
+          done
+          # Delete AMG workspace by crossplane-name tag
+          for WS_ID in $(aws grafana list-workspaces --region {{.AWS_REGION}} --query "workspaces[].id" --output text 2>/dev/null); do
+            TAG_VAL=$(aws grafana describe-workspace --workspace-id "$WS_ID" --region {{.AWS_REGION}} --query "workspace.tags.\"crossplane-name\"" --output text 2>/dev/null || echo "")
+            if [ "$TAG_VAL" = "{{.RESOURCE_PREFIX}}-amg" ]; then
+              echo "Deleting AMG workspace $WS_ID (crossplane-name={{.RESOURCE_PREFIX}}-amg)"
+              aws grafana delete-workspace --workspace-id "$WS_ID" --region {{.AWS_REGION}} 2>/dev/null || true
+            fi
+          done
+          # Wait for scrapers to fully delete (they hold ENIs in VPCs)
+          for i in $(seq 1 40); do
+            REMAINING=$(aws amp list-scrapers --region {{.AWS_REGION}} --query "scrapers[?starts_with(alias,'{{.RESOURCE_PREFIX}}-') && status.statusCode!='DELETION_FAILED'] | length(@)" --output text 2>/dev/null || echo "0")
+            [ "$REMAINING" = "0" ] && break
+            echo "Waiting for $REMAINING scraper(s) to delete... ($i/40)"
+            sleep 15
+          done
+        ignore_error: true
+      # Phase 8: VPC-level orphan cleanup. The Crossplane VPC delete in Phase 4
       # can stop reconciling once the providers are torn down in Phase 5, leaving
       # AWS-side dependencies (ELBs, NAT gateways, VPC endpoints, EIPs, subnets,
       # IGW, route tables, security groups). Tear them down by Crossplane tag so
@@ -1087,11 +1136,11 @@ tasks:
           done
           # Secrets Manager — Crossplane cluster claims also push hub/spoke config
           # secrets that survive the AWS resource teardown
-          for SECRET in {{.HUB_CLUSTER_NAME}}/config {{.HUB_CLUSTER_NAME}}/keycloak {{.HUB_CLUSTER_NAME}}/keycloak-clients spoke-dev/config spoke-prod/config; do
+          for SECRET in {{.HUB_CLUSTER_NAME}}/config {{.HUB_CLUSTER_NAME}}/keycloak {{.HUB_CLUSTER_NAME}}/keycloak-clients {{.HUB_CLUSTER_NAME}}/secrets spoke-dev/config spoke-prod/config spoke-dev/secrets spoke-prod/secrets; do
             aws secretsmanager delete-secret --secret-id "$SECRET" --force-delete-without-recovery --region {{.AWS_REGION}} --output text 2>/dev/null || true
           done
         ignore_error: true
-      # Phase 8: Clean up Kind (pass CLEANUP_KIND=true to remove)
+      # Phase 9: Clean up Kind (pass CLEANUP_KIND=true to remove)
       - cmd: |
           if [ "{{.CLEANUP_KIND}}" = "true" ]; then
             kind delete cluster --name {{.KIND_CLUSTER_NAME}}

--- a/gitops/bootstrap/clusters.yaml
+++ b/gitops/bootstrap/clusters.yaml
@@ -33,9 +33,9 @@ spec:
         - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
           targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
           ref: values
-        - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
-          path: '{{ .metadata.annotations.fleetRepoBasepath }}abstractions/resource-groups/platform-cluster'
-          targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
+        - repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
+          path: '{{ .metadata.annotations.addonsRepoBasepath }}abstractions/resource-groups/platform-cluster'
+          targetRevision: '{{ .metadata.annotations.addonsRepoRevision }}'
           helm:
             releaseName: 'clusters-{{ index (splitList "/" .path.path) 4 }}'
             ignoreMissingValueFiles: true

--- a/gitops/bootstrap/fleet-secrets.yaml
+++ b/gitops/bootstrap/fleet-secrets.yaml
@@ -33,8 +33,8 @@ spec:
         - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
           targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
           ref: values
-        - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
-          targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
+        - repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
+          targetRevision: '{{ .metadata.annotations.addonsRepoRevision }}'
           path: 'platform-charts/fleet-secret'
           helm:
             releaseName: 'fleet-secret-{{ .clusterName }}'

--- a/gitops/bootstrap/hub-fleet-secret.yaml
+++ b/gitops/bootstrap/hub-fleet-secret.yaml
@@ -26,8 +26,8 @@ spec:
         - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
           targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
           ref: values
-        - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
-          targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
+        - repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
+          targetRevision: '{{ .metadata.annotations.addonsRepoRevision }}'
           path: 'platform-charts/fleet-secret'
           helm:
             releaseName: 'fleet-secret-{{ .metadata.annotations.aws_cluster_name }}'

--- a/gitops/bootstrap/root-appset.yaml
+++ b/gitops/bootstrap/root-appset.yaml
@@ -19,9 +19,9 @@ spec:
     spec:
       project: default
       source:
-        repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
-        path: '{{ .metadata.annotations.fleetRepoBasepath }}bootstrap'
-        targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
+        repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
+        path: '{{ .metadata.annotations.addonsRepoBasepath }}bootstrap'
+        targetRevision: '{{ .metadata.annotations.addonsRepoRevision }}'
         directory:
           recurse: false
           exclude: '{root-appset.yaml}'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR makes two improvements to the Kind-Crossplane cluster provider:

1. Separate fleet repo configuration — allows an external repo (e.g., open-agentic-platform) to manage fleet membership, cluster targeting, and addon enablement overlays independently from the platform addons repo.
2. Fix observability resource cleanup — the destroy task now properly cleans up AMP/AMG workspaces and scrapers, and the seed-observability task correctly identifies workspaces using Crossplane tags instead of name-only queries.

**Changes**

Fleet repo decoupling

- Added FLEET_REPO_URL, FLEET_REPO_REVISION, FLEET_REPO_BASEPATH vars with fallback to repo.* (backward compatible — existing users without fleetRepo in config are unaffected)
- hub:seed-secret now writes separate fleetRepoURL/fleetRepoRevision/fleetRepoBasepath annotations on the hub cluster secret
- secrets-manager:seed uses the fleet vars in the Secrets Manager metadata JSON

  This enables the pattern where:

- addonsRepo* → points to appmod-blueprints (addon charts, bootstrap)
- fleetRepo* → points to an external repo that controls fleet members, enabled-addons.yaml overlays, and per-cluster addon targeting

**Observability workspace lookup (seed-observability)**

- AMP: Now uses crossplane-name tag (list-tags-for-resource) to identify the correct workspace instead of relying on alias alone. Prevents ValidationException: Invalid workspaceId when duplicate workspaces exist from previous runs.
- AMG: Same tag-based approach using describe-workspace to check workspace.tags.crossplane-name.

Destroy task — observability cleanup (new Phase 7)

Previously, task destroy did not clean up AMP scrapers, AMP workspaces, or AMG workspaces. This left orphaned resources that:

- Held ENIs in VPCs (blocking VPC deletion)
- Caused duplicate workspace errors on subsequent installs

  New:

  - Deletes AMP scrapers matching <resourcePrefix>-* alias
  - Deletes AMP workspace by crossplane-name tag
  - Deletes AMG workspace by crossplane-name tag
  - Waits for scrapers to fully delete before proceeding to VPC cleanup

  Secrets Manager cleanup

  - Added <hub>/secrets, spoke-dev/secrets, spoke-prod/secrets to the destroy cleanup list (observability credentials were previously orphaned)

 Testing

  - Validated end-to-end install with fleetRepo pointing to an external repo
  - Confirmed tag-based workspace lookup resolves correctly with single and duplicate workspaces
  - Verified backward compatibility: omitting fleetRepo from config falls back to repo.* values

 Config example

```
  # config.local.yaml — new optional section
  fleetRepo:
    url: "https://github.com/org/my-fleet-repo.git"
    revision: "main"
    basepath: "gitops/"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

