### PR TITLE
Decouple fleet repo from addons repo, fix bootstrap and seed-secret bugs

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -418,7 +418,7 @@ tasks:
       - printf '{{.C_STEP}}▸ Creating seed cluster secret on hub...{{.C_RESET}}\n'
       - KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl create namespace argocd --dry-run=client -o yaml | KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl apply -f -
       - |
-        cat <<'EOF' | sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g; s|CLUSTER_ARN|{{.CLUSTER_ARN}}|g; s|REPO_URL|{{.REPO_URL}}|g; s|REPO_REVISION|{{.REPO_REVISION}}|g; s|REPO_BASEPATH|{{.REPO_BASEPATH}}|g; s|FLEET_REPO_URL|{{.FLEET_REPO_URL}}|g; s|FLEET_REPO_REVISION|{{.FLEET_REPO_REVISION}}|g; s|FLEET_REPO_BASEPATH|{{.FLEET_REPO_BASEPATH}}|g" | KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl apply -f -
+        cat <<'EOF' | sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g; s|CLUSTER_ARN|{{.CLUSTER_ARN}}|g; s|FLEET_REPO_URL|{{.FLEET_REPO_URL}}|g; s|FLEET_REPO_REVISION|{{.FLEET_REPO_REVISION}}|g; s|FLEET_REPO_BASEPATH|{{.FLEET_REPO_BASEPATH}}|g; s|REPO_URL|{{.REPO_URL}}|g; s|REPO_REVISION|{{.REPO_REVISION}}|g; s|REPO_BASEPATH|{{.REPO_BASEPATH}}|g" | KUBECONFIG={{.ROOT_DIR}}/private/hub-kubeconfig kubectl apply -f -
         apiVersion: v1
         kind: Secret
         type: Opaque

--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -8,8 +8,8 @@ env:
   AWS_PROFILE: "{{.AWS_PROFILE}}"
 
 vars:
-  GITOPS_ROOT:
-    sh: echo "$(dirname {{.CONFIG_FILE}})/gitops"
+  CONFIG_FILE: "{{.ROOT_DIR}}/config.local.yaml"
+  GITOPS_ROOT: "{{.ROOT_DIR}}/gitops"
   REQUIRED_CLIS: [kind, kubectl, helm, yq, aws]
   AWS_PROFILE:
     sh: yq '.aws.profile // "default"' {{.CONFIG_FILE}}
@@ -63,7 +63,7 @@ vars:
   C_RESET:
     sh: printf '\033[0m'
   ARGOCD_VERSION:
-    sh: yq '.argocd.defaultVersion' "$(dirname {{.CONFIG_FILE}})/gitops/addons/registry/core.yaml"
+    sh: yq '.argocd.defaultVersion' "{{.ROOT_DIR}}/gitops/addons/registry/core.yaml"
 
 tasks:
   validate:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR enables a clean architectural separation between the platform addons repo (this repo, appmod-blueprints) and a downstream fleet repo that controls cluster fleet membership and addon enablement. It also fixes several bootstrap bugs that prevented end-to-end deployment from succeeding.

  Changes

  Repo decoupling (cluster-providers/kind-crossplane/Taskfile.yaml)

  - Add FLEET_REPO_URL, FLEET_REPO_REVISION, FLEET_REPO_BASEPATH task vars that read fleetRepo.* from config.local.yaml, falling back to repo.* when not set.
  - Pass both addonsRepo* and fleetRepo* annotations into hub:seed-secret and secrets-manager:seed, so cluster secrets and AWS Secrets Manager configs carry the split coordinates that ApplicationSets template against.

  Bootstrap manifests source split

  - gitops/bootstrap/root-appset.yaml: read bootstrap directory from addonsRepoURL (this repo).
  - gitops/bootstrap/clusters.yaml: chart from addonsRepo, KRO values matrix from fleetRepo.
  - gitops/bootstrap/fleet-secrets.yaml: chart from addonsRepo, fleet members and overlays from fleetRepo.
  - gitops/bootstrap/hub-fleet-secret.yaml: same pattern for the hub seed secret.

The clusters ApplicationSet generator path resolves against the fleet repo, the platform-cluster Helm chart resolves against this repo, and consumers can host their own fleet/kro-values/tenants/*/kro-clusters/values.yaml and overlays/environments/*/enabled-addons.yaml without touching this repo.

Observability cleanup (cluster-providers/kind-crossplane/Taskfile.yaml)

  Seed-secret FLEET_ prefix bug 

  Validation

  End-to-end validated against:

  - appmod-blueprints (this repo) at feature/agent-platform-shapirov
  - sample-open-agentic-platform at feature/refactor-agent-platform as the fleet repo

  Hub bootstrap, fleet-secret generation, addon ApplicationSets, agentic-platform addons, and Crossplane provider/composition installation all succeed with the split repo configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
