### PR TITLE
feat(karpenter): self-managed Karpenter addon alongside EKS Auto Mode

### DIFF
--- a/gitops/addons/charts/karpenter/Chart.yaml
+++ b/gitops/addons/charts/karpenter/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: karpenter
+description: >-
+  Self-managed Karpenter (alongside EKS Auto Mode) as a single addon: wraps the
+  upstream karpenter controller chart as a dependency (values nested under the
+  `karpenter:` key) and adds the Crossplane-managed IAM it needs — controller
+  pod-identity (Role + official v1.14 controller policy + PodIdentityAssociation)
+  and the node IAM role (+ managed policies + EC2_LINUX access entry) — plus the
+  optional (manageAddons-gated) vpc-cni/kube-proxy EKS addons a self-managed node
+  requires when the cluster has none. One enable_karpenter flip brings up the
+  controller + all its IAM together.
+type: application
+version: 0.1.0
+dependencies:
+  - name: karpenter
+    # First upstream release with cpuOptions.nestedVirtualization (Kata).
+    version: '1.14.0'
+    repository: oci://public.ecr.aws/karpenter

--- a/gitops/addons/charts/karpenter/templates/controller-identity.yaml
+++ b/gitops/addons/charts/karpenter/templates/controller-identity.yaml
@@ -1,0 +1,297 @@
+{{- if .Values.controller.enabled }}
+{{- /*
+Karpenter CONTROLLER pod-identity: IAM Role (pods.eks.amazonaws.com trust) +
+the official Karpenter v1.14 controller policy + a PodIdentityAssociation binding
+it to the karpenter ServiceAccount. Role/policy names match what the Karpenter
+helm chart + the policy's PassRole self-reference expect.
+deletionPolicy: Orphan — a disable must never delete a role a live node relies on.
+*/ -}}
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-controller-role
+  annotations:
+    crossplane.io/external-name: KarpenterControllerRole-{{ .Values.aws.clusterName }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  labels:
+    platform.gitops.io/role: {{ .Values.aws.clusterName }}-karpenter-controller
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": { "Service": "pods.eks.amazonaws.com" },
+            "Action": ["sts:AssumeRole", "sts:TagSession"]
+          }
+        ]
+      }
+    {{- with .Values.tags }}
+    tags:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-controller-policy
+  annotations:
+    crossplane.io/external-name: KarpenterControllerPolicy-{{ .Values.aws.clusterName }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "AllowScopedEC2InstanceAccessActions",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:aws:ec2:{{ .Values.aws.region }}::image/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}::snapshot/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:security-group/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:subnet/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:capacity-reservation/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:placement-group/*"
+            ],
+            "Action": ["ec2:RunInstances", "ec2:CreateFleet"]
+          },
+          {
+            "Sid": "AllowScopedEC2LaunchTemplateAccessActions",
+            "Effect": "Allow",
+            "Resource": "arn:aws:ec2:{{ .Values.aws.region }}:*:launch-template/*",
+            "Action": ["ec2:RunInstances", "ec2:CreateFleet"],
+            "Condition": {
+              "StringEquals": {"aws:ResourceTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned"},
+              "StringLike": {"aws:ResourceTag/karpenter.sh/nodepool": "*"}
+            }
+          },
+          {
+            "Sid": "AllowScopedEC2InstanceActionsWithTags",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:fleet/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:instance/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:volume/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:network-interface/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:launch-template/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:spot-instances-request/*"
+            ],
+            "Action": ["ec2:RunInstances", "ec2:CreateFleet", "ec2:CreateLaunchTemplate"],
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned",
+                "aws:RequestTag/eks:eks-cluster-name": "{{ .Values.aws.clusterName }}"
+              },
+              "StringLike": {"aws:RequestTag/karpenter.sh/nodepool": "*"}
+            }
+          },
+          {
+            "Sid": "AllowScopedResourceCreationTagging",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:fleet/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:instance/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:volume/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:network-interface/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:launch-template/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:spot-instances-request/*"
+            ],
+            "Action": "ec2:CreateTags",
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned",
+                "aws:RequestTag/eks:eks-cluster-name": "{{ .Values.aws.clusterName }}",
+                "ec2:CreateAction": ["RunInstances", "CreateFleet", "CreateLaunchTemplate"]
+              },
+              "StringLike": {"aws:RequestTag/karpenter.sh/nodepool": "*"}
+            }
+          },
+          {
+            "Sid": "AllowScopedResourceTagging",
+            "Effect": "Allow",
+            "Resource": "arn:aws:ec2:{{ .Values.aws.region }}:*:instance/*",
+            "Action": "ec2:CreateTags",
+            "Condition": {
+              "StringEquals": {"aws:ResourceTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned"},
+              "StringLike": {"aws:ResourceTag/karpenter.sh/nodepool": "*"},
+              "StringEqualsIfExists": {"aws:RequestTag/eks:eks-cluster-name": "{{ .Values.aws.clusterName }}"},
+              "ForAllValues:StringEquals": {
+                "aws:TagKeys": ["eks:eks-cluster-name", "karpenter.sh/nodeclaim", "Name"]
+              }
+            }
+          },
+          {
+            "Sid": "AllowScopedDeletion",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:instance/*",
+              "arn:aws:ec2:{{ .Values.aws.region }}:*:launch-template/*"
+            ],
+            "Action": ["ec2:TerminateInstances", "ec2:DeleteLaunchTemplate"],
+            "Condition": {
+              "StringEquals": {"aws:ResourceTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned"},
+              "StringLike": {"aws:ResourceTag/karpenter.sh/nodepool": "*"}
+            }
+          },
+          {
+            "Sid": "AllowRegionalReadActions",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": [
+              "ec2:DescribeCapacityReservations",
+              "ec2:DescribeImages",
+              "ec2:DescribeInstances",
+              "ec2:DescribeInstanceStatus",
+              "ec2:DescribeInstanceTypeOfferings",
+              "ec2:DescribeInstanceTypes",
+              "ec2:DescribeLaunchTemplates",
+              "ec2:DescribePlacementGroups",
+              "ec2:DescribeSecurityGroups",
+              "ec2:DescribeSpotPriceHistory",
+              "ec2:DescribeSubnets"
+            ],
+            "Condition": {"StringEquals": {"aws:RequestedRegion": "{{ .Values.aws.region }}"}}
+          },
+          {
+            "Sid": "AllowSSMReadActions",
+            "Effect": "Allow",
+            "Resource": "arn:aws:ssm:{{ .Values.aws.region }}::parameter/aws/service/*",
+            "Action": "ssm:GetParameter"
+          },
+          {
+            "Sid": "AllowPricingReadActions",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": "pricing:GetProducts"
+          },
+          {
+            "Sid": "AllowUnscopedInstanceProfileListAction",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": "iam:ListInstanceProfiles"
+          },
+          {
+            "Sid": "AllowInstanceProfileReadActions",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::{{ .Values.aws.accountId }}:instance-profile/*",
+            "Action": "iam:GetInstanceProfile"
+          },
+          {
+            "Sid": "AllowPassingInstanceRole",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::{{ .Values.aws.accountId }}:role/KarpenterNodeRole-{{ .Values.aws.clusterName }}",
+            "Action": "iam:PassRole",
+            "Condition": {
+              "StringEquals": {"iam:PassedToService": ["ec2.amazonaws.com", "ec2.amazonaws.com.cn"]}
+            }
+          },
+          {
+            "Sid": "AllowScopedInstanceProfileCreationActions",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::{{ .Values.aws.accountId }}:instance-profile/*",
+            "Action": ["iam:CreateInstanceProfile"],
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned",
+                "aws:RequestTag/eks:eks-cluster-name": "{{ .Values.aws.clusterName }}",
+                "aws:RequestTag/topology.kubernetes.io/region": "{{ .Values.aws.region }}"
+              },
+              "StringLike": {"aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"}
+            }
+          },
+          {
+            "Sid": "AllowScopedInstanceProfileTagActions",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::{{ .Values.aws.accountId }}:instance-profile/*",
+            "Action": ["iam:TagInstanceProfile"],
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned",
+                "aws:ResourceTag/topology.kubernetes.io/region": "{{ .Values.aws.region }}",
+                "aws:RequestTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned",
+                "aws:RequestTag/eks:eks-cluster-name": "{{ .Values.aws.clusterName }}",
+                "aws:RequestTag/topology.kubernetes.io/region": "{{ .Values.aws.region }}"
+              },
+              "StringLike": {
+                "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*",
+                "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
+              }
+            }
+          },
+          {
+            "Sid": "AllowScopedInstanceProfileActions",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::{{ .Values.aws.accountId }}:instance-profile/*",
+            "Action": [
+              "iam:AddRoleToInstanceProfile",
+              "iam:RemoveRoleFromInstanceProfile",
+              "iam:DeleteInstanceProfile"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/kubernetes.io/cluster/{{ .Values.aws.clusterName }}": "owned",
+                "aws:ResourceTag/topology.kubernetes.io/region": "{{ .Values.aws.region }}"
+              },
+              "StringLike": {"aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"}
+            }
+          },
+          {
+            "Sid": "AllowAPIServerEndpointDiscovery",
+            "Effect": "Allow",
+            "Resource": "arn:aws:eks:{{ .Values.aws.region }}:{{ .Values.aws.accountId }}:cluster/{{ .Values.aws.clusterName }}",
+            "Action": "eks:DescribeCluster"
+          }
+        ]
+      }
+    {{- with .Values.tags }}
+    tags:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: RolePolicyAttachment
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-controller-attachment
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    policyArnRef:
+      name: {{ .Values.aws.clusterName }}-karpenter-controller-policy
+    roleRef:
+      name: {{ .Values.aws.clusterName }}-karpenter-controller-role
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+---
+apiVersion: eks.aws.upbound.io/v1beta1
+kind: PodIdentityAssociation
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-controller-assoc
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    clusterName: {{ .Values.aws.clusterName }}
+    namespace: {{ .Values.controller.serviceAccountNamespace | default "kube-system" }}
+    serviceAccount: {{ .Values.controller.serviceAccountName | default "karpenter" }}
+    roleArnRef:
+      name: {{ .Values.aws.clusterName }}-karpenter-controller-role
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+{{- end }}

--- a/gitops/addons/charts/karpenter/templates/eks-addons.yaml
+++ b/gitops/addons/charts/karpenter/templates/eks-addons.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.node.enabled .Values.node.manageAddons }}
+{{- /*
+vpc-cni + kube-proxy EKS addons for the self-managed Karpenter node.
+
+Auto Mode's built-in networking applies ONLY to its own Bottlerocket nodes; a
+self-managed AL2023 node has neither the CNI nor kube-proxy, so pods on it can't
+reach the API server (node NotReady "cni plugin not initialized" / kata-deploy
+crashloop). external-name "<cluster>:<addon>" ADOPTS-or-creates in place, and
+OVERWRITE takes field ownership from a self-managed install.
+
+GATED behind node.manageAddons (default false): EKS addons are per-cluster
+singletons, so this must be OFF on any cluster where something else owns them
+(e.g. the platform-cluster Composition on managed-node-group clusters) or the two
+owners fight. Enable ONLY on a pure Auto Mode cluster with no existing owner.
+The vpc-cni toleration lets it schedule onto the tainted kata node.
+*/ -}}
+apiVersion: eks.aws.upbound.io/v1beta1
+kind: Addon
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-vpc-cni
+  annotations:
+    crossplane.io/external-name: {{ printf "%s:vpc-cni" .Values.aws.clusterName | quote }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    clusterName: {{ .Values.aws.clusterName }}
+    addonName: vpc-cni
+    resolveConflictsOnCreate: OVERWRITE
+    resolveConflictsOnUpdate: OVERWRITE
+    # Tolerate the kata taint so the CNI DaemonSet lands on the self-managed node.
+    configurationValues: |
+      {"tolerations":[{"operator":"Exists"}]}
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+---
+apiVersion: eks.aws.upbound.io/v1beta1
+kind: Addon
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-kube-proxy
+  annotations:
+    crossplane.io/external-name: {{ printf "%s:kube-proxy" .Values.aws.clusterName | quote }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    clusterName: {{ .Values.aws.clusterName }}
+    addonName: kube-proxy
+    resolveConflictsOnCreate: OVERWRITE
+    resolveConflictsOnUpdate: OVERWRITE
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+{{- end }}

--- a/gitops/addons/charts/karpenter/templates/node-identity.yaml
+++ b/gitops/addons/charts/karpenter/templates/node-identity.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.node.enabled }}
+{{- /*
+Karpenter NODE IAM: EC2-trusted Role (KarpenterNodeRole-<cluster>, referenced by
+the EC2NodeClass role field + the controller policy's PassRole), the managed
+policies a self-managed node needs (Auto Mode's node role does NOT cover
+self-managed nodes), and an EC2_LINUX EKS AccessEntry so launched nodes join.
+deletionPolicy: Orphan — a disable must never delete a role a live node assumes.
+*/ -}}
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-node-role
+  annotations:
+    crossplane.io/external-name: KarpenterNodeRole-{{ .Values.aws.clusterName }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  labels:
+    platform.gitops.io/role: {{ .Values.aws.clusterName }}-karpenter-node
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": { "Service": "ec2.amazonaws.com" },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
+    {{- with .Values.tags }}
+    tags:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+{{- range $i, $arn := .Values.node.managedPolicyArns }}
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: RolePolicyAttachment
+metadata:
+  name: {{ $.Values.aws.clusterName }}-karpenter-node-attachment-{{ $i }}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    policyArn: {{ $arn | quote }}
+    roleRef:
+      name: {{ $.Values.aws.clusterName }}-karpenter-node-role
+  providerConfigRef:
+    name: {{ $.Values.providerConfigName | default "default" }}
+{{- end }}
+---
+apiVersion: eks.aws.upbound.io/v1beta1
+kind: AccessEntry
+metadata:
+  name: {{ .Values.aws.clusterName }}-karpenter-node-access
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    clusterName: {{ .Values.aws.clusterName }}
+    # EC2_LINUX so Karpenter-launched Linux nodes authenticate to the cluster.
+    type: EC2_LINUX
+    principalArnRef:
+      name: {{ .Values.aws.clusterName }}-karpenter-node-role
+  providerConfigRef:
+    name: {{ .Values.providerConfigName | default "default" }}
+{{- end }}

--- a/gitops/addons/charts/karpenter/values.yaml
+++ b/gitops/addons/charts/karpenter/values.yaml
@@ -1,0 +1,75 @@
+# karpenter — self-managed Karpenter (alongside EKS Auto Mode) as one addon:
+# upstream controller (dependency, values under `karpenter:`) + its Crossplane IAM.
+# aws.* are injected by the addon registry entry's valuesObject from the cluster
+# secret annotations (aws_region / aws_cluster_name / aws_account_id).
+aws:
+  region: ""
+  clusterName: ""
+  accountId: ""
+
+# ── Upstream karpenter controller (subchart) ────────────────────────────────
+# Subchart values MUST nest under the dependency name `karpenter:`.
+karpenter:
+  settings:
+    # clusterName is injected by the registry valuesObject (karpenter.settings.clusterName).
+    clusterName: ""
+    # Endpoint discovered via eks:DescribeCluster (granted by the controller policy).
+    # No SQS interruption queue (on-demand pools); set to enable spot handling.
+    interruptionQueue: ""
+  # Pod Identity (NOT IRSA): the SA is bound to KarpenterControllerRole-<cluster>
+  # by the PodIdentityAssociation this chart creates. No IRSA role-arn annotation.
+  serviceAccount:
+    create: true
+    name: karpenter
+  # Pin the controller to the Auto Mode `system` nodepool. The upstream default
+  # REQUIRED rule is `karpenter.sh/nodepool DoesNotExist` — on Auto Mode EVERY node
+  # carries that label, so it matches nothing and the controller stays Pending.
+  # We can't null the required rule (Helm subchart coalesce won't overwrite a table
+  # with null), but we CAN replace its nodeSelectorTerms (table→table merge) with an
+  # `In [system]` match — binding the controller to Auto Mode's built-in system pool
+  # and keeping it off the self-managed kata pool.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: karpenter.sh/nodepool
+                operator: In
+                values: ["system"]
+
+# Crossplane ProviderConfig (provider-aws-iam / -eks).
+providerConfigName: default
+
+# ── Controller pod-identity IAM ─────────────────────────────────────────────
+# Role trusted by pods.eks.amazonaws.com + the official Karpenter v1.14 controller
+# policy + PodIdentityAssociation. Names match what the upstream chart + the policy
+# self-reference expect (KarpenterControllerRole-<cluster>).
+controller:
+  enabled: true
+  serviceAccountNamespace: kube-system
+  serviceAccountName: karpenter
+
+# ── Node IAM ────────────────────────────────────────────────────────────────
+# EC2-trusted role + the four managed policies a self-managed node needs (Auto
+# Mode's node role does NOT apply to self-managed nodes) + an EC2_LINUX AccessEntry
+# so launched nodes join. Role name KarpenterNodeRole-<cluster> (referenced by the
+# controller PassRole + the EC2NodeClass role field).
+node:
+  enabled: true
+  managedPolicyArns:
+    - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+    - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+    - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
+    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+  # A self-managed node needs vpc-cni + kube-proxy EKS addons (Auto Mode's built-in
+  # networking covers only its OWN Bottlerocket nodes). manageAddons provisions them
+  # as Crossplane Addon MRs that ADOPT-or-create in place (external-name <cluster>:<addon>,
+  # OVERWRITE). Leave FALSE unless nothing else owns them — on a managed-node-group
+  # cluster the platform-cluster Composition already owns these; enabling here would
+  # create a dual-owner conflict. Set true ONLY on a pure Auto Mode cluster.
+  manageAddons: false
+
+# Common tags on managed IAM resources.
+tags:
+  managed-by: crossplane
+  purpose: karpenter

--- a/gitops/addons/registry/core.yaml
+++ b/gitops/addons/registry/core.yaml
@@ -392,3 +392,47 @@ external-dns:
               namespace: kube-system
               serviceAccount: external-dns-sa
               deploymentLabel: app.kubernetes.io/name=external-dns
+
+# ─── Karpenter (self-managed, alongside EKS Auto Mode) ──────────────────────
+# Self-managed Karpenter for dedicated workload pools (e.g. Kata nested-virt nodes)
+# that Auto Mode's Bottlerocket nodes can't host. Coexists with Auto Mode: each
+# controller owns only NodePools whose nodeClassRef.group matches its NodeClass API
+# (Auto Mode = eks.amazonaws.com; self-managed = karpenter.k8s.aws), so neither
+# manages the other's NodeClaims.
+#
+# Single wrapper chart (addons/charts/karpenter): upstream karpenter as a Helm
+# DEPENDENCY (values nested under `karpenter:`) + the Crossplane IAM it needs
+# (controller pod-identity, node role + access entry, optional manageAddons-gated
+# vpc-cni/kube-proxy). One enable_karpenter flip brings up controller + IAM together.
+# The EC2NodeClass + NodePool objects are supplied by the consuming layer (e.g. the
+# agentic kata-nodepool addon), NOT here.
+#
+# CRDs: the upstream subchart ships CRDs in crds/ (Helm install-if-absent) + the app
+# uses ServerSideApply, so the shared karpenter.sh nodepools/nodeclaims CRDs that Auto
+# Mode owns are left intact; only the non-shared karpenter.k8s.aws/ec2nodeclasses is added.
+# v1.14.0: first upstream release with cpuOptions.nestedVirtualization (needed for Kata).
+karpenter:
+  namespace: kube-system
+  path: '{{.metadata.annotations.addonsRepoBasepath}}addons/charts/karpenter'
+  defaultVersion: '0.1.0'
+  annotationsAppSet:
+    # After crossplane-base (wave 3) registers iam/eks CRDs. The in-chart IAM
+    # resources carry their own negative sync-waves so they apply first within this app.
+    argocd.argoproj.io/sync-wave: '5'
+  selector:
+    matchExpressions:
+      - key: enable_karpenter
+        operator: In
+        values: ['true']
+  valuesObject:
+    # Top-level: consumed by the IAM templates (policy ARNs, external-names).
+    aws:
+      region: '{{.metadata.annotations.aws_region}}'
+      clusterName: '{{.metadata.annotations.aws_cluster_name}}'
+      accountId: '{{.metadata.annotations.aws_account_id}}'
+    # Upstream controller settings nest under the subchart name `karpenter:`.
+    # (affinity override + Pod-Identity SA are chart defaults; only clusterName
+    # needs per-cluster injection here.)
+    karpenter:
+      settings:
+        clusterName: '{{.metadata.annotations.aws_cluster_name}}'


### PR DESCRIPTION
## Summary

Adds a **self-managed Karpenter** addon that runs **alongside EKS Auto Mode**, for dedicated workload pools (e.g. Kata nested-virt sandbox nodes) that Auto Mode's Bottlerocket nodes cannot host. The two coexist safely: each controller only reconciles NodePools whose `nodeClassRef.group` matches its NodeClass API (Auto Mode = `eks.amazonaws.com`, self-managed = `karpenter.k8s.aws`), so neither manages the other's NodeClaims. Verified live on a spoke cluster.

Gated behind `enable_karpenter`. Provisions **only the controller + its IAM** — the `EC2NodeClass` + `NodePool` objects are supplied by the consuming layer (e.g. an agentic `kata-nodepool` addon), not here.

## What's included

Single wrapper chart `gitops/addons/charts/karpenter` + a `karpenter` entry in `registry/core.yaml`:

- **Upstream karpenter `1.14.0` as a Helm dependency** (values nested under `karpenter:`). 1.14.0 is the first release exposing `cpuOptions.nestedVirtualization`, which Kata micro-VMs require.
- **Controller scheduling** — pinned to Auto Mode's built-in `system` nodepool via required `nodeAffinity` `karpenter.sh/nodepool In [system]`. The upstream default (`DoesNotExist`) matches nothing on Auto Mode (every node carries the label) → the controller would stay `Pending`. A subchart table can't be nulled via Helm coalesce, so we replace the `nodeSelectorTerms` instead.
- **Controller pod-identity** — IAM Role (trusted by `pods.eks.amazonaws.com`) + the official Karpenter v1.14 controller policy + a `PodIdentityAssociation`. Uses **EKS Pod Identity, not IRSA**, matching this platform.
- **Node IAM** — EC2-trusted Role + worker/CNI/ECR/SSM managed policies + an `EC2_LINUX` `AccessEntry` so Karpenter-launched nodes join.
- **`node.manageAddons` (default `false`)** — optionally adopt-or-create the `vpc-cni` + `kube-proxy` EKS addons a self-managed node needs (Auto Mode's networking covers only its own nodes). Default off so it never dual-owns addons the `platform-cluster` Composition already manages on managed-node-group clusters; enable only on a pure Auto Mode cluster.
- All Crossplane MRs use `deletionPolicy: Orphan` + `SkipDryRunOnMissingResource` — disabling the addon never deletes a role a live node is still assuming.

## CRD coexistence

The upstream subchart ships CRDs in `crds/` (Helm install-if-absent) and the addons app uses `ServerSideApply`, so Auto Mode's **shared** `karpenter.sh` `nodepools`/`nodeclaims` CRDs are left intact; only the non-shared `karpenter.k8s.aws/ec2nodeclasses` CRD is added.

## Testing

Validated on a live spoke (pure Auto Mode) during development of the coexistence approach:
- self-managed Karpenter provisioned a dedicated tainted node while Auto Mode was undisturbed (5 nodes stayed Ready, its NodePools uneventful);
- NodeClaims partitioned cleanly by `nodeClassRef.group` — zero cross-controller ownership;
- workloads with a required kata label + toleration scheduled onto the Karpenter node only; normal pods stayed on Auto Mode (Karpenter ignored them, its pool being tainted).

Chart renders clean; `node.manageAddons` gate verified (0 Addon MRs off, 2 on); embedded controller policy JSON validates.
