### PR TITLE
feat(gitlab): Dedicated NLB + CloudFront for GitLab in cloudfront mode

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -364,6 +364,8 @@ tasks:
           if [ "{{.EXPOSURE_MODE}}" = "cloudfront" ]; then
             cd {{.ROOT_DIR}} && task kind-crossplane:hub:create-alb
             cd {{.ROOT_DIR}} && task kind-crossplane:hub:cloudfront
+            cd {{.ROOT_DIR}} && task kind-crossplane:gitlab:create-nlb
+            cd {{.ROOT_DIR}} && task kind-crossplane:gitlab:cloudfront
           fi
       - task: secrets-manager:seed
       - task: secrets-manager:seed-keycloak
@@ -588,6 +590,99 @@ tasks:
       - rm -f {{.ROOT_DIR}}/private/hub-kubeconfig
       - printf '{{.C_OK}}✓ CloudFront distribution ready.{{.C_RESET}}\n'
 
+
+  gitlab:create-nlb:
+    desc: Pre-create GitLab NLB so CloudFront can be configured early (cloudfront mode only)
+    status:
+      - aws elbv2 describe-load-balancers --names {{.HUB_CLUSTER_NAME}}-gitlab --region {{.AWS_REGION}} 2>/dev/null
+    cmds:
+      - printf '{{.C_STEP}}▸ Creating GitLab NLB...{{.C_RESET}}\n'
+      - |
+        set -e
+        VPC_ID=$(aws eks describe-cluster --name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'cluster.resourcesVpcConfig.vpcId' --output text)
+        PUBLIC_SUBNETS=$(aws eks describe-cluster --name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'cluster.resourcesVpcConfig.subnetIds' --output text | tr '\t' '\n')
+        PUBLIC_SUBNETS=$(aws ec2 describe-subnets --subnet-ids $PUBLIC_SUBNETS --region {{.AWS_REGION}} --query 'Subnets[?MapPublicIpOnLaunch==`true`].SubnetId' --output text | tr '\t' ' ')
+        NLB_ARN=$(aws elbv2 create-load-balancer \
+          --name "{{.HUB_CLUSTER_NAME}}-gitlab" \
+          --subnets $PUBLIC_SUBNETS \
+          --scheme internet-facing \
+          --type network \
+          --tags Key=elbv2.k8s.aws/cluster,Value={{.HUB_CLUSTER_NAME}} Key=service.k8s.aws/stack,Value=gitlab/gitlab \
+          --region {{.AWS_REGION}} \
+          --query 'LoadBalancers[0].LoadBalancerArn' --output text)
+        # Default target group (HTTP, no targets — LBC will adopt and register)
+        TG_ARN=$(aws elbv2 create-target-group \
+          --name "{{.HUB_CLUSTER_NAME}}-gitlab-http" \
+          --protocol TCP --port 80 \
+          --vpc-id "$VPC_ID" \
+          --target-type ip \
+          --region {{.AWS_REGION}} \
+          --query 'TargetGroups[0].TargetGroupArn' --output text)
+        aws elbv2 create-listener \
+          --load-balancer-arn "$NLB_ARN" \
+          --protocol TCP --port 80 \
+          --default-actions "Type=forward,TargetGroupArn=$TG_ARN" \
+          --region {{.AWS_REGION}} > /dev/null
+        NLB_DNS=$(aws elbv2 describe-load-balancers --load-balancer-arns "$NLB_ARN" --region {{.AWS_REGION}} --query 'LoadBalancers[0].DNSName' --output text)
+        echo "GitLab NLB created: $NLB_DNS"
+      - printf '{{.C_OK}}✓ GitLab NLB ready.{{.C_RESET}}\n'
+
+  gitlab:cloudfront:
+    desc: Create CloudFront distribution for GitLab NLB (idempotent)
+    status:
+      - aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='{{.HUB_CLUSTER_NAME}}-gitlab'].Id" --output text | grep -q .
+    cmds:
+      - printf '{{.C_STEP}}▸ Creating GitLab CloudFront distribution...{{.C_RESET}}\n'
+      - |
+        set -e
+        NLB_DNS=$(aws elbv2 describe-load-balancers --names "{{.HUB_CLUSTER_NAME}}-gitlab" --region {{.AWS_REGION}} --query 'LoadBalancers[0].DNSName' --output text 2>/dev/null)
+        if [ -z "$NLB_DNS" ] || [ "$NLB_DNS" = "None" ]; then
+          echo "ERROR: GitLab NLB not found. Run gitlab:create-nlb first."
+          exit 1
+        fi
+        CF_CONFIG=$(cat <<'CFEOF'
+        {
+          "CallerReference": "{{.HUB_CLUSTER_NAME}}-gitlab-TIMESTAMP",
+          "Comment": "{{.HUB_CLUSTER_NAME}}-gitlab",
+          "Enabled": true,
+          "Origins": {
+            "Quantity": 1,
+            "Items": [{
+              "Id": "gitlab-nlb",
+              "DomainName": "NLB_DNS_PLACEHOLDER",
+              "CustomOriginConfig": {
+                "HTTPPort": 80,
+                "HTTPSPort": 443,
+                "OriginProtocolPolicy": "http-only",
+                "OriginSslProtocols": {"Quantity": 1, "Items": ["TLSv1.2"]}
+              }
+            }]
+          },
+          "DefaultCacheBehavior": {
+            "TargetOriginId": "gitlab-nlb",
+            "ViewerProtocolPolicy": "redirect-to-https",
+            "AllowedMethods": {"Quantity": 7, "Items": ["GET","HEAD","OPTIONS","PUT","POST","PATCH","DELETE"], "CachedMethods": {"Quantity": 2, "Items": ["GET","HEAD"]}},
+            "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+            "OriginRequestPolicyId": "216adef6-5c7f-47e4-b989-5492eafa07d3",
+            "Compress": true
+          },
+          "ViewerCertificate": {
+            "CloudFrontDefaultCertificate": true
+          },
+          "PriceClass": "PriceClass_100"
+        }
+        CFEOF
+        )
+        CF_CONFIG=$(echo "$CF_CONFIG" | sed "s|NLB_DNS_PLACEHOLDER|$NLB_DNS|g; s|TIMESTAMP|$(date +%s)|g")
+        DIST_OUTPUT=$(aws cloudfront create-distribution \
+          --distribution-config "$CF_CONFIG" \
+          --query "Distribution.{Id:Id,DomainName:DomainName}" --output json)
+        CF_DOMAIN=$(echo "$DIST_OUTPUT" | jq -r '.DomainName')
+        mkdir -p {{.ROOT_DIR}}/private
+        echo -n "$CF_DOMAIN" > {{.ROOT_DIR}}/private/gitlab-cloudfront-domain
+        echo "GitLab CloudFront: $CF_DOMAIN"
+      - printf '{{.C_OK}}✓ GitLab CloudFront distribution ready.{{.C_RESET}}\n'
+
   hub:wait-for-sync:
     desc: Wait for hub ArgoCD apps to reach Synced state
     vars:
