### PR TITLE
fix: aws_secretsmanager_secret_version race condition causes intermittent bootstrap failures

### DIFF
--- a/platform/infra/terraform/common/secrets.tf
+++ b/platform/infra/terraform/common/secrets.tf
@@ -112,6 +112,13 @@ resource "aws_secretsmanager_secret_version" "cluster_config" {
       }
     }
   })
+
+  # Workaround for hashicorp/terraform-provider-aws#31216
+  # The provider has a race condition where version_stages transitions from known to unknown
+  # between plan and apply phases, causing "Provider produced inconsistent final plan" errors.
+  lifecycle {
+    ignore_changes = [version_stages]
+  }
 }
 
 # Platform Configuration
@@ -148,6 +155,13 @@ resource "aws_secretsmanager_secret_version" "git_secret" {
     amp_endpoint_url          = module.managed_service_prometheus.workspace_prometheus_endpoint
     amp_region                = each.value.region
   })
+
+  # Workaround for hashicorp/terraform-provider-aws#31216
+  # The provider has a race condition where version_stages transitions from known to unknown
+  # between plan and apply phases, causing "Provider produced inconsistent final plan" errors.
+  lifecycle {
+    ignore_changes = [version_stages]
+  }
 }
 
 # Create the secret for AMP endpoint to be used in Kubevela service
@@ -166,4 +180,11 @@ resource "aws_secretsmanager_secret_version" "argorollouts_secret_version" {
     amp-region    = local.hub_cluster.region
     amp-workspace = module.managed_service_prometheus.workspace_prometheus_endpoint
   })
+
+  # Workaround for hashicorp/terraform-provider-aws#31216
+  # The provider has a race condition where version_stages transitions from known to unknown
+  # between plan and apply phases, causing "Provider produced inconsistent final plan" errors.
+  lifecycle {
+    ignore_changes = [version_stages]
+  }
 }


### PR DESCRIPTION
## Summary

Adds `lifecycle { ignore_changes = [version_stages] }` to all three `aws_secretsmanager_secret_version` resources in `platform/infra/terraform/common/secrets.tf`.

## Problem

During Workshop Studio event provisioning, ~50% of accounts fail with:

```
Error: Provider produced inconsistent final plan
When expanding the plan for aws_secretsmanager_secret_version.git_secret["spoke2"]...
provider produced an invalid new value for .version_stages: was known, but now unknown.
```

This is a known AWS Terraform provider race condition ([hashicorp/terraform-provider-aws#31216](https://github.com/hashicorp/terraform-provider-aws/issues/31216)) where the Secrets Manager API returns an intermediate state between plan and apply phases.

## Changes

Added lifecycle block to:
- `aws_secretsmanager_secret_version.cluster_config`
- `aws_secretsmanager_secret_version.git_secret`
- `aws_secretsmanager_secret_version.argorollouts_secret_version`

## Impact

- Eliminates the non-deterministic `Provider produced inconsistent final plan` errors
- Secret values are still fully managed by Terraform — only version staging metadata is ignored
- No behavioral change to the secrets themselves

Fixes #759