### PR TITLE
fix(karpenter): AccessEntry ref field is principalArnFromRoleRef

### DIFF
--- a/gitops/addons/charts/karpenter/templates/node-identity.yaml
+++ b/gitops/addons/charts/karpenter/templates/node-identity.yaml
@@ -72,7 +72,12 @@ spec:
     clusterName: {{ .Values.aws.clusterName }}
     # EC2_LINUX so Karpenter-launched Linux nodes authenticate to the cluster.
     type: EC2_LINUX
-    principalArnRef:
+    # NOTE: the AccessEntry CRD's cross-resource reference field is
+    # principalArnFromRoleRef (NOT principalArnRef — that name is pruned by the
+    # API server as it's absent from the structural schema, leaving principalArn
+    # empty → "InvalidParameterException: principalArn ... not valid []").
+    # This differs from PodIdentityAssociation, whose ref field IS roleArnRef.
+    principalArnFromRoleRef:
       name: {{ .Values.aws.clusterName }}-karpenter-node-role
   providerConfigRef:
     name: {{ .Values.providerConfigName | default "default" }}


### PR DESCRIPTION
## Problem

The self-managed Karpenter node `AccessEntry` (`eks.aws.upbound.io`) failed to reconcile on spoke-dev:

```
observe failed: reading EKS Access Entry (spoke-dev:<no value>):
  InvalidParameterException: The principalArn parameter format is not valid []
```

## Root cause

The template used `principalArnRef`, which is **not a field** on the AccessEntry CRD (provider-aws-eks v2.6.1). The CRD's cross-resource reference field is `principalArnFromRoleRef` (siblings: `principalArn`, `principalArnFromRoleSelector`).

Because `principalArnRef` is absent from the CRD's structural schema, the API server **prunes it on apply**. The live MR ends up with no ref and never resolves `principalArn` → `<no value>` → `InvalidParameterException`.

This is why only the node AccessEntry failed while the controller `PodIdentityAssociation` synced fine — its ref field genuinely **is** `roleArnRef`. The naming convention differs per EKS CRD.

| CRD | valid ref field |
|---|---|
| PodIdentityAssociation | `roleArnRef` |
| AccessEntry | `principalArnFromRoleRef` |

## Fix

Rename `principalArnRef` → `principalArnFromRoleRef`. Verified: the node Role MR is healthy with its ARN populated, so the ref resolves once the field name is correct. Renders both `region` (from #790) and the corrected ref. Diff is field rename + explanatory comment only.