### PR TITLE
fix(dashboards): rename LiteLLM Gateway dashboard to Bifrost LLM Gateway

### DIFF
--- a/gitops/addons/charts/grafana-dashboards/templates/agent-platform-dashboards.yaml
+++ b/gitops/addons/charts/grafana-dashboards/templates/agent-platform-dashboards.yaml
@@ -32,11 +32,11 @@ spec:
           "targets": [{"expr": "count(kube_pod_info{namespace=~\"mcp-.*\"})", "legendFormat": "MCP Servers"}]
         },
         {
-          "title": "LiteLLM / Bifrost Ready",
+          "title": "Bifrost Ready",
           "type": "stat",
           "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
           "datasource": {"uid": "prometheus"},
-          "targets": [{"expr": "count(kube_pod_status_ready{namespace=~\"litellm|bifrost\",condition=\"true\"})", "legendFormat": "Ready"}]
+          "targets": [{"expr": "count(kube_pod_status_ready{namespace=\"bifrost\",condition=\"true\"})", "legendFormat": "Ready"}]
         },
         {
           "title": "Agent Gateway Ready",
@@ -51,7 +51,7 @@ spec:
           "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
           "datasource": {"uid": "prometheus"},
           "targets": [
-            {"expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"litellm|bifrost|otel|agentgateway-system|langfuse|jaeger|mcp-.*|default\"}[5m])) by (namespace)", "legendFormat": "{{ "{{" }}namespace{{ "}}" }}"}
+            {"expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"bifrost|otel|agentgateway-system|langfuse|jaeger|mcp-.*|default\"}[5m])) by (namespace)", "legendFormat": "{{ "{{" }}namespace{{ "}}" }}"}
           ]
         },
         {
@@ -60,7 +60,7 @@ spec:
           "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
           "datasource": {"uid": "prometheus"},
           "targets": [
-            {"expr": "sum(container_memory_working_set_bytes{namespace=~\"litellm|bifrost|otel|agentgateway-system|langfuse|jaeger|mcp-.*|default\"}) by (namespace) / 1024 / 1024", "legendFormat": "{{ "{{" }}namespace{{ "}}" }} (MiB)"}
+            {"expr": "sum(container_memory_working_set_bytes{namespace=\"bifrost|otel|agentgateway-system|langfuse|jaeger|mcp-.*|default\"}) by (namespace) / 1024 / 1024", "legendFormat": "{{ "{{" }}namespace{{ "}}" }} (MiB)"}
           ]
         },
         {
@@ -69,7 +69,7 @@ spec:
           "gridPos": {"h": 8, "w": 24, "x": 0, "y": 12},
           "datasource": {"uid": "prometheus"},
           "targets": [
-            {"expr": "increase(kube_pod_container_status_restarts_total{namespace=~\"litellm|bifrost|otel|agentgateway-system|langfuse|mcp-.*|default\"}[1h]) > 0", "legendFormat": "{{ "{{" }}namespace{{ "}}" }}/{{ "{{" }}pod{{ "}}" }}"}
+            {"expr": "increase(kube_pod_container_status_restarts_total{namespace=\"bifrost|otel|agentgateway-system|langfuse|mcp-.*|default\"}[1h]) > 0", "legendFormat": "{{ "{{" }}namespace{{ "}}" }}/{{ "{{" }}pod{{ "}}" }}"}
           ]
         },
         {
@@ -182,34 +182,16 @@ spec:
       dashboards: "external-grafana"
   json: |
     {
-      "title": "Agent Platform - LiteLLM Gateway",
+      "title": "Agent Platform - Bifrost LLM Gateway",
       "uid": "agent-platform-litellm",
-      "tags": ["agent-platform", "litellm"],
+      "tags": ["agent-platform", "bifrost"],
       "timezone": "browser",
       "schemaVersion": 39,
       "panels": [
         {
-          "title": "LiteLLM CPU",
-          "type": "timeseries",
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
-          "datasource": {"uid": "prometheus"},
-          "targets": [
-            {"expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"litellm\",pod=~\"litellm.*\"}[5m])) by (pod)", "legendFormat": "{{ "{{" }}pod{{ "}}" }}"}
-          ]
-        },
-        {
-          "title": "LiteLLM Memory",
-          "type": "timeseries",
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-          "datasource": {"uid": "prometheus"},
-          "targets": [
-            {"expr": "sum(container_memory_working_set_bytes{namespace=\"litellm\",pod=~\"litellm.*\"}) by (pod) / 1024 / 1024", "legendFormat": "{{ "{{" }}pod{{ "}}" }} (MiB)"}
-          ]
-        },
-        {
           "title": "Bifrost CPU",
           "type": "timeseries",
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
           "datasource": {"uid": "prometheus"},
           "targets": [
             {"expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"bifrost\",pod=~\"bifrost.*\"}[5m])) by (pod)", "legendFormat": "{{ "{{" }}pod{{ "}}" }}"}
@@ -218,20 +200,20 @@ spec:
         {
           "title": "Bifrost Memory",
           "type": "timeseries",
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
           "datasource": {"uid": "prometheus"},
           "targets": [
             {"expr": "sum(container_memory_working_set_bytes{namespace=\"bifrost\",pod=~\"bifrost.*\"}) by (pod) / 1024 / 1024", "legendFormat": "{{ "{{" }}pod{{ "}}" }} (MiB)"}
           ]
         },
         {
-          "title": "LLM Gateway Network I/O",
+          "title": "Bifrost Network I/O",
           "type": "timeseries",
-          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
           "datasource": {"uid": "prometheus"},
           "targets": [
-            {"expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"litellm|bifrost\"}[5m])) by (namespace, pod) / 1024", "legendFormat": "{{ "{{" }}pod{{ "}}" }} RX (KiB/s)"},
-            {"expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"litellm|bifrost\"}[5m])) by (namespace, pod) / 1024", "legendFormat": "{{ "{{" }}pod{{ "}}" }} TX (KiB/s)"}
+            {"expr": "sum(rate(container_network_receive_bytes_total{namespace=\"bifrost\"}[5m])) by (pod) / 1024", "legendFormat": "{{ "{{" }}pod{{ "}}" }} RX (KiB/s)"},
+            {"expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"bifrost\"}[5m])) by (pod) / 1024", "legendFormat": "{{ "{{" }}pod{{ "}}" }} TX (KiB/s)"}
           ]
         }
       ]


### PR DESCRIPTION
LiteLLM is no longer used — Bifrost is the sole LLM gateway. Updated dashboard title, tags, panels, and PromQL queries to reference only the bifrost namespace. Removed duplicate LiteLLM CPU/Memory panels.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
