### PR TITLE
feat(crossplane-base): enable provider-aws-dynamodb on all clusters

### DIFF
--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -61,6 +61,9 @@ crossplane-base:
       rds:
         version: "v2.5.3"
         createIdentity: true
+      dynamodb:
+        version: "v2.5.3"
+        createIdentity: true
       amp:
         version: "v2.5.3"
         createIdentity: true


### PR DESCRIPTION
## Summary
Enables `provider-aws-dynamodb` in the `crossplane-base` registry so the KubeVela path can provision DynamoDB tables on the spokes. Fixes the remaining 🔴 items from the KubeVela validation report (#7 and #8) that left **20.4 PROD PARTIAL** (DynamoDB table blocked).

## Root cause
`provider-aws-dynamodb` was absent from the `crossplane-base` providers list in `gitops/addons/registry/platform.yaml` (only iam, ec2, eks, rds, amp, grafana, kubernetes were enabled). Without it, no `Table` CRD or controller exists on the spokes, so KubeVela's `ddbtable` ComponentDefinition cannot reconcile.

## Change
```yaml
      dynamodb:
        version: "v2.5.3"
        createIdentity: true
```

Because the provider is `createIdentity: true`, `crossplane-base/templates/iam.yaml` automatically creates everything it needs — so **one config change covers both report items**:
- **#7 — install the provider**: `providers.yaml` renders `Provider/provider-aws-dynamodb` (+ SA + DeploymentRuntimeConfig from `provider-config.yaml`).
- **#8 — pod identity / DynamoDB permissions**: `iam.yaml` renders `Role/dynamodb-provider-role` (external-name `<cluster>-CrossplaneDynamoDBProviderRole`, trust `pods.eks.amazonaws.com`) + `RolePolicyAttachment` (AdministratorAccess) + `PodIdentityAssociation` (provider-aws-dynamodb SA → role).

## Note on the report's crossplane-pod-identity suggestion
The report recommended ensuring `crossplane-pod-identity` creates the association. That chart only covers `createIdentity: false` add-ons (ESO / LBC / external-dns). For `createIdentity: true` providers (ec2/amp/grafana/rds/**dynamodb**), the role + Pod Identity association are created by `crossplane-base` itself, so **no `crossplane-pod-identity` change is required**.

## Dependency
On spokes this relies on the iam/eks provider identity seed being present (`task spokes:seed-provider-identity`, added separately). With the seed in place on spoke-prod, the dynamodb provider's role + association are created by the (now authenticated) iam/eks providers, the provider installs, gets Pod Identity, and reconciles `Table` resources via the existing `provider-aws-config` ProviderConfig (`source: PodIdentity`, verified present on spoke-prod).

## Testing
- [x] `gitops/addons/registry/platform.yaml` parses as YAML; `dynamodb` present under `crossplane-base.valuesObject.providers`
- [x] `helm template crossplane-base --set providers.dynamodb.version=v2.5.3` renders `Provider/provider-aws-dynamodb`, `Role/dynamodb-provider-role`, `RolePolicyAttachment`, and `PodIdentityAssociation`
- [ ] Post-merge: sync, confirm provider-aws-dynamodb HEALTHY on spoke-prod and the KubeVela `Table` reconciles (20.4 PROD)

## Scope
Enables dynamodb on all crossplane-base clusters (hub, spoke-dev, spoke-prod), consistent with the other `createIdentity: true` providers. `+3` lines, registry-only.