### PR TITLE
fix: EC2 AWS_PROFILE resolution + spoke-prod pod-identity parity

### DIFF
--- a/cluster-providers/README.md
+++ b/cluster-providers/README.md
@@ -148,6 +148,33 @@ Providers read shared configuration from `gitops/config.yaml`:
 Provider-specific config (e.g., Kind node count, VPC CIDR) can live in the
 provider's own directory but should not duplicate values from `config.yaml`.
 
+### AWS credential resolution (EC2 vs local) — kubectl implications
+
+The provider Taskfiles export `AWS_PROFILE` (from `aws.profile`, default `"default"`)
+to every `aws`/`kubectl`/`helm` call so local multi-account users get consistent
+credential targeting. On an EC2 instance authenticated by an **instance role**,
+there is usually no `[default]` profile in `~/.aws/config`, so a bare
+`AWS_PROFILE=default` fails (`config profile (default) could not be found`) and the
+credential chain never falls through to IMDS.
+
+To keep `AWS_PROFILE` flowing while still resolving on EC2, the Taskfiles set
+`AWS_CONFIG_FILE`: on an EC2 host they generate `private/aws-config` containing
+`[default]\ncredential_source = Ec2InstanceMetadata` and point `AWS_CONFIG_FILE`
+at it; off-instance they fall back to the user's existing `AWS_CONFIG_FILE` or
+`~/.aws/config` (unchanged behavior).
+
+> **⚠️ kubectl outside `task` on EC2.** `aws eks update-kubeconfig` bakes the
+> active `AWS_PROFILE` (`default`) into the kubeconfig's exec block. That profile
+> only resolves when `AWS_CONFIG_FILE` points at the generated config — which the
+> Taskfiles set, but your interactive shell does not. So `kubectl` run directly
+> (outside `task`) on an EC2 host will fail with
+> `config profile (default) could not be found` / `exec: executable aws failed`.
+> Fix with **either**:
+> - export the generated config for your shell:
+>   `export AWS_CONFIG_FILE=<repo>/.platform/private/aws-config`, **or**
+> - regenerate the kubeconfig without a profile so it uses the instance role:
+>   `env -u AWS_PROFILE aws eks update-kubeconfig --name <hub> --region <region>`
+
 ## Adding a New Provider
 
 1. Create a directory under `cluster-providers/` matching the provider name

--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -17,6 +17,11 @@ env:
   KUBECONFIG: "{{.ROOT_DIR}}/private/kubeconfig"
   AWS_PAGER: ""
   AWS_PROFILE: "{{.AWS_PROFILE}}"
+  # Keep AWS_PROFILE flowing to every aws/kubectl/helm call (local multi-account
+  # users depend on it). On EC2 the profile name (e.g. "default") has no entry in
+  # ~/.aws/config, so point AWS_CONFIG_FILE at a generated config whose profile
+  # resolves to the instance role via the credential provider chain (IMDS).
+  AWS_CONFIG_FILE: "{{.AWS_CONFIG_FILE}}"
 
 vars:
   CONFIG_FILE: "{{.ROOT_DIR}}/config.local.yaml"
@@ -24,6 +29,18 @@ vars:
   REQUIRED_CLIS: [kind, kubectl, helm, yq, aws]
   AWS_PROFILE:
     sh: yq '.aws.profile // "default"' {{.CONFIG_FILE}}
+  # On EC2: generate a config that resolves the profile to the instance role and
+  # return its path. Off-instance: fall back to the user's existing AWS_CONFIG_FILE
+  # or ~/.aws/config, so local behavior is unchanged (zero regression).
+  AWS_CONFIG_FILE:
+    sh: |
+      if curl -s -m 2 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" >/dev/null 2>&1; then
+        mkdir -p "{{.ROOT_DIR}}/private"
+        printf '[default]\ncredential_source = Ec2InstanceMetadata\n' > "{{.ROOT_DIR}}/private/aws-config"
+        echo "{{.ROOT_DIR}}/private/aws-config"
+      else
+        echo "${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+      fi
   HUB_CLUSTER_NAME:
     sh: yq '.hub.clusterName' {{.CONFIG_FILE}}
   HUB_K8S_VERSION:

--- a/cluster-providers/terraform/Taskfile.yaml
+++ b/cluster-providers/terraform/Taskfile.yaml
@@ -5,6 +5,11 @@ silent: true
 env:
   AWS_PAGER: ""
   AWS_PROFILE: "{{.AWS_PROFILE}}"
+  # Keep AWS_PROFILE flowing to every aws/kubectl/helm call (local multi-account
+  # users depend on it). On EC2 the profile name (e.g. "default") has no entry in
+  # ~/.aws/config, so point AWS_CONFIG_FILE at a generated config whose profile
+  # resolves to the instance role via the credential provider chain (IMDS).
+  AWS_CONFIG_FILE: "{{.AWS_CONFIG_FILE}}"
 
 vars:
   TF_DIR: "{{.ROOT_DIR}}/cluster-providers/terraform"
@@ -14,6 +19,18 @@ vars:
   REQUIRED_CLIS: [terraform, kubectl, helm, yq, aws]
   AWS_PROFILE:
     sh: yq '.aws.profile // "default"' {{.CONFIG_FILE}}
