### PR TITLE
fix: increase EKS cluster creation timeout to 60m

### DIFF
--- a/platform/infra/terraform/cluster/deploy.sh
+++ b/platform/infra/terraform/cluster/deploy.sh
@@ -119,6 +119,32 @@ main() {
   
   # Apply Terraform configuration
   log "Applying clusters stack..."
+
+  # Helper: wait for any CREATING clusters to reach a terminal state before retrying.
+  # Without this, a retry after a Terraform timeout hits ResourceInUseException because
+  # the clusters are still being created by AWS in the background.
+  wait_for_clusters() {
+    log "Waiting for in-progress EKS clusters to reach a terminal state before retrying..."
+    local cluster_names
+    cluster_names=$(aws eks list-clusters --query 'clusters[]' --output text 2>/dev/null || echo "")
+    for cluster in $cluster_names; do
+      local status
+      status=$(aws eks describe-cluster --name "$cluster" --query 'cluster.status' --output text 2>/dev/null || echo "")
+      if [[ "$status" == "CREATING" || "$status" == "UPDATING" ]]; then
+        log "  Cluster $cluster is $status — waiting up to 30m..."
+        local waited=0
+        while [[ "$status" == "CREATING" || "$status" == "UPDATING" ]] && (( waited < 1800 )); do
+          sleep 30
+          waited=$((waited + 30))
+          status=$(aws eks describe-cluster --name "$cluster" --query 'cluster.status' --output text 2>/dev/null || echo "")
+        done
+        log "  Cluster $cluster is now $status"
+      fi
+    done
+  }
+
+
+  log "Applying clusters stack..."
   if ! terraform -chdir=$DEPLOY_SCRIPTDIR apply \
     -var-file="${GENERATED_TFVAR_FILE}" \
     -var="hub_vpc_id=${HUB_VPC_ID}" \
@@ -127,6 +153,7 @@ main() {
     -var="workshop_participant_role_arn=${WS_PARTICIPANT_ROLE_ARN}" \
     -parallelism=3 -auto-approve; then
     log_warning "Terraform apply for clusters stack failed, trying again..."
+    wait_for_clusters
     if ! terraform -chdir=$DEPLOY_SCRIPTDIR apply \
       -var-file="${GENERATED_TFVAR_FILE}" \
       -var="hub_vpc_id=${HUB_VPC_ID}" \

--- a/platform/infra/terraform/cluster/deploy.sh
+++ b/platform/infra/terraform/cluster/deploy.sh
@@ -117,75 +117,7 @@ main() {
   fi
   cd -
   
-  # Import any EKS clusters that already exist in AWS but are missing from Terraform state.
-  # This handles the case where a previous apply timed out after creating the clusters
-  # but before saving state — preventing ResourceInUseException on the next apply.
-  import_existing_clusters() {
-    log "Checking for existing EKS clusters not yet in Terraform state..."
-    local state_clusters
-    state_clusters=$(terraform -chdir="$DEPLOY_SCRIPTDIR" state list 2>/dev/null | grep 'aws_eks_cluster' | sed 's/.*\["\(.*\)"\].*/\1/' || echo "")
-
-    # Get cluster names from config
-    local config_clusters
-    config_clusters=$(jq -r '.[].name' "$GENERATED_TFVAR_FILE" 2>/dev/null || echo "")
-
-    for cluster_name in $config_clusters; do
-      # Check if cluster exists in AWS
-      local status
-      status=$(aws eks describe-cluster --name "$cluster_name" --query 'cluster.status' --output text 2>/dev/null || echo "")
-      if [[ -z "$status" ]]; then
-        continue  # doesn't exist in AWS, nothing to import
-      fi
-
-      # Check if already in TF state
-      local tf_key
-      tf_key=$(terraform -chdir="$DEPLOY_SCRIPTDIR" state list 2>/dev/null | grep "aws_eks_cluster" | grep "$cluster_name" || echo "")
-      if [[ -z "$tf_key" ]]; then
-        log "  Importing existing cluster $cluster_name (status: $status) into Terraform state..."
-        # Find the for_each key for this cluster name
-        local for_each_key
-        for_each_key=$(jq -r "to_entries[] | select(.value.name==\"$cluster_name\") | .key" "$GENERATED_TFVAR_FILE" 2>/dev/null || echo "")
-        if [[ -n "$for_each_key" ]]; then
-          terraform -chdir="$DEPLOY_SCRIPTDIR" import \
-            -var-file="${GENERATED_TFVAR_FILE}" \
-            -var="hub_vpc_id=${HUB_VPC_ID}" \
-            -var="hub_subnet_ids=$(echo "${HUB_SUBNET_IDS}" | sed "s/'/\"/g")" \
-            -var="resource_prefix=${RESOURCE_PREFIX}" \
-            -var="workshop_participant_role_arn=${WS_PARTICIPANT_ROLE_ARN}" \
-            "module.eks[\"${for_each_key}\"].aws_eks_cluster.this[0]" "$cluster_name" || \
-            log_warning "  Import of $cluster_name failed, continuing anyway"
-        fi
-      else
-        log "  Cluster $cluster_name already in Terraform state"
-      fi
-    done
-  }
-  import_existing_clusters
-
-
-  # Without this, a retry after a Terraform timeout hits ResourceInUseException because
-  # the clusters are still being created by AWS in the background.
-  wait_for_clusters() {
-    log "Waiting for in-progress EKS clusters to reach a terminal state before retrying..."
-    local cluster_names
-    cluster_names=$(aws eks list-clusters --query 'clusters[]' --output text 2>/dev/null || echo "")
-    for cluster in $cluster_names; do
-      local status
-      status=$(aws eks describe-cluster --name "$cluster" --query 'cluster.status' --output text 2>/dev/null || echo "")
-      if [[ "$status" == "CREATING" || "$status" == "UPDATING" ]]; then
-        log "  Cluster $cluster is $status — waiting up to 30m..."
-        local waited=0
-        while [[ "$status" == "CREATING" || "$status" == "UPDATING" ]] && (( waited < 1800 )); do
-          sleep 30
-          waited=$((waited + 30))
-          status=$(aws eks describe-cluster --name "$cluster" --query 'cluster.status' --output text 2>/dev/null || echo "")
-        done
-        log "  Cluster $cluster is now $status"
-      fi
-    done
-  }
-
-
+  # Apply Terraform configuration
   log "Applying clusters stack..."
   if ! terraform -chdir=$DEPLOY_SCRIPTDIR apply \
     -var-file="${GENERATED_TFVAR_FILE}" \
@@ -195,7 +127,6 @@ main() {
     -var="workshop_participant_role_arn=${WS_PARTICIPANT_ROLE_ARN}" \
     -parallelism=3 -auto-approve; then
     log_warning "Terraform apply for clusters stack failed, trying again..."
-    wait_for_clusters
     if ! terraform -chdir=$DEPLOY_SCRIPTDIR apply \
       -var-file="${GENERATED_TFVAR_FILE}" \
       -var="hub_vpc_id=${HUB_VPC_ID}" \

--- a/platform/infra/terraform/cluster/deploy.sh
+++ b/platform/infra/terraform/cluster/deploy.sh
@@ -117,10 +117,52 @@ main() {
   fi
   cd -
   
-  # Apply Terraform configuration
-  log "Applying clusters stack..."
+  # Import any EKS clusters that already exist in AWS but are missing from Terraform state.
+  # This handles the case where a previous apply timed out after creating the clusters
+  # but before saving state — preventing ResourceInUseException on the next apply.
+  import_existing_clusters() {
+    log "Checking for existing EKS clusters not yet in Terraform state..."
+    local state_clusters
+    state_clusters=$(terraform -chdir="$DEPLOY_SCRIPTDIR" state list 2>/dev/null | grep 'aws_eks_cluster' | sed 's/.*\["\(.*\)"\].*/\1/' || echo "")
 
-  # Helper: wait for any CREATING clusters to reach a terminal state before retrying.
+    # Get cluster names from config
+    local config_clusters
+    config_clusters=$(jq -r '.[].name' "$GENERATED_TFVAR_FILE" 2>/dev/null || echo "")
+
+    for cluster_name in $config_clusters; do
+      # Check if cluster exists in AWS
+      local status
+      status=$(aws eks describe-cluster --name "$cluster_name" --query 'cluster.status' --output text 2>/dev/null || echo "")
+      if [[ -z "$status" ]]; then
+        continue  # doesn't exist in AWS, nothing to import
+      fi
+
+      # Check if already in TF state
+      local tf_key
+      tf_key=$(terraform -chdir="$DEPLOY_SCRIPTDIR" state list 2>/dev/null | grep "aws_eks_cluster" | grep "$cluster_name" || echo "")
+      if [[ -z "$tf_key" ]]; then
+        log "  Importing existing cluster $cluster_name (status: $status) into Terraform state..."
+        # Find the for_each key for this cluster name
+        local for_each_key
+        for_each_key=$(jq -r "to_entries[] | select(.value.name==\"$cluster_name\") | .key" "$GENERATED_TFVAR_FILE" 2>/dev/null || echo "")
+        if [[ -n "$for_each_key" ]]; then
+          terraform -chdir="$DEPLOY_SCRIPTDIR" import \
+            -var-file="${GENERATED_TFVAR_FILE}" \
+            -var="hub_vpc_id=${HUB_VPC_ID}" \
+            -var="hub_subnet_ids=$(echo "${HUB_SUBNET_IDS}" | sed "s/'/\"/g")" \
+            -var="resource_prefix=${RESOURCE_PREFIX}" \
+            -var="workshop_participant_role_arn=${WS_PARTICIPANT_ROLE_ARN}" \
+            "module.eks[\"${for_each_key}\"].aws_eks_cluster.this[0]" "$cluster_name" || \
+            log_warning "  Import of $cluster_name failed, continuing anyway"
+        fi
+      else
+        log "  Cluster $cluster_name already in Terraform state"
+      fi
+    done
+  }
+  import_existing_clusters
+
+
   # Without this, a retry after a Terraform timeout hits ResourceInUseException because
   # the clusters are still being created by AWS in the background.
   wait_for_clusters() {

--- a/platform/infra/terraform/cluster/main.tf
+++ b/platform/infra/terraform/cluster/main.tf
@@ -66,6 +66,15 @@ module "eks" {
     node_pools = ["system"]
   }
 
+  # Increase EKS cluster creation timeout — Auto Mode clusters in fresh accounts
+  # can take longer than the 30m default, causing the deploy to fail with a timeout
+  # and triggering a retry that hits ResourceInUseException (cluster still CREATING).
+  cluster_timeouts = {
+    create = "60m"
+    update = "60m"
+    delete = "30m"
+  }
+
   tags = {
     Blueprint  = local.context_prefix
     GithubRepo = "https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest"

--- a/platform/infra/terraform/cluster/main.tf
+++ b/platform/infra/terraform/cluster/main.tf
@@ -69,7 +69,7 @@ module "eks" {
   # Increase EKS cluster creation timeout — Auto Mode clusters in fresh accounts
   # can take longer than the 30m default, causing the deploy to fail with a timeout
   # and triggering a retry that hits ResourceInUseException (cluster still CREATING).
-  cluster_timeouts = {
+  timeouts = {
     create = "60m"
     update = "60m"
     delete = "30m"


### PR DESCRIPTION
## Problem

In fresh accounts (e.g. Workshop Studio sandboxes), EKS Auto Mode clusters can take longer than the Terraform AWS provider default 30m create timeout to become `ACTIVE`. When the waiter times out, `cluster/deploy.sh` retries `terraform apply`, but the clusters are still `CREATING` and the retry fails with:

```
ResourceInUseException: Cluster already exists with name: peeks-hub
```

This causes intermittent `deployment_failed` on the clusters stack.

## Fix

Set an explicit `timeouts` block on the EKS module so the create waiter allows up to 60m:

```hcl
timeouts = {
  create = "60m"
  update = "60m"
  delete = "30m"
}
```

Note: the correct input variable for terraform-aws-modules/eks/aws **v21** is `timeouts` (not `cluster_timeouts`). Validated with `terraform validate`.

## Why only the timeout

We also prototyped a defensive retry path (wait for CREATING→ACTIVE, then `terraform state rm` + `import` to reconcile a half-written state). Testing showed that importing only `aws_eks_cluster` in isolation breaks the EKS module (`Error: Attempt to index null value` on dependent resources like the OIDC provider). The module is not designed for partial imports, so that approach is unreliable and was dropped. Increasing the timeout prevents the half-written state from happening in the first place, which is the robust fix.

## Testing

- `terraform validate` passes.
- Verified the failure mode and root cause end-to-end on Workshop Studio test events.