### PR TITLE
feat(bootstrap): seed Crossplane provider identity for spoke clusters

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -1666,6 +1666,63 @@ tasks:
       - kubectl -n crossplane-system wait --for=condition=Ready --timeout=1800s platformclusters.platform.gitops.io/{{.HUB_CLUSTER_NAME}}
       - task: destroy-kind
 
+  spokes:seed-provider-identity:
+    desc: >-
+      Seed the bootstrap Crossplane provider IAM roles + EKS Pod Identity
+      associations for spoke clusters (same account). The iam/eks providers are
+      createIdentity:false in the registry, so crossplane-base does NOT create
+      their roles; without this seed a spoke's iam/eks providers cannot
+      authenticate (chicken-and-egg). Mirrors the hub bootstrap. Idempotent.
+      Run after spokes are provisioned (ACTIVE). Cross-account spokes are NOT
+      handled here - their roles must be bootstrapped in the target account.
+    cmds:
+      - cmd: |
+          # provider service-account suffix -> IAM role name suffix
+          PROVIDERS="iam:CrossplaneIAMProviderRole eks:CrossplaneEKSProviderRole"
+          # Discover spokes from fleet members, excluding the hub.
+          SPOKES=$(ls "{{.GITOPS_ROOT}}/fleet/members" 2>/dev/null | grep -vx "{{.HUB_CLUSTER_NAME}}" || true)
+          if [ -z "$SPOKES" ]; then
+            printf '{{.C_INFO}}  No spoke members under fleet/members; nothing to seed.{{.C_RESET}}\n'
+            exit 0
+          fi
+          for SPOKE in $SPOKES; do
+            STATUS=$(aws eks describe-cluster --name "$SPOKE" --region {{.AWS_REGION}} --query 'cluster.status' --output text 2>/dev/null || echo "NONE")
+            if [ "$STATUS" != "ACTIVE" ]; then
+              printf '{{.C_INFO}}  Skipping %s (cluster status: %s){{.C_RESET}}\n' "$SPOKE" "$STATUS"
+              continue
+            fi
+            for ENTRY in $PROVIDERS; do
+              SVC="${ENTRY%%:*}"            # iam | eks
+              ROLE_NAME="${SPOKE}-${ENTRY##*:}"
+              SA="provider-aws-${SVC}"
+              ROLE_ARN="arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/${ROLE_NAME}"
+              # 1. IAM role trusting EKS Pod Identity (idempotent)
+              if ! aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+                aws iam create-role --role-name "$ROLE_NAME" \
+                  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"pods.eks.amazonaws.com"},"Action":["sts:AssumeRole","sts:TagSession"]}]}' \
+                  --tags Key=managed-by,Value=platform-bootstrap Key=purpose,Value="${SVC}-provider" >/dev/null
+                printf '{{.C_OK}}  ✓ %s: created role %s{{.C_RESET}}\n' "$SPOKE" "$ROLE_NAME"
+              else
+                printf '{{.C_INFO}}  %s: role %s exists{{.C_RESET}}\n' "$SPOKE" "$ROLE_NAME"
+              fi
+              # 2. AdministratorAccess (attach is idempotent)
+              aws iam attach-role-policy --role-name "$ROLE_NAME" \
+                --policy-arn arn:aws:iam::aws:policy/AdministratorAccess >/dev/null
+              # 3. Pod Identity association on the spoke (idempotent)
+              EXISTING=$(aws eks list-pod-identity-associations --cluster-name "$SPOKE" --region {{.AWS_REGION}} \
+                --namespace crossplane-system --service-account "$SA" \
+                --query 'associations[0].associationId' --output text 2>/dev/null || echo "None")
+              if [ "$EXISTING" = "None" ] || [ -z "$EXISTING" ]; then
+                aws eks create-pod-identity-association --cluster-name "$SPOKE" --region {{.AWS_REGION}} \
+                  --namespace crossplane-system --service-account "$SA" --role-arn "$ROLE_ARN" >/dev/null
+                printf '{{.C_OK}}  ✓ %s: pod identity %s -> %s{{.C_RESET}}\n' "$SPOKE" "$SA" "$ROLE_NAME"
+              else
+                printf '{{.C_INFO}}  %s: pod identity for %s exists{{.C_RESET}}\n' "$SPOKE" "$SA"
+              fi
+            done
+          done
+          printf '{{.C_OK}}✓ Spoke provider identity seeding complete.{{.C_RESET}}\n'
+
   hub:destroy-addons:
     desc: Remove all addons from the hub cluster (no git changes needed)
     vars:


