### PR TITLE
fix: repair empty Grafana panels for Rust metrics and EKS workload/compute dashboards

### DIFF
--- a/gitops/addons/charts/grafana-dashboards/templates/rust-dashboard.yaml
+++ b/gitops/addons/charts/grafana-dashboards/templates/rust-dashboard.yaml
@@ -197,13 +197,22 @@ spec:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "expr": "histogram_quantile(0.5, rate(rocket_http_requests_duration_seconds_bucket{endpoint!=\"/metrics\"}[$__range])) * 10000",
-              "legendFormat": "{{ `{{endpoint}}` }}",
+              "expr": "histogram_quantile(0.5, sum(rate(rocket_http_requests_duration_seconds_bucket{endpoint!=\"/metrics\"}[5m])) by (le)) * 1000",
+              "legendFormat": "p50",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "expr": "histogram_quantile(0.95, sum(rate(rocket_http_requests_duration_seconds_bucket{endpoint!=\"/metrics\"}[5m])) by (le)) * 1000",
+              "legendFormat": "p95",
+              "refId": "B"
             }
           ],
           "title": "Response Time Distribution",
-          "type": "histogram"
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -286,18 +295,9 @@ spec:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "expr": "rate(process_cpu_seconds_total{container_name=\"rust-app\"}[1m])",
-              "legendFormat": "process",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"rust-microservice\", namespace=\"team-rust\"}[1m])) by (pod)",
+              "legendFormat": "{{pod}}",
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "expr": "sum(rate(container_cpu_usage_seconds_total{container_name=\"rust-app\"}[1m])) by (name)",
-              "legendFormat": "container",
-              "refId": "B"
             }
           ],
           "title": "CPU usage",
@@ -329,18 +329,9 @@ spec:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "expr": "process_resident_memory_bytes{container_name=\"rust-app\"} / 1024 / 1024",
-              "legendFormat": "process",
+              "expr": "sum(container_memory_working_set_bytes{container=\"rust-microservice\", namespace=\"team-rust\"}) by (pod) / 1024 / 1024",
+              "legendFormat": "{{pod}}",
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "expr": "container_memory_usage_bytes{container_name=\"rust-app\"} / 1024 / 1024",
-              "legendFormat": "container",
-              "refId": "B"
             }
           ],
           "title": "Memory usage",

--- a/platform/infra/terraform/common/manifests/scraper-config-accelerator.yaml
+++ b/platform/infra/terraform/common/manifests/scraper-config-accelerator.yaml
@@ -50,6 +50,10 @@ scrape_configs:
       source_labels:
       - __meta_kubernetes_node_name
       target_label: __metrics_path__
+    # The aws-observability-accelerator recording rules and dashboards expect
+    # kubelet metrics under job="kubelet". Override the job label accordingly.
+    - replacement: kubelet
+      target_label: job
     scheme: https
     scrape_interval: 60s
     scrape_timeout: 15s
@@ -73,10 +77,14 @@ scrape_configs:
     - replacement: kubernetes.default.svc:443
       target_label: __address__
     - regex: (.+)
-      replacement: /api/v1/nodes/$${1}/proxy/metrics/cadvisor
+      replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
       source_labels:
       - __meta_kubernetes_node_name
       target_label: __metrics_path__
+    # The aws-observability-accelerator recording rules and dashboards expect
+    # cAdvisor container_* metrics under job="kubelet". Override the job label.
+    - replacement: kubelet
+      target_label: job
     scheme: https
     tls_config:
       ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
## Summary

Fixes #731

Repairs empty Grafana panels in the **Rust Metrics** dashboard (Module 3 – Metrics Driven Decisions) and several AWS Observability Accelerator dashboards in the **Platform / Workload Observability** folders. Three independent root causes, all confirmed and fixed against the live AMP workspace.

## Changes

### `platform/infra/terraform/common/manifests/scraper-config-accelerator.yaml`

1. **Fix the cAdvisor scrape path.** The `cadvisor` job used a double-dollar capture group `/api/v1/nodes/$${1}/proxy/metrics/cadvisor`; Prometheus renders `$$` as a literal `$`, so the node name was never substituted and every scrape 404'd (`up{job="cadvisor"}=0`, zero `container_*` metrics in AMP). Changed to single dollar `${1}`, matching the working kubelet job.
2. **Align the job label with the recording rules.** The observability-accelerator recording rules and dashboards expect kubelet/cAdvisor metrics under `job="kubelet"`, but the scraper labeled them `kubernetes-kubelet` / `cadvisor`. Since scrape job names must be unique, a relabel overrides the job label to `kubelet` on both jobs:
   ```yaml
   - replacement: kubelet
     target_label: job
   ```

### `gitops/addons/charts/grafana-dashboards/templates/rust-dashboard.yaml`

3. **CPU usage / Memory usage** – replaced `container_name="rust-app"` (wrong) and the non-emitted `process_*` metrics with cAdvisor `container_cpu_usage_seconds_total` / `container_memory_working_set_bytes` filtered by `container="rust-microservice", namespace="team-rust"`, grouped by pod. `rust-microservice` is the appmod-service `image_name` used by both the KubeVela and kro metrics analysis templates.
4. **Response Time Distribution** – changed the panel from `type: histogram` (which can't render a `histogram_quantile()` value, so it was always empty) to `timeseries`, plotting p50 and p95 latency in ms (corrected the `* 10000` scale bug to `* 1000`).

The four `rocket_http_*` metrics used by the lab's 5 evaluation criteria remain fully represented across the HTTP panels; no lab-metric coverage was removed.

## Testing (live Workshop Studio environment, us-west-2)

- [x] Applied the corrected scrape config to the live AMP scraper → `up{job="cadvisor"}` **0 → 1**; `container_cpu_usage_seconds_total` appears with `job="kubelet"` (186 series).
- [x] Recording rule `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate` went from **empty → 114 series**.
- [x] Patched the live Rust dashboard and generated HTTP traffic → all six panels render real data: HTTP req/s, requests last minute, **p50/p95 latency**, mean response time, **per-pod CPU**, **per-pod memory**.
- [x] Verified `container="rust-microservice"` / `namespace="team-rust"` is the correct cAdvisor label set (read directly from the kubelet cAdvisor endpoint).
- [x] Platform Observability `Kubernetes / Kubelet` dashboard now shows Running Kubelets/Pods/Containers and operation rates.
- [x] Confirmed no recording rule or dashboard references the old `kubernetes-kubelet` / `cadvisor` job names (safe relabel).

## Out of scope

The **Java/JMX** and **NGINX** dashboards remain empty for environmental reasons (the sample Java app ships no JMX/Prometheus instrumentation — plain Tomcat WAR, port 8080 only; no NGINX ingress controller is deployed). Those require app/infra changes rather than a scraper fix and are not addressed here.