### PR TITLE
feat: add ArgoCD Lua health checks addon for kro and Crossplane

### DIFF
--- a/gitops/addons/bootstrap/default/addons.yaml
+++ b/gitops/addons/bootstrap/default/addons.yaml
@@ -639,6 +639,21 @@ kro-manifests-hub:
         operator: In
         values: ['true']
 
+argocd-health-checks:
+  enabled: false
+  type: manifest
+  namespace: argocd
+  annotationsAppSet:
+    argocd.argoproj.io/sync-wave: '-3' # Before kro RGDs so health checks are ready
+  path: '{{.metadata.annotations.addons_repo_basepath}}charts/argocd-health-checks'
+  directory:
+    recurse: false
+  selector:
+    matchExpressions:
+      - key: enable_argocd_health_checks
+        operator: In
+        values: ['true']
+
 multi-acct:
   enabled: false
   namespace: kro

--- a/gitops/addons/charts/argocd-health-checks/argocd-cm.yaml
+++ b/gitops/addons/charts/argocd-health-checks/argocd-cm.yaml
@@ -1,0 +1,44 @@
+# ArgoCD custom Lua health check for kro resources.
+# Deployed by the argocd-health-checks addon (enable_argocd_health_checks label).
+#
+# Uses the resource.customizations wildcard format so a single entry covers
+# all kro.run/* kinds (any RGD-generated CRD + ResourceGraphDefinition itself).
+#
+# Note: Crossplane (*.upbound.io) health checks are already built-in to OSS ArgoCD.
+# See: https://github.com/argoproj/argo-cd/blob/master/resource_customizations/_.upbound.io/_/health.lua
+#
+# Ref: https://argo-cd.readthedocs.io/en/latest/operator-manual/health/#way-1-define-a-custom-health-check-in-argocd-cm-configmap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+data:
+  resource.customizations: |
+    kro.run/*:
+      health.lua: |
+        local hs = {}
+        if obj.status == nil or obj.status.conditions == nil then
+          hs.status = "Progressing"
+          hs.message = "Waiting for KRO to report status"
+          return hs
+        end
+        if obj.status.state == "ERROR" or obj.status.state == "FAILED" then
+          hs.status = "Degraded"
+          hs.message = obj.status.conditions[#obj.status.conditions].message or "Instance has errors"
+          return hs
+        end
+        for _, condition in ipairs(obj.status.conditions) do
+          if condition.type == "Ready" then
+            if condition.status == "True" then
+              hs.status = "Healthy"
+              hs.message = condition.message or "Ready"
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for Ready condition"
+        return hs


### PR DESCRIPTION
**Waiting for feature to be GA**

## Summary

Adds a new addon `argocd-health-checks` (`enable_argocd_health_checks` label) that deploys an `argocd-cm` ConfigMap with custom Lua health check scripts for kro and Crossplane resources.

## Problem

Without custom health checks, ArgoCD reports kro instances and Crossplane managed resources as **Healthy** immediately upon creation — even when they're still provisioning (`IN_PROGRESS`) or in error state (`ERROR`).

## Solution

A manifest-based addon that deploys `argocd-cm` to the `argocd` namespace with:

| Resource Family | Health Logic |
|----------------|-------------|
| kro instances (9 kinds) | `status.state`: ACTIVE→Healthy, IN_PROGRESS→Progressing, ERROR→Degraded |
| kro ResourceGraphDefinition | `status.state`: Active→Healthy, Inactive→Degraded |
| Crossplane managed (10 types) | conditions: Ready+Synced→Healthy, !Synced→Degraded, !Ready→Progressing |

## Usage

Add label to your cluster secret:
```yaml
enable_argocd_health_checks: 'true'
```

## Testing

Validated on `arn:aws:eks:us-west-2:515966522948:cluster/peeks-hub` (ArgoCD v3.3.10-eks1):
- ✅ kro: Progressing→Healthy (SlowReady), ERROR→Degraded (FailDemo)
- ✅ Crossplane: Ready+Synced condition evaluation
- ✅ RGD: Active/Inactive detection
- ❌ Wildcard `kro.run/*` not supported by EKS managed ArgoCD (per-kind keys required)

Closes #741