### PR TITLE
fix(platform): bump fluent-bit 3.4.9 + fix keycloak/argo-workflows in…

### DIFF
--- a/gitops/addons/charts/argo-workflows/templates/ingress.yaml
+++ b/gitops/addons/charts/argo-workflows/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /* insecure: HTTP-only ingress, no cert (consumer terminates TLS upstream, e.g. CloudFront). */ -}}
-{{- $insecure := .Values.insecure -}}
+{{- $insecure := eq (toString (.Values.insecure | default "false")) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/gitops/addons/charts/keycloak/templates/ingress.yaml
+++ b/gitops/addons/charts/keycloak/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /* insecure: HTTP-only ingress, no cert (consumer terminates TLS upstream, e.g. CloudFront). */ -}}
-{{- $insecure := .Values.global.insecure -}}
+{{- $insecure := eq (toString (.Values.global.insecure | default "false")) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/gitops/addons/registry/observability.yaml
+++ b/gitops/addons/registry/observability.yaml
@@ -267,7 +267,7 @@ aws-for-fluentbit:
       # Track the latest aws-for-fluent-bit 3.x image (AL2023, fluent-bit v5.x).
       # Bump as new patch/minor releases ship with CVE fixes:
       # https://github.com/aws/aws-for-fluent-bit/releases
-      tag: 3.4.8
+      tag: 3.4.9
 
 cni-metrics-helper:
   namespace: kube-system


### PR DESCRIPTION
…gress insecure flag

1. Bump aws-for-fluent-bit from 3.4.8 to 3.4.9 to resolve high-severity CVEs (ALAS2023-2026-1986, ALAS2023-2026-1942, CVE-2026-11850).

2. Fix keycloak and argo-workflows ingress templates: the insecure flag was evaluated as a bare Go template conditional, but the ApplicationSet passes the string "false" which is truthy. Changed to explicit eq comparison so insecure=false correctly renders HTTPS listen-ports with the host field set, placing the ingress rules on the 443 listener alongside Langfuse and AgentGateway.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
