### PR TITLE
fix(observability): Bump aws-for-fluent-bit to 3.4.5

### DIFF
--- a/gitops/addons/registry/observability.yaml
+++ b/gitops/addons/registry/observability.yaml
@@ -265,7 +265,7 @@ aws-for-fluentbit:
       # Track the latest aws-for-fluent-bit 3.x image (AL2023, fluent-bit v5.x).
       # Bump as new patch/minor releases ship with CVE fixes:
       # https://github.com/aws/aws-for-fluent-bit/releases
-      tag: 3.4.3
+      tag: 3.4.5
 
 cni-metrics-helper:
   namespace: kube-system


### PR DESCRIPTION
Resolves:
- ALAS2023-2026-1853 (High): openssl-fips-provider, openssl-libs 1:3.5.5-1.amzn2023.0.4 → 1:3.5.5-1.amzn2023.0.5
- ALAS2023-2026-1824 (Low): libssh CVE-2026-0965 0:0.10.6-1.amzn2023.0.7 → 0:0.10.6-1.amzn2023.0.8

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