@@ -775,6 +870,11 @@ tasks:
           if [ "$(yq '.modelS3Bucket.enabled // false' {{.CONFIG_FILE}})" = "true" ]; then
             echo "{{.RESOURCE_PREFIX}}-model-artifacts"
           fi
+      GITLAB_DOMAIN:
+        sh: |
+          if [ "{{.EXPOSURE_MODE}}" = "cloudfront" ] && [ -f {{.ROOT_DIR}}/private/gitlab-cloudfront-domain ]; then
+            cat {{.ROOT_DIR}}/private/gitlab-cloudfront-domain
+          fi
     cmds:
       - |
         SECRET_KEY="{{.HUB_CLUSTER_NAME}}/config"
@@ -786,7 +886,7 @@ tasks:
           --arg cluster_security_group_id "{{.CLUSTER_SG}}" \
           '{id: $id, subnet_ids: $subnet_ids, cluster_security_group_id: $cluster_security_group_id}' | jq -c .)
         SECRET_VALUE=$(jq -n \
-          --arg metadata '{"addonsRepoURL":"{{.REPO_URL}}","addonsRepoRevision":"{{.REPO_REVISION}}","addonsRepoBasepath":"{{.REPO_BASEPATH}}","fleetRepoURL":"{{.REPO_URL}}","fleetRepoRevision":"{{.REPO_REVISION}}","fleetRepoBasepath":"{{.REPO_BASEPATH}}","aws_region":"{{.AWS_REGION}}","aws_account_id":"{{.AWS_ACCOUNT_ID}}","aws_cluster_name":"{{.HUB_CLUSTER_NAME}}","aws_cluster_arn":"{{.CLUSTER_ARN}}","aws_vpc_id":"{{.VPC_ID}}","aws_subnet_ids":"{{.SUBNET_IDS}}","aws_private_subnet_ids":"{{.PRIVATE_SUBNET_IDS}}","aws_cluster_security_group_id":"{{.CLUSTER_SG}}","alb_controller_mode":"oss","ingress_domain_name":"{{.INGRESS_DOMAIN}}","ingress_name":"{{.INGRESS_NAME}}","ingress_security_groups":"{{.INGRESS_SECURITY_GROUPS}}","exposure_mode":"{{.EXPOSURE_MODE}}","resource_prefix":"{{.RESOURCE_PREFIX}}","admin_role_name":"{{.ADMIN_ROLE_NAME}}","model_s3_bucket":"{{.MODEL_S3_BUCKET}}"}' \
+          --arg metadata '{"addonsRepoURL":"{{.REPO_URL}}","addonsRepoRevision":"{{.REPO_REVISION}}","addonsRepoBasepath":"{{.REPO_BASEPATH}}","fleetRepoURL":"{{.REPO_URL}}","fleetRepoRevision":"{{.REPO_REVISION}}","fleetRepoBasepath":"{{.REPO_BASEPATH}}","aws_region":"{{.AWS_REGION}}","aws_account_id":"{{.AWS_ACCOUNT_ID}}","aws_cluster_name":"{{.HUB_CLUSTER_NAME}}","aws_cluster_arn":"{{.CLUSTER_ARN}}","aws_vpc_id":"{{.VPC_ID}}","aws_subnet_ids":"{{.SUBNET_IDS}}","aws_private_subnet_ids":"{{.PRIVATE_SUBNET_IDS}}","aws_cluster_security_group_id":"{{.CLUSTER_SG}}","alb_controller_mode":"oss","ingress_domain_name":"{{.INGRESS_DOMAIN}}","ingress_name":"{{.INGRESS_NAME}}","ingress_security_groups":"{{.INGRESS_SECURITY_GROUPS}}","exposure_mode":"{{.EXPOSURE_MODE}}","resource_prefix":"{{.RESOURCE_PREFIX}}","admin_role_name":"{{.ADMIN_ROLE_NAME}}","model_s3_bucket":"{{.MODEL_S3_BUCKET}}","gitlab_domain_name":"{{.GITLAB_DOMAIN}}"}' \
           --arg config '{"tlsClientConfig":{"insecure":false}}' \
           --arg server '{{.CLUSTER_ARN}}' \
           --arg addons '' \

--- a/gitops/addons/charts/gitlab/templates/gitlab.yaml
+++ b/gitops/addons/charts/gitlab/templates/gitlab.yaml
@@ -65,17 +65,21 @@ spec:
         ports:
         - containerPort: 80
           name: http
-        # - containerPort: 443
-        #   name: https
+{{- if ne (default "domain" .Values.exposure_mode) "cloudfront" }}
         - containerPort: 22
           name: ssh
+{{- end }}
         env:
         - name: GITLAB_OMNIBUS_CONFIG
           value: |
             external_url 'https://{{ .Values.domain_name }}'
             gitlab_rails['gitlab_shell_ssh_port'] = 22
             gitlab_rails['gitlab_shell_git_timeout'] = 800
+{{- if eq (default "domain" .Values.exposure_mode) "cloudfront" }}
+            gitlab_rails['enabled_git_access_protocol'] = 'http'
+{{- else }}
             gitlab_rails['enabled_git_access_protocol'] = 'ssh'
+{{- end }}
 
             # Disable Let's Encrypt
             letsencrypt['enable'] = false
@@ -210,9 +214,12 @@ metadata:
   name: gitlab
   namespace: gitlab
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-name: "gitlab"
+    service.beta.kubernetes.io/aws-load-balancer-name: "{{ .Values.global.aws_cluster_name }}-gitlab"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+{{- if .Values.security_groups }}
     service.beta.kubernetes.io/aws-load-balancer-security-groups: "{{ .Values.security_groups }}"
+{{- end }}
     service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "true"
 spec:
   type: LoadBalancer
@@ -221,9 +228,11 @@ spec:
   - name: http
     port: 80
     targetPort: 80
+{{- if ne (default "domain" .Values.exposure_mode) "cloudfront" }}
   - name: ssh
     port: 22
     targetPort: 22
+{{- end }}
   selector:
     app: gitlab
 ---

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -296,9 +296,12 @@ gitlab:
         operator: In
         values: ['true']
   valuesObject:
-    domain_name: '{{.metadata.annotations.ingress_domain_name}}'
+    domain_name: '{{default .metadata.annotations.ingress_domain_name .metadata.annotations.gitlab_domain_name}}'
     keycloak_domain_name: '{{.metadata.annotations.ingress_domain_name}}'
     security_groups: '{{.metadata.annotations.ingress_security_groups}}'
+    exposure_mode: '{{default "domain" .metadata.annotations.exposure_mode}}'
+    global:
+      aws_cluster_name: '{{.metadata.annotations.aws_cluster_name}}'
   ignoreDifferences:
     - group: external-secrets.io
       kind: ExternalSecret

--- a/gitops/overlays/environments/control-plane/enabled-addons.yaml
+++ b/gitops/overlays/environments/control-plane/enabled-addons.yaml
@@ -43,7 +43,7 @@ enabledAddons:
   backstage: true
   kubevela: false
   devlake: false
-  gitlab: false
+  gitlab: true
   # ACK controllers
   ack_iam: false
   ack_eks: false


### PR DESCRIPTION
## Summary

GitLab needs its own root URL (can't run at a subpath). This PR adds a dedicated NLB + CloudFront distribution for GitLab, pre-created early in bootstrap for fast startup.

## Changes

- **Taskfile**: `gitlab:create-nlb` and `gitlab:cloudfront` tasks, called during `hub:seed`
- **GitLab chart**: conditional SSH port (domain mode only), HTTP git protocol in cloudfront mode
- **Registry**: `gitlab_domain_name` annotation for dedicated CF domain
- **secrets-manager:seed**: includes `gitlab_domain_name` in metadata
- **enabled-addons**: GitLab enabled for control-plane

## Architecture

```
CloudFront (gitlab) → NLB (peeks-hub-gitlab, port 80) → GitLab pod
CloudFront (platform) → ALB (peeks-hub-platform) → Backstage/Keycloak/Argo
```

## Still TODO (follow-up commits)

- [ ] GitLab init job: create user, push templates from GitHub
- [ ] Backstage conditional integration (GitLab vs GitHub fallback)
- [ ] Seed GitLab credentials into Secrets Manager

Refs: #698, #699