### PR TITLE
fix: restart Keycloak on keycloak-config changes

### DIFF
--- a/gitops/addons/charts/keycloak/templates/_helpers.tpl
+++ b/gitops/addons/charts/keycloak/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/*
+keycloak.conf file content, shared between the keycloak-config ConfigMap and the
+StatefulSet's checksum/config annotation (see templates/install.yaml). Keeping this in
+one place ensures the checksum always reflects the actual rendered config — if the two
+drifted, a config change could ship without triggering a pod restart, leaving Keycloak
+running stale settings (e.g. hostname/SAML config) after `git pull` + ArgoCD sync only
+updates the ConfigMap in place.
+*/}}
+{{- define "keycloak.conf" -}}
+# Database
+# The database vendor.
+db=postgres
+
+# The username of the database user.
+db-url=jdbc:postgresql://postgresql.keycloak.svc.cluster.local:5432/postgres
+
+# hostname settings — must use ingress_domain_name (platform CloudFront domain)
+# Do NOT fall back to gitlab_domain_name — that domain routes to GitLab, not Keycloak
+#
+# IMPORTANT: `hostname` must be the bare base URL (scheme + host only), WITHOUT the
+# /keycloak context path. `http-relative-path` below already supplies that path, and
+# Keycloak appends it to `hostname` internally. Including "/keycloak" in BOTH settings
+# causes a double-path bug in Keycloak's SAML metadata builder (observed on 26.3.3):
+# the generated SAML EntityDescriptor/SSO/SLO Location URLs come out malformed as
+# "https:/keycloak/realms/<realm>/..." (missing host, single slash after scheme),
+# which AWS IAM Identity Center then rejects with "Unable to build attributes from
+# provided metadata object as url validation failed" when importing the IdP metadata.
+# OIDC is unaffected by this, which is why only the SAML/IDC federation flow broke.
+hostname=https://{{ .Values.global.ingress_domain_name }}
+hostname-admin=https://{{ .Values.global.ingress_domain_name }}
+hostname-strict=false
+http-relative-path=keycloak
+http-enabled=true
+hostname-debug=true
+# .../keycloak/realms/platform/hostname-debug
+
+# Proxy configuration for CloudFront/ALB - use xforwarded for AWS setup
+proxy-headers=xforwarded
+
+# Enable account console and admin features
+features=account,admin
+
+# Development mode settings for better debugging
+log-level=INFO
+{{- end -}}

--- a/gitops/addons/charts/keycloak/templates/install.yaml
+++ b/gitops/addons/charts/keycloak/templates/install.yaml
@@ -59,6 +59,13 @@ spec:
     metadata:
       labels:
         app: keycloak
+      annotations:
+        # Force a rolling restart whenever keycloak.conf content changes. Kubernetes does
+        # not hot-reload files from a mounted ConfigMap, so without this checksum the
+        # running Keycloak pods keep stale config (e.g. hostname/SAML settings) after
+        # `git pull` + ArgoCD sync updates the ConfigMap in place — only freshly created
+        # pods would otherwise pick up the new file.
+        checksum/config: {{ include "keycloak.conf" . | sha256sum }}
     spec:
       nodeSelector:
         karpenter.sh/nodepool: system
@@ -143,42 +150,7 @@ spec:
 apiVersion: v1
 data:
   keycloak.conf: |
-    # Database
-    # The database vendor.
-    db=postgres
-
-    # The username of the database user.
-    db-url=jdbc:postgresql://postgresql.keycloak.svc.cluster.local:5432/postgres
-
-    # hostname settings — must use ingress_domain_name (platform CloudFront domain)
-    # Do NOT fall back to gitlab_domain_name — that domain routes to GitLab, not Keycloak
-    #
-    # IMPORTANT: `hostname` must be the bare base URL (scheme + host only), WITHOUT the
-    # /keycloak context path. `http-relative-path` below already supplies that path, and
-    # Keycloak appends it to `hostname` internally. Including "/keycloak" in BOTH settings
-    # causes a double-path bug in Keycloak's SAML metadata builder (observed on 26.3.3):
-    # the generated SAML EntityDescriptor/SSO/SLO Location URLs come out malformed as
-    # "https:/keycloak/realms/<realm>/..." (missing host, single slash after scheme),
-    # which AWS IAM Identity Center then rejects with "Unable to build attributes from
-    # provided metadata object as url validation failed" when importing the IdP metadata.
-    # OIDC is unaffected by this, which is why only the SAML/IDC federation flow broke.
-    hostname=https://{{ .Values.global.ingress_domain_name }}
-    hostname-admin=https://{{ .Values.global.ingress_domain_name }}
-    hostname-strict=false
-    http-relative-path=keycloak
-    http-enabled=true
-    hostname-debug=true
-    # .../keycloak/realms/platform/hostname-debug
-    
-    # Proxy configuration for CloudFront/ALB - use xforwarded for AWS setup
-    proxy-headers=xforwarded
-    
-    # Enable account console and admin features
-    features=account,admin
-    
-    # Development mode settings for better debugging
-    log-level=INFO
-
+{{ include "keycloak.conf" . | indent 4 }}
 kind: ConfigMap
 metadata:
   name: keycloak-config


### PR DESCRIPTION
## Summary

Follow-up to #777. That PR fixed the Keycloak hostname config that caused malformed SAML metadata, but a separate workshop environment pulled the fix and still hit the same error — because its Keycloak pods never restarted after ArgoCD synced the updated ConfigMap. Kubernetes doesn't hot-reload mounted ConfigMap files into a running process, and this chart had no restart trigger tied to config changes.

## Changes

- Added `gitops/addons/charts/keycloak/templates/_helpers.tpl` defining `keycloak.conf` as a shared named template.
- `install.yaml`: the ConfigMap's `keycloak.conf` data and a new `checksum/config` annotation on the StatefulSet pod template both derive from this same named template (standard Helm pattern, also used by `devlake-grafana` elsewhere in this repo). Any future change to `keycloak.conf` now changes the pod template hash, so ArgoCD/Kubernetes automatically triggers a rolling restart.

## Testing

- `helm lint` and `helm template` render cleanly.
- Confirmed the rendered `keycloak.conf` ConfigMap output is byte-identical to before the refactor (no behavior change to existing config).
- Confirmed the checksum changes when config content changes, and stays identical when it doesn't (deterministic, correctly wired).