### PR DESCRIPTION
## Summary
Adds an idempotent Taskfile task `spokes:seed-provider-identity` that seeds the bootstrap Crossplane provider IAM roles + EKS Pod Identity associations for **same-account** spoke clusters. This fixes the root cause behind `crossplane-base-spoke-*` staying `Degraded`.

## Background / root cause
- In the addon registry, the `iam` and `eks` providers are `createIdentity: false` ("bootstrap-managed"), so `crossplane-base/templates/iam.yaml` does **not** create their `Role` / `RolePolicyAttachment` / `PodIdentityAssociation`.
- Nothing else seeds them for spokes either:
  - The `XPlatformCluster` composition creates only cluster/node/mng roles + access entries + KRO/ACK capabilities.
  - The `crossplane-pod-identity` chart only covers ESO / LBC / external-dns.
- This is a **chicken-and-egg**: a spoke's `provider-aws-iam` / `provider-aws-eks` need the very credentials (Pod Identity) that they would otherwise create. They cannot bootstrap themselves.
- The **hub** breaks this during `task install` by rendering `crossplane-base` with the chart default (`createIdentity: true`) from the credentialed Kind cluster. Spokes had **no equivalent step**.

Result: a freshly provisioned spoke (e.g. `spoke-prod`) is left without `spoke-prod-Crossplane{IAM,EKS}ProviderRole` and its associations → its iam/eks providers fail with `no EC2 IMDS role found` → `crossplane-base-spoke-prod` `Degraded`. (`spoke-dev` only has them as leftover MRs from a period when `createIdentity` was `true`.)

## What this task does (idempotent)
For each fleet member under `gitops/fleet/members/` (excluding the hub) whose EKS cluster is `ACTIVE`, and for `provider-aws-iam` + `provider-aws-eks`:
1. Create `<spoke>-Crossplane{IAM,EKS}ProviderRole` trusting `pods.eks.amazonaws.com` (`sts:AssumeRole` + `sts:TagSession`) — skipped if it already exists.
2. Attach `AdministratorAccess` (attach is idempotent) — mirrors the hub / spoke-dev pattern.
3. Create the `crossplane-system` Pod Identity association `provider-aws-{iam,eks}` → role on the spoke — skipped if it already exists.

Run it after spokes are provisioned: `task spokes:seed-provider-identity`. Safe to re-run; skips non-ACTIVE spokes.

## Scope / limitations
- **Same-account spokes only.** Cross-account spokes are intentionally out of scope: their `cluster-mgmt-*` / provider roles must be bootstrapped **in the target account** with a trust policy allowing the hub's capability role. The hub's account credentials cannot create roles in another account without assuming a bootstrap role there (better handled by a per-account bootstrap or an Org CloudFormation StackSet).
- `AdministratorAccess` matches the existing platform pattern (hub + spoke-dev). Tightening is a separate follow-up.
- This is the Taskfile (imperative bootstrap) path; a fully GitOps-native alternative would be to have the hub `XPlatformCluster` composition create these during spoke provisioning. Documented as a future option.

## Testing
- [x] `Taskfile.yaml` parses as YAML (`yaml.safe_load`)
- [x] `task --list` shows the new task and description
- [ ] Run `task spokes:seed-provider-identity` against `spoke-prod` and confirm `crossplane-base-spoke-prod` reaches Synced/Healthy

## Note on the live incident
`spoke-prod` is currently blocked by exactly this gap. Merging this task provides the supported, repeatable way to seed it (equivalent to the manual unblock).