### PR TITLE
fix: replace dig with index/or for ArgoCD 3.x compatibility

### DIFF
--- a/gitops/bootstrap/addons.yaml
+++ b/gitops/bootstrap/addons.yaml
@@ -24,8 +24,8 @@ spec:
         - repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
           targetRevision: '{{ .metadata.annotations.addonsRepoRevision }}'
           ref: defaults
-        - repoURL: '{{ dig "overlay_repo_url" .metadata.annotations.addonsRepoURL .metadata.annotations }}'
-          targetRevision: '{{ dig "overlay_repo_revision" .metadata.annotations.addonsRepoRevision .metadata.annotations }}'
+        - repoURL: '{{ or (index .metadata.annotations "overlay_repo_url") .metadata.annotations.addonsRepoURL }}'
+          targetRevision: '{{ or (index .metadata.annotations "overlay_repo_revision") .metadata.annotations.addonsRepoRevision }}'
           ref: overlay
         - repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
           path: 'platform-charts/appset-chart'
@@ -44,12 +44,12 @@ spec:
               - $defaults/{{ .metadata.annotations.addonsRepoBasepath }}addons/registry/ml.yaml
               - $defaults/{{ .metadata.annotations.addonsRepoBasepath }}overlays/environments/{{ .metadata.labels.environment }}/overrides.yaml
               - $defaults/{{ .metadata.annotations.addonsRepoBasepath }}overlays/clusters/{{ .nameNormalized }}/overrides.yaml
-              - $overlay/{{ dig "overlay_repo_basepath" .metadata.annotations.addonsRepoBasepath .metadata.annotations }}overlays/environments/{{ .metadata.labels.environment }}/overrides.yaml
-              - $overlay/{{ dig "overlay_repo_basepath" .metadata.annotations.addonsRepoBasepath .metadata.annotations }}overlays/clusters/{{ .nameNormalized }}/overrides.yaml
+              - $overlay/{{ or (index .metadata.annotations "overlay_repo_basepath") .metadata.annotations.addonsRepoBasepath }}overlays/environments/{{ .metadata.labels.environment }}/overrides.yaml
+              - $overlay/{{ or (index .metadata.annotations "overlay_repo_basepath") .metadata.annotations.addonsRepoBasepath }}overlays/clusters/{{ .nameNormalized }}/overrides.yaml
             valuesObject:
-              overlayRepoURLGit: '{{ dig "overlay_repo_url" "" .metadata.annotations }}'
-              overlayRepoURLGitRevision: '{{ dig "overlay_repo_revision" "main" .metadata.annotations }}'
-              overlayRepoURLGitBasePath: '{{ dig "overlay_repo_basepath" "" .metadata.annotations }}'
+              overlayRepoURLGit: '{{ index .metadata.annotations "overlay_repo_url" }}'
+              overlayRepoURLGitRevision: '{{ or (index .metadata.annotations "overlay_repo_revision") "main" }}'
+              overlayRepoURLGitBasePath: '{{ index .metadata.annotations "overlay_repo_basepath" }}'
       destination:
         namespace: argocd
         name: '{{ .name }}'

--- a/gitops/bootstrap/fleet-secrets.yaml
+++ b/gitops/bootstrap/fleet-secrets.yaml
@@ -33,8 +33,8 @@ spec:
         - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
           targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
           ref: values
-        - repoURL: '{{ dig "overlay_repo_url" .metadata.annotations.fleetRepoURL .metadata.annotations }}'
-          targetRevision: '{{ dig "overlay_repo_revision" .metadata.annotations.fleetRepoRevision .metadata.annotations }}'
+        - repoURL: '{{ or (index .metadata.annotations "overlay_repo_url") .metadata.annotations.fleetRepoURL }}'
+          targetRevision: '{{ or (index .metadata.annotations "overlay_repo_revision") .metadata.annotations.fleetRepoRevision }}'
           ref: overlay
         - repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
           targetRevision: '{{ .metadata.annotations.addonsRepoRevision }}'
@@ -62,8 +62,8 @@ spec:
               - '$values/{{ .metadata.annotations.fleetRepoBasepath }}fleet/members/{{ .clusterName }}/values.yaml'
               - '$values/{{ .metadata.annotations.fleetRepoBasepath }}overlays/environments/{{ .labels.environment }}/enabled-addons.yaml'
               - '$values/{{ .metadata.annotations.fleetRepoBasepath }}overlays/clusters/{{ .clusterName }}/addon-overrides.yaml'
