### PR TITLE
fix(registry): move kubevela to wave 4 after argo-rollouts

### DIFF
--- a/gitops/addons/registry/README.md
+++ b/gitops/addons/registry/README.md
@@ -91,6 +91,8 @@ When `type: manifest` is set, the Helm rendering block is skipped entirely -- Ar
 
 ## Sync-Wave Reference
 
+The wave a chart sits at is determined by the **highest wave it consumes**, not by the resources it emits. New ComponentDefinitions, Traits, or Application templates inside an existing chart do not change its wave.
+
 | Wave | Category | Addons |
 |------|----------|--------|
 | -5 | Multi-account | multi-acct |
@@ -100,11 +102,17 @@ When `type: manifest` is set, the Helm rendering block is skipped entirely -- Ar
 | 0 | Core | argocd, metrics-server |
 | 1 | Ingress | ingress-class-alb |
 | 2 | Certificates | cert-manager |
-| 3 | Security / Observability | kyverno, argo-rollouts, argo-events, grafana-operator, kube-state-metrics, otel, cni-metrics-helper, aws-for-fluentbit |
-| 4 | Platform / GitOps | efs-csi, grafana, kyverno-policies, kyverno-policy-reporter, kargo, flux, crossplane-aws |
-| 5 | ML/AI / Dashboards / Networking | lbc, external-dns, jupyterhub, kubeflow, mlflow, ray-operator, spark-operator, airflow, grafana-dashboards, cw-prometheus |
+| 3 | Operators delivering workload-kind CRDs | kyverno, argo-rollouts, argo-events, grafana-operator, kube-state-metrics, otel, cni-metrics-helper, aws-for-fluentbit |
+| 4 | Platform orchestrators that compose wave-3 workload kinds | kubevela, efs-csi, grafana, kyverno-policies, kyverno-policy-reporter, kargo, flux, crossplane-aws |
+| 5 | Declarative consumers (workloads, ApplicationSets of agents/templates) | lbc, external-dns, jupyterhub, kubeflow, mlflow, ray-operator, spark-operator, airflow, grafana-dashboards, cw-prometheus, oam-agent-components |
 | 6 | Security (late) | keycloak |
 | 7 | GitOps (late) | argo-workflows |
+
+### Wave 4 vs wave 3 — why kubevela is at wave 4
+
+KubeVela ships built-in ComponentDefinitions (`appmod-service`, etc.) whose CUE templates render to `argoproj.io/v1alpha1.Rollout`. The KubeVela admission webhook does pre-render validation when registering ComponentDefinitions and rejects them if the `Rollout` CRD is not present. Argo Rollouts (wave 3) must therefore be installed before the KubeVela chart syncs.
+
+Charts that ship their own ComponentDefinitions/Traits referencing additional resource kinds (e.g., `oam-agent-components` in `sample-open-agentic-platform`) sit at wave 5 — they consume both the wave-3 workload-kind CRDs and the wave-4 KubeVela machinery.
 
 ## How to Add a New Addon Entry
 

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -206,7 +206,7 @@ kubevela:
   namespace: vela-system
   path: '{{.metadata.annotations.addonsRepoBasepath}}addons/charts/kubevela'
   annotationsAppSet:
-    argocd.argoproj.io/sync-wave: '3'
+    argocd.argoproj.io/sync-wave: '4'  # after argo-rollouts (wave 3) — chart ships ComponentDefinitions emitting Rollout
   selector:
     matchExpressions:
       - key: enable_kubevela


### PR DESCRIPTION
## Problem

The KubeVela chart and Argo Rollouts are both at sync-wave 3, so ArgoCD applies them in parallel. KubeVela ships built-in ComponentDefinitions (`appmod-service`, etc.) whose CUE templates render to `argoproj.io/v1alpha1.Rollout`. The KubeVela admission webhook does pre-render validation when a ComponentDefinition is registered and rejects it if the `Rollout` CRD is not present:

```
admission webhook "mutating.core.oam-dev.v1beta1.componentdefinitions" denied the request:
no matches for kind "Rollout" in version "argoproj.io/v1alpha1"
```

This creates a race on first install. ArgoCD's selfHeal eventually converges, but the customer-visible install transitions through `OutOfSync` / `Degraded` with admission-webhook errors. It also showed up downstream when registering the `agent` and `mcp-server` ComponentDefinitions in `sample-open-agentic-platform`'s `oam-agent-components` chart — same root cause.

## Fix

Move kubevela from wave 3 to wave 4 in `gitops/addons/registry/platform.yaml`. Argo Rollouts (wave 3) is now guaranteed to converge before KubeVela syncs.

## Taxonomy rule (now documented)

A chart's wave is determined by the **highest wave it consumes**, not by the resources it emits. Adding new ComponentDefinitions, Traits, or templates inside an existing chart does not change its wave.

| Wave | Role |
|---|---|
| 3 | Operators delivering workload-kind CRDs (argo-rollouts, kyverno, otel, etc.) |
| 4 | Platform orchestrators that compose wave-3 workload kinds (kubevela, kargo, flux, crossplane-aws) |
| 5 | Declarative consumers — workloads, ApplicationSets of agents/templates (oam-agent-components, app charts) |

Updated `gitops/addons/registry/README.md`:
- Renamed wave 3 to "Operators delivering workload-kind CRDs"
- Renamed wave 4 to "Platform orchestrators that compose wave-3 workload kinds"; added kubevela
- Renamed wave 5 to "Declarative consumers"; added oam-agent-components for cross-repo visibility
- Added an introduction paragraph stating the rule
- Added a short subsection explaining why kubevela is at wave 4

## Validation

- All 3 ComponentDefinitions (`agent`, `mcp-server`, `agentcore-memory`) from `sample-open-agentic-platform`'s `oam-agent-components` chart are currently registered on `peeks-hub`, `spoke-dev`, `spoke-prod` after enabling argo_rollouts in OAP overlays — verifying that with kubevela at wave 4 (effective after this PR), the install converges cleanly.
- No deployment changes for any other wave.

## Related

`sample-open-agentic-platform` PR #18 enables `argo_rollouts: true` in the cluster overlays so this wave-3 prerequisite is actually deployed on hub + spokes.