### PR TITLE
fix(karpenter): set forProvider.region on EKS PodIdentityAssociation …

### DIFF
--- a/gitops/addons/charts/karpenter/templates/controller-identity.yaml
+++ b/gitops/addons/charts/karpenter/templates/controller-identity.yaml
@@ -287,6 +287,10 @@ metadata:
 spec:
   deletionPolicy: Orphan
   forProvider:
+    # region is REQUIRED on every eks.aws.upbound.io MR (unlike the global
+    # iam.aws.upbound.io Role/Policy). Without it the MR fails admission with
+    # "spec.forProvider.region: Required value".
+    region: {{ .Values.aws.region }}
     clusterName: {{ .Values.aws.clusterName }}
     namespace: {{ .Values.controller.serviceAccountNamespace | default "kube-system" }}
     serviceAccount: {{ .Values.controller.serviceAccountName | default "karpenter" }}

--- a/gitops/addons/charts/karpenter/templates/node-identity.yaml
+++ b/gitops/addons/charts/karpenter/templates/node-identity.yaml
@@ -65,6 +65,10 @@ metadata:
 spec:
   deletionPolicy: Orphan
   forProvider:
+    # region is REQUIRED on every eks.aws.upbound.io MR (unlike the global
+    # iam.aws.upbound.io Role). Without it the MR fails admission with
+    # "spec.forProvider.region: Required value".
+    region: {{ .Values.aws.region }}
     clusterName: {{ .Values.aws.clusterName }}
     # EC2_LINUX so Karpenter-launched Linux nodes authenticate to the cluster.
     type: EC2_LINUX


### PR DESCRIPTION
…+ AccessEntry

Every eks.aws.upbound.io managed resource requires spec.forProvider.region; the PodIdentityAssociation and AccessEntry templates omitted it, so both failed admission at sync:

  spec.forProvider.region: Required value

.Values.aws.region is already injected (the controller policy uses it throughout) — wire it into both forProvider blocks. The iam.aws.upbound.io MRs (Role/Policy/RolePolicyAttachment) are global and unaffected.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
