### PR TITLE
fix: escape {{pod}} legendFormat in grafana-dashboards Helm template

### DIFF
--- a/gitops/addons/charts/grafana-dashboards/templates/rust-dashboard.yaml
+++ b/gitops/addons/charts/grafana-dashboards/templates/rust-dashboard.yaml
@@ -296,7 +296,7 @@ spec:
                 "uid": "$datasource"
               },
               "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"rust-microservice\", namespace=\"team-rust\"}[1m])) by (pod)",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{ `{{pod}}` }}",
               "refId": "A"
             }
           ],
@@ -330,7 +330,7 @@ spec:
                 "uid": "$datasource"
               },
               "expr": "sum(container_memory_working_set_bytes{container=\"rust-microservice\", namespace=\"team-rust\"}) by (pod) / 1024 / 1024",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{ `{{pod}}` }}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
Fixes #739

## Problem

PR #732 introduced two `legendFormat` fields using `{{pod}}` without Helm escaping in `rust-dashboard.yaml`. Helm interprets `{{pod}}` as a template function call and fails with `function "pod" not defined`, breaking manifest generation for the entire `grafana-dashboards` chart. The `grafana-dashboards-peeks-hub` ArgoCD app stays in `ComparisonError` indefinitely and the Rust Metrics dashboard never appears in Grafana.

## Fix

Apply the same backtick escaping already used for `{{endpoint}}` elsewhere in the same file (lines 299 and 333):

```diff
- "legendFormat": "{{pod}}"
+ "legendFormat": "{{ `{{pod}}` }}"
```

## Validation

Applied and verified in two Workshop Studio event accounts. After syncing ArgoCD, `ComparisonError` resolved and the Rust Metrics dashboard appeared in the `Workload Observability` folder in Amazon Managed Grafana.