### PR TITLE
feat(ingress): Conditional ALB listen-ports based on CloudFront domain

### DIFF
--- a/gitops/addons/charts/argo-workflows/templates/ingress.yaml
+++ b/gitops/addons/charts/argo-workflows/templates/ingress.yaml
@@ -5,8 +5,12 @@ metadata:
   namespace: argo
   annotations:
     alb.ingress.kubernetes.io/target-type: ip
+    {{- if contains "cloudfront.net" .Values.ingress_domain_name }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    {{- else }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: '443'
+    {{- end }}
     alb.ingress.kubernetes.io/transforms.argo-server: |
       [{"type":"url-rewrite","urlRewriteConfig":{"rewrites":[{"regex":"^\\/argo-workflows\\/?(.*)$","replace":"/$1"}]}}]
 spec:

--- a/gitops/addons/charts/keycloak/templates/ingress.yaml
+++ b/gitops/addons/charts/keycloak/templates/ingress.yaml
@@ -6,9 +6,13 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "10"
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /keycloak/health
+    {{- if contains "cloudfront.net" .Values.global.ingress_domain_name }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    {{- else }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: '443'
-    alb.ingress.kubernetes.io/healthcheck-path: /keycloak/health
+    {{- end }}
 spec:
   ingressClassName: platform
   rules:


### PR DESCRIPTION
Ingress templates now auto-detect CloudFront vs custom domain:
- If ingress_domain_name contains 'cloudfront.net': ALB listens on HTTP:80 only (CloudFront terminates TLS)
- Otherwise: ALB listens on HTTPS:443 with ssl-redirect (ACM cert required for custom domains)

This removes the need for ACM certificates when using CloudFront default domains and eliminates the LBC 'no certificate found' error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
