### PR TITLE
fix(kubevela): ServerSideApply to stop vela-core webhook config drift

### DIFF
--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -234,6 +234,26 @@ kubevela:
         values: ['true']
   valuesObject:
     systemDefinitionNamespace: vela-system
+  # Replicates the inherited default syncPolicy and adds ServerSideApply so the
+  # apiserver-defaulted fields on the vela-core admission webhooks
+  # (matchPolicy/namespaceSelector/objectSelector/timeoutSeconds/rules.scope) are
+  # reconciled via server-side field ownership instead of showing as permanent
+  # drift. NOTE: a per-addon syncPolicy fully overrides the default, so the
+  # default values are replicated below.
+  syncPolicy:
+    automated:
+      selfHeal: false
+      allowEmpty: true
+      prune: false
+    retry:
+      limit: -1
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 10m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
   ignoreDifferences:
     - group: admissionregistration.k8s.io
       kind: MutatingWebhookConfiguration


### PR DESCRIPTION
## Summary
Stops `kubevela-spoke-*` (and hub) apps from being permanently `OutOfSync` on the `vela-core-admission` `Mutating`/`ValidatingWebhookConfiguration`. Cosmetic only — the apps were already `Healthy` and KubeVela is fully functional.

## Root cause
The OutOfSync is **not** the `caBundle` (already covered by `ignoreDifferences`). It is **apiserver server-side defaulting** of fields the rendered Git manifest omits:
```
matchPolicy:       null  ->  "Equivalent"
namespaceSelector: null  ->  {}
objectSelector:    null  ->  {}
rules[].scope:     (absent) ->  "*"
timeoutSeconds:    null  ->  10
```
A normal sync re-applies the Git version, the apiserver re-defaults these fields, and the diff returns — so the app reports `op=Succeeded` yet stays `OutOfSync` forever.

The registry entry already has an `ignoreDifferences` rule with `managedFieldsManagers` including `apiserver`, but that only takes effect with **server-side diff**.

## Fix
Add a per-addon `syncPolicy` for `kubevela` with `ServerSideApply=true`. ArgoCD then performs server-side apply/diff and honours field ownership, so the apiserver-defaulted fields no longer register as drift.

Because a per-addon `syncPolicy` **fully overrides** the inherited default (`_defaults.yaml`), the default `automated` / `retry` / `CreateNamespace=true` values are replicated alongside the new `ServerSideApply=true`.

```yaml
  syncPolicy:
    automated: { selfHeal: false, allowEmpty: true, prune: false }
    retry: { limit: -1, backoff: { duration: 5s, factor: 2, maxDuration: 10m } }
    syncOptions:
      - CreateNamespace=true
      - ServerSideApply=true
```

## Testing
- [x] `gitops/addons/registry/platform.yaml` parses as YAML
- [x] `kubevela.syncPolicy.syncOptions` = `[CreateNamespace=true, ServerSideApply=true]`; `automated`/`retry` match the inherited default
- [ ] Post-merge: re-render the `cluster-addons` appset, confirm `kubevela-spoke-prod` (and hub/dev) reach `Synced/Healthy`

## Scope / risk
Registry-only, `+20` lines, scoped to the `kubevela` addon. No functional change to KubeVela; only how ArgoCD applies/diffs its resources. Verified the previous functional incident work is unaffected (20.4 PROD: DynamoDB table ACTIVE, all other spoke-prod apps Synced/Healthy).