### PR TITLE
fix(observability): Bump aws-for-fluent-bit to 3.4.8

### DIFF
--- a/gitops/addons/registry/observability.yaml
+++ b/gitops/addons/registry/observability.yaml
@@ -267,7 +267,7 @@ aws-for-fluentbit:
       # Track the latest aws-for-fluent-bit 3.x image (AL2023, fluent-bit v5.x).
       # Bump as new patch/minor releases ship with CVE fixes:
       # https://github.com/aws/aws-for-fluent-bit/releases
-      tag: 3.4.7
+      tag: 3.4.8
 
 cni-metrics-helper:
   namespace: kube-system


### PR DESCRIPTION
Release v3.4.8 (2026-07-16) — AL2023 base image refresh.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
