### PR TITLE
fix(pod-identities): Guard PodIdentityAssociation against empty region

### DIFF
--- a/gitops/addons/charts/crossplane-pod-identity/templates/pod-identity-association.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/templates/pod-identity-association.yaml
@@ -1,5 +1,5 @@
 {{- range $name, $identity := .Values.identities }}
-{{- if not (eq (toString $identity.enabled) "false") }}
+{{- if and (not (eq (toString $identity.enabled) "false")) $.Values.aws.region }}
 ---
 apiVersion: eks.aws.upbound.io/v1beta1
 kind: PodIdentityAssociation

--- a/gitops/addons/charts/crossplane-pod-identity/values.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/values.yaml
@@ -1,8 +1,4 @@
-aws:
-  region: ""
-  clusterName: ""
-  accountId: ""
-
+aws: {}
 identities:
   eso:
     enabled: false


### PR DESCRIPTION
The EKS ArgoCD Capability does not reliably merge valuesObject over chart defaults for scalar values. When aws.region defaults to empty string in values.yaml, the rendered PodIdentityAssociation has no region field, failing CRD validation and blocking the entire pod-identities app from syncing (including LBC and external-dns).

Changes:
- Remove explicit empty-string defaults for aws (region, clusterName, accountId) from chart values.yaml — use aws: {} instead so valuesObject is the sole source
- Add aws.region guard to the PodIdentityAssociation template conditional — if region is empty, skip rendering instead of producing an invalid manifest

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