+  # On EC2: generate a config that resolves the profile to the instance role and
+  # return its path. Off-instance: fall back to the user's existing AWS_CONFIG_FILE
+  # or ~/.aws/config, so local behavior is unchanged (zero regression).
+  AWS_CONFIG_FILE:
+    sh: |
+      if curl -s -m 2 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" >/dev/null 2>&1; then
+        mkdir -p "{{.ROOT_DIR}}/private"
+        printf '[default]\ncredential_source = Ec2InstanceMetadata\n' > "{{.ROOT_DIR}}/private/aws-config"
+        echo "{{.ROOT_DIR}}/private/aws-config"
+      else
+        echo "${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+      fi
   HUB_CLUSTER_NAME:
     sh: yq '.hub.clusterName' {{.CONFIG_FILE}}
   AWS_REGION:

--- a/gitops/overlays/environments/prod/pod-identities/values.yaml
+++ b/gitops/overlays/environments/prod/pod-identities/values.yaml
@@ -13,7 +13,7 @@
 # here — that path is reserved for the bootstrap providers only.
 identities:
   eso:
-    enabled: false
+    enabled: true
   # Bootstrap the spoke's Crossplane iam/eks providers from the hub (see chart
   # values.yaml). Without these, the spoke's createIdentity:false providers have
   # no credentials and all spoke Crossplane providers fail (IMDS fallback).
@@ -21,33 +21,3 @@ identities:
     enabled: true
   crossplane-eks-provider:
     enabled: true
-  crossplane-iam:
-    enabled: true
-    roleName: CrossplaneIAMProviderRole
-    namespace: crossplane-system
-    serviceAccount: provider-aws-iam
-    tags:
-      managed-by: crossplane
-      purpose: crossplane-iam-provider
-    policy:
-      name: CrossplaneIAMProviderPolicy
-      document: |
-        {
-          "Version": "2012-10-17",
-          "Statement": [{"Effect": "Allow","Action": "*","Resource": "*"}]
-        }
-  crossplane-eks:
-    enabled: true
-    roleName: CrossplaneEKSProviderRole
-    namespace: crossplane-system
-    serviceAccount: provider-aws-eks
-    tags:
-      managed-by: crossplane
-      purpose: crossplane-eks-provider
-    policy:
-      name: CrossplaneEKSProviderPolicy
-      document: |
-        {
-          "Version": "2012-10-17",
-          "Statement": [{"Effect": "Allow","Action": "*","Resource": "*"}]
-        }


### PR DESCRIPTION
## Summary

Three related fixes surfaced while deploying `feature/agent-platform` on an EC2 instance-role host with a hub + dev/prod spokes.

### 1. `fix(pod-identities)` — spoke-prod identity set (commit 1)
The prod pod-identities overlay diverged from dev in two ways, both causing `pod-identities-spoke-prod` / `external-secrets-spoke-prod` to go **Degraded**:
- **Duplicate crossplane identities** — enabled *both* the base `crossplane-iam`/`crossplane-eks` **and** `crossplane-iam-provider`/`crossplane-eks-provider`, which target the same service accounts (`provider-aws-iam`/`eks`). EKS allows one PodIdentityAssociation per (SA, namespace), so the duplicates fail with `409 ResourceInUseException`. Removed the redundant base entries; the `-provider` variants are canonical.
- **`eso` disabled** — `eso.enabled: false` meant no `external-secrets-sa` pod identity, so ESO on prod couldn't read Secrets Manager. The overlay's own header lists external-secrets as foundational. Set `eso.enabled: true`.

Result: prod's `identities` block is now identical to the healthy dev overlay.

### 2. `docs(cluster-providers)` — EC2 AWS_CONFIG_FILE + kubectl caveat (commit 2)
Documents the credential-resolution behavior below and warns that `kubectl` run **directly** (outside `task`) on an EC2 host needs either `AWS_CONFIG_FILE` exported or a profile-less kubeconfig regeneration.

### 3. `fix(taskfiles)` — AWS_PROFILE=default on EC2 (commit 3)
Both cluster-provider Taskfiles export `AWS_PROFILE` (default `"default"`) to every `aws`/`kubectl`/`helm` call. On an EC2 instance-role host with no `[default]` profile in `~/.aws/config`, that fails and never falls through to IMDS — bootstrap hangs at the hub-verify loop. Added an EC2-aware `AWS_CONFIG_FILE` var: on EC2, generate `private/aws-config` with `credential_source=Ec2InstanceMetadata`; off-instance, fall back to the user's `AWS_CONFIG_FILE`/`~/.aws/config` (zero regression for local multi-account users).

## Testing
- Deployed hub + dev/prod spokes from `feature/agent-platform` on an EC2 instance-role host.
- Taskfile fix: bootstrap proceeds past the previously-hanging hub-verify loop; all `aws`/`kubectl`/`helm` calls resolve to the instance role.
- Pod-identity fix validated against dev (already healthy): prod's duplicate 409s and missing ESO identity are the only deltas; matching dev resolves both.

## Notes
- Doc commit intentionally ordered before the Taskfile commit.
- No change to off-EC2 / local behavior.