### PR TITLE
fix: register DynamoDB Table template in Backstage catalog location

### DIFF
--- a/platform/backstage/templates/catalog-info.yaml
+++ b/platform/backstage/templates/catalog-info.yaml
@@ -18,6 +18,7 @@ spec:
     - ./create-dev-and-prod-env/template-create-dev-and-prod-env.yaml
     - ./cicd-pipeline/template-cicd-pipeline.yaml
     - ./platform-entities.yaml
+    - ../customtemplates/ddb-table/template.yaml
 ---
 apiVersion: backstage.io/v1alpha1
 kind: System

--- a/platform/backstage/templates/catalog-info.yaml
+++ b/platform/backstage/templates/catalog-info.yaml
@@ -18,7 +18,8 @@ spec:
     - ./create-dev-and-prod-env/template-create-dev-and-prod-env.yaml
     - ./cicd-pipeline/template-cicd-pipeline.yaml
     - ./platform-entities.yaml
-    - ../customtemplates/ddb-table/template.yaml
+    # Uncomment the line below to register the custom DynamoDB template (Module 1 - GenAI section)
+    # - ../customtemplates/ddb-table/template.yaml
 ---
 apiVersion: backstage.io/v1alpha1
 kind: System


### PR DESCRIPTION
## Summary

Fixes #727

Adds the DynamoDB Table template as a **commented-out entry** in `platform/backstage/templates/catalog-info.yaml`. Participants uncomment the line as part of the GenAI lab to register their AI-generated template via GitOps.

## Change

```diff
     - ./cicd-pipeline/template-cicd-pipeline.yaml
     - ./platform-entities.yaml
+    # Uncomment the line below to register the custom DynamoDB template (Module 1 - GenAI section)
+    # - ../customtemplates/ddb-table/template.yaml
```

## Why this approach

- The manual "Register Existing Component" import UI silently fails for this GitLab integration (see #727 for root cause)
- `templates/catalog-info.yaml` is the **only** catalog location Backstage polls (confirmed in `backstage-config` ConfigMap)
- Keeping the line commented preserves the learning objective: participants discover the GitOps pattern of modifying a platform config file to register a template

## Participant flow (replaces broken import UI steps)

1. Generate DDB template with AI, compare with reference solution
2. Uncomment `# - ../customtemplates/ddb-table/template.yaml` in `catalog-info.yaml`
3. `git add / commit / push`
4. `kubectl rollout restart deployment/backstage -n backstage && kubectl rollout status ...` (~60s)
5. Template immediately visible in Backstage Create page

**Note:** The companion workshop content change (updating `005_Section4_Gitlab_Push/index.en.md` to replace the broken import steps with the GitOps steps above) must be applied in the workshop content repo (GitLab).

## Testing

Verified end-to-end:
- [x] Commented line present — template NOT in Backstage Create page ✅
- [x] Uncomment + git push + kubectl rollout restart ✅
- [x] Backstage pod comes up in ~60s ✅
- [x] Template immediately available at `/backstage/create/templates/default/ddb-table-template-ack-kro` ✅
- [x] Template form loads, submission creates DynamoDB table ✅