-              - '$overlay/{{ dig "overlay_repo_basepath" .metadata.annotations.fleetRepoBasepath .metadata.annotations }}overlays/environments/{{ .labels.environment }}/enabled-addons.yaml'
-              - '$overlay/{{ dig "overlay_repo_basepath" .metadata.annotations.fleetRepoBasepath .metadata.annotations }}overlays/clusters/{{ .clusterName }}/addon-overrides.yaml'
+              - '$overlay/{{ or (index .metadata.annotations "overlay_repo_basepath") .metadata.annotations.fleetRepoBasepath }}overlays/environments/{{ .labels.environment }}/enabled-addons.yaml'
+              - '$overlay/{{ or (index .metadata.annotations "overlay_repo_basepath") .metadata.annotations.fleetRepoBasepath }}overlays/clusters/{{ .clusterName }}/addon-overrides.yaml'
       destination:
         name: '{{ .name }}'
         namespace: argocd

--- a/gitops/bootstrap/hub-fleet-secret.yaml
+++ b/gitops/bootstrap/hub-fleet-secret.yaml
@@ -26,8 +26,8 @@ spec:
         - repoURL: '{{ .metadata.annotations.fleetRepoURL }}'
           targetRevision: '{{ .metadata.annotations.fleetRepoRevision }}'
           ref: values
-        - repoURL: '{{ dig "overlay_repo_url" .metadata.annotations.fleetRepoURL .metadata.annotations }}'
-          targetRevision: '{{ dig "overlay_repo_revision" .metadata.annotations.fleetRepoRevision .metadata.annotations }}'
+        - repoURL: '{{ or (index .metadata.annotations "overlay_repo_url") .metadata.annotations.fleetRepoURL }}'
+          targetRevision: '{{ or (index .metadata.annotations "overlay_repo_revision") .metadata.annotations.fleetRepoRevision }}'
           ref: overlay
         - repoURL: '{{ .metadata.annotations.addonsRepoURL }}'
           targetRevision: '{{ .metadata.annotations.addonsRepoRevision }}'
@@ -45,8 +45,8 @@ spec:
               - '$values/{{ .metadata.annotations.fleetRepoBasepath }}fleet/hub/values.yaml'
               - '$values/{{ .metadata.annotations.fleetRepoBasepath }}overlays/environments/control-plane/enabled-addons.yaml'
               - '$values/{{ .metadata.annotations.fleetRepoBasepath }}overlays/clusters/{{ .metadata.annotations.aws_cluster_name }}/addon-overrides.yaml'
-              - '$overlay/{{ dig "overlay_repo_basepath" .metadata.annotations.fleetRepoBasepath .metadata.annotations }}overlays/environments/control-plane/enabled-addons.yaml'
-              - '$overlay/{{ dig "overlay_repo_basepath" .metadata.annotations.fleetRepoBasepath .metadata.annotations }}overlays/clusters/{{ .metadata.annotations.aws_cluster_name }}/addon-overrides.yaml'
+              - '$overlay/{{ or (index .metadata.annotations "overlay_repo_basepath") .metadata.annotations.fleetRepoBasepath }}overlays/environments/control-plane/enabled-addons.yaml'
+              - '$overlay/{{ or (index .metadata.annotations "overlay_repo_basepath") .metadata.annotations.fleetRepoBasepath }}overlays/clusters/{{ .metadata.annotations.aws_cluster_name }}/addon-overrides.yaml'
       destination:
         name: '{{ .name }}'
         namespace: argocd


### PR DESCRIPTION
Fixes #734

## Problem
The `dig` Go template function fails with ArgoCD 3.2+ when called on `.metadata.annotations` (`map[string]string`):
```
error calling dig: interface conversion: interface {} is map[string]string, not map[string]interface {}
```

## Fix
Replace all `dig` usages with `index` + `or`:
- `{{ dig "key" default .metadata.annotations }}` → `{{ or (index .metadata.annotations "key") default }}`
- `{{ dig "key" "" .metadata.annotations }}` → `{{ index .metadata.annotations "key" }}`

## Affected files
- `gitops/bootstrap/addons.yaml`
- `gitops/bootstrap/hub-fleet-secret.yaml`
- `gitops/bootstrap/fleet-secrets.yaml`

## Testing
- Compatible with ArgoCD 2.x and 3.x
- EKS ArgoCD Capability 3.2.7-eks-2