### PR TITLE
feat(kro): add protectFromDeletion parameter to EksCluster and Vpc RGDs

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
@@ -29,6 +29,7 @@ spec:
       git_username: string | default="user1"
       aws_partition: string | default="aws"
       aws_dns_suffix: string | default="amazonaws.com"
+      protectFromDeletion: string | default="true"
       network:
         vpcID: string
         subnets:
@@ -350,6 +351,7 @@ spec:
             kro-management: ${schema.spec.name}
             tenant: ${schema.spec.tenant}
             environment: ${schema.spec.environment}
+            auto-delete: ${schema.spec.protectFromDeletion == "true" ? "no" : "yes"}
 
     - id: podIdentityAddon
       template:

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-vpc.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-vpc.yaml
@@ -19,6 +19,7 @@ spec:
         privateSubnet1Cidr: string | default="10.0.11.0/24"
         privateSubnet2Cidr: string | default="10.0.12.0/24"
       natGateways: integer | default=1 # Reserved for future HA (currently always 1 NAT Gateway)
+      protectFromDeletion: string | default="true"
     status:
       vpcID: ${vpc.status.vpcID}
       publicSubnet1ID: ${publicSubnet1.status.subnetID}
@@ -51,6 +52,8 @@ spec:
         tags:
           - key: "Name"
             value: ${schema.spec.name}-vpc
+          - key: "auto-delete"
+            value: ${schema.spec.protectFromDeletion == "true" ? "no" : "yes"}
   - id: internetGateway
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1
@@ -97,6 +100,8 @@ spec:
         tags:
           - key: "Name"
             value: ${schema.spec.name}-nat-gateway1
+          - key: "auto-delete"
+            value: ${schema.spec.protectFromDeletion == "true" ? "no" : "yes"}
   - id: eip1
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1


### PR DESCRIPTION
## Problem

SpringClean deletes EKS clusters and NAT Gateways managed by kro because manually-applied `auto-delete: no` tags are overwritten by kro reconciliation.

## Solution

Adds a new optional schema field `protectFromDeletion` (default: `"true"`) to both the EksCluster and Vpc RGDs. This propagates an `auto-delete` tag via CEL ternary:

```yaml
auto-delete: ${schema.spec.protectFromDeletion == "true" ? "no" : "yes"}
```

**Default behavior**: all clusters and VPCs are protected (opt-out model).

To allow cleanup, set `protectFromDeletion: "false"` in the EksCluster/Vpc instance.

## Changes

- `rg-eks.yaml`: added schema field + `auto-delete` tag on EKS Cluster
- `rg-vpc.yaml`: added schema field + `auto-delete` tag on VPC and NAT Gateway

## Testing

Existing instances don't need changes — the new field defaults to `true`, so next ArgoCD sync will tag all clusters/VPCs with `auto-delete: no` automatically.