### PR TITLE
fix(observability-aws): Use safe default for missing annotations

### DIFF
--- a/gitops/addons/registry/observability.yaml
+++ b/gitops/addons/registry/observability.yaml
@@ -13,19 +13,19 @@ observability-aws:
         values: ["true"]
   valuesObject:
     aws:
-      region: "{{.metadata.annotations.aws_region}}"
-      accountId: "{{.metadata.annotations.aws_account_id}}"
-      vpcId: "{{.metadata.annotations.aws_vpc_id}}"
-      clusterName: "{{.metadata.annotations.aws_cluster_name}}"
+      region: '{{default "" (index .metadata.annotations "aws_region")}}'
+      accountId: '{{default "" (index .metadata.annotations "aws_account_id")}}'
+      vpcId: '{{default "" (index .metadata.annotations "aws_vpc_id")}}'
+      clusterName: '{{default "" (index .metadata.annotations "aws_cluster_name")}}'
     ingress:
-      domainName: "{{.metadata.annotations.ingress_domain_name}}"
-    resourcePrefix: "{{.metadata.annotations.resource_prefix}}"
+      domainName: '{{default "" (index .metadata.annotations "ingress_domain_name")}}'
+    resourcePrefix: '{{default "" (index .metadata.annotations "resource_prefix")}}'
     amg:
       subnetIds: ""
     scraper:
-      clusterArn: '{{index .metadata.annotations "aws_cluster_arn"}}'
-      clusterSubnetIds: '{{index .metadata.annotations "aws_private_subnet_ids"}}'
-      clusterSecurityGroupIds: '{{index .metadata.annotations "aws_cluster_security_group_id"}}'
+      clusterArn: '{{default "" (index .metadata.annotations "aws_cluster_arn")}}'
+      clusterSubnetIds: '{{default "" (index .metadata.annotations "aws_private_subnet_ids")}}'
+      clusterSecurityGroupIds: '{{default "" (index .metadata.annotations "aws_cluster_security_group_id")}}'
     spokeScrapers:
       spoke-dev:
         clusterArn: '{{default "" (index .metadata.annotations "spoke_dev_cluster_arn")}}'


### PR DESCRIPTION
The observability-aws ApplicationSet uses goTemplateOptions missingkey=error. When the control-plane cluster secret (which has enable_observability_aws=true but no AWS infrastructure annotations like aws_vpc_id) is evaluated, the template fails with 'map has no entry for key'.

Fix: use {{default "" (index .metadata.annotations "key")}} for all annotation references in the valuesObject. This renders empty when the annotation is absent, and the chart guards resources with conditionals.

The spoke-scraper annotations already used this safe pattern — this aligns the core AWS values (region, accountId, vpcId, clusterName, etc.) to the same approach.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
