### PR TITLE
fix: update DORA dashboard URLs to graduated apache/devlake repo

### DIFF
--- a/gitops/addons/charts/grafana-dashboards/templates/dora-dashboards.yaml
+++ b/gitops/addons/charts/grafana-dashboards/templates/dora-dashboards.yaml
@@ -9,7 +9,7 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: "external-grafana"
-  url: "https://raw.githubusercontent.com/apache/incubator-devlake/refs/heads/main/grafana/dashboards/DORA.json"
+  url: "https://raw.githubusercontent.com/apache/devlake/refs/heads/main/grafana/dashboards/mysql/DORA.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -21,7 +21,7 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: "external-grafana"
-  url: "https://raw.githubusercontent.com/apache/incubator-devlake/refs/heads/main/grafana/dashboards/DORADetails-DeploymentFrequency.json"
+  url: "https://raw.githubusercontent.com/apache/devlake/refs/heads/main/grafana/dashboards/mysql/dora-details-deployment-frequency.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -33,7 +33,7 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: "external-grafana"
-  url: "https://raw.githubusercontent.com/apache/incubator-devlake/refs/heads/main/grafana/dashboards/DORADetails-ChangeFailureRate.json"
+  url: "https://raw.githubusercontent.com/apache/devlake/refs/heads/main/grafana/dashboards/mysql/dora-details-change-failure-rate.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -45,7 +45,7 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: "external-grafana"
-  url: "https://raw.githubusercontent.com/apache/incubator-devlake/refs/heads/main/grafana/dashboards/DORADetails-FailedDeploymentRecoveryTime.json"
+  url: "https://raw.githubusercontent.com/apache/devlake/refs/heads/main/grafana/dashboards/mysql/dora-details-failed-deployment-recovery-time.json"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -57,4 +57,4 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: "external-grafana"
-  url: "https://raw.githubusercontent.com/apache/incubator-devlake/refs/heads/main/grafana/dashboards/DORADetails-LeadTimeforChanges.json"
+  url: "https://raw.githubusercontent.com/apache/devlake/refs/heads/main/grafana/dashboards/mysql/dora-details-lead-timefor-changes.json"


### PR DESCRIPTION
## Summary

Fixes #729

The DORA dashboards never appear in Grafana because the `GrafanaDashboard` CRs reference DevLake dashboard JSON files at URLs that now return 404.

## Root Cause

1. Apache DevLake graduated from incubation: `apache/incubator-devlake` -> `apache/devlake`.
2. Dashboard JSON files moved into DB-specific subdirectories (`mysql/`, `postgresql/`) and were renamed.

The Grafana operator logs `failed to fetch contents: ... get 404 ... reason: InvalidModelResolution`, so the dashboards are never created and the `DORA Dashboards` folder never appears. See #729 for full analysis.

## Fix

Update all 5 DORA dashboard URLs to `apache/devlake` under `grafana/dashboards/mysql/` (this workshop's DevLake uses an RDS MySQL backend per `devlake/templates/rds.yaml`).

## Testing

Verified end-to-end in a Workshop Studio environment (us-west-2):
- [x] Patched a live GrafanaDashboard URL to the new `mysql/` path
- [x] Operator status changed from `InvalidSpec`/404 to resolved `contentUrl` + content hash
- [x] `DORA Dashboards` folder now appears in Grafana
- [x] DORA dashboard renders the Overall DORA Metrics panel (Deployment frequency, Lead time for changes, Change failure rate, Failed deployment recovery time)
- [x] All 5 new URLs return HTTP 200