### PR TITLE
fix(observability): Bump aws-for-fluent-bit to 3.4.6

### DIFF
--- a/gitops/addons/registry/observability.yaml
+++ b/gitops/addons/registry/observability.yaml
@@ -265,7 +265,7 @@ aws-for-fluentbit:
       # Track the latest aws-for-fluent-bit 3.x image (AL2023, fluent-bit v5.x).
       # Bump as new patch/minor releases ship with CVE fixes:
       # https://github.com/aws/aws-for-fluent-bit/releases
-      tag: 3.4.5
+      tag: 3.4.6
 
 cni-metrics-helper:
   namespace: kube-system


### PR DESCRIPTION
Resolves:
- ALAS2023-2026-1911 (Medium): libxml2 CVE-2026-6653 0:2.10.4-1.amzn2023.0.18 → 0:2.10.4-1.amzn2023.0.19
- ALAS2023-2026-1916: libblkid, libmount, libuuid 0:2.37.4-1.amzn2023.0.4 → 0:2.37.4-1.amzn2023.0.5

Release: v3.4.6 (fluent-bit v5.0.7, AL2023 base refresh)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
