### PR TITLE
feat: enable selfHeal on ApplicationSets for automatic drift correction

### DIFF
--- a/gitops/fleet/bootstrap/addons.yaml
+++ b/gitops/fleet/bootstrap/addons.yaml
@@ -42,7 +42,7 @@ spec:
         name: '{{.name}}'
       syncPolicy:
         automated:
-          selfHeal: false
+          selfHeal: true
           allowEmpty: true
           prune: false
         retry:

--- a/gitops/fleet/bootstrap/clusters.yaml
+++ b/gitops/fleet/bootstrap/clusters.yaml
@@ -54,7 +54,7 @@ spec:
         name: '{{.name}}'
       syncPolicy:
         automated:
-          selfHeal: false
+          selfHeal: true
           allowEmpty: true
           prune: true
         retry:


### PR DESCRIPTION
Enables `selfHeal: true` on the `addons` and `clusters` ApplicationSets.

## Why

With `selfHeal: false` (current default), drifted resources accumulate silently and critical resources like NodePools can remain undeployed after sync failures. This caused a cascading issue where:

1. `platform-manifests-bootstrap` sync failed (webhook down)
2. NodePools never applied → no nodes → all pods Pending
3. Manual intervention required every time

## What changes

- `gitops/fleet/bootstrap/addons.yaml`: `selfHeal: false` → `true`
- `gitops/fleet/bootstrap/clusters.yaml`: `selfHeal: false` → `true`

## Risk

Kyverno CRDs may show reconciliation loops due to cosmetic diffs. If this becomes an issue, add `ServerSideDiff` + `RespectIgnoreDifferences` annotations to the kyverno app specifically.