### PR TITLE
refactor(nodepools): decouple workshop-tuned pools; default to EKS Auto Mode built-ins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ config.local.yaml
 
 # Pinned platform artifact clone (OAP-style consumption)
 .platform/
+*.creds

--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -457,7 +457,7 @@ spec:
         app: backstage
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: system-peeks
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
@@ -626,7 +626,7 @@ spec:
         app: postgresql
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: system-peeks
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/gitops/addons/charts/gitlab/templates/gitlab.yaml
+++ b/gitops/addons/charts/gitlab/templates/gitlab.yaml
@@ -34,7 +34,7 @@ spec:
         app: gitlab
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: system
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/gitops/addons/charts/gitlab/templates/init-job.yaml
+++ b/gitops/addons/charts/gitlab/templates/init-job.yaml
@@ -277,7 +277,7 @@ spec:
       serviceAccountName: default
       restartPolicy: OnFailure
       nodeSelector:
-        karpenter.sh/nodepool: system
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/gitops/addons/charts/keycloak/templates/install.yaml
+++ b/gitops/addons/charts/keycloak/templates/install.yaml
@@ -68,7 +68,7 @@ spec:
         checksum/config: {{ include "keycloak.conf" . | sha256sum }}
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: system-peeks
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
@@ -201,7 +201,7 @@ spec:
         app: postgresql
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: system-peeks
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/gitops/addons/charts/kubevela/values.yaml
+++ b/gitops/addons/charts/kubevela/values.yaml
@@ -21,7 +21,7 @@ vela-core:
   
   # Node Selection for System Nodepool
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   
   # Tolerations for system nodes
   tolerations:

--- a/gitops/addons/charts/platform-manifests-bootstrap/templates/custom-nodepools.yaml
+++ b/gitops/addons/charts/platform-manifests-bootstrap/templates/custom-nodepools.yaml
@@ -1,87 +1,20 @@
-{{- if .Values.customNodepools.enabled }}
+{{- /*
+Custom Karpenter NodePools, rendered from a caller-supplied list.
+
+The generic solution ships NO custom pools (default empty) and relies on the EKS
+Auto Mode built-in `system` / `general-purpose` NodePools. Consumers that need
+tuned pools — e.g. the workshop's stability-oriented pools with a daytime
+"do-not-disrupt" budget and a longer termination grace — supply the full pool
+definitions via their own overlay (see workshop/overlay/.../platform-manifests/values.yaml).
+
+Each entry: { name: <string>, spec: <karpenter.sh/v1 NodePool spec> }.
+*/ -}}
+{{- range .Values.customNodepools.pools }}
 ---
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: general-purpose-peeks
+  name: {{ .name }}
 spec:
-  disruption:
-    consolidationPolicy: WhenEmptyOrUnderutilized
-    consolidateAfter: 5m
-    budgets:
-    - nodes: "0"
-    - nodes: "30%"
-      schedule: "0 20 * * *"
-      duration: 2h
-  template:
-    metadata:
-      labels:
-        node-type: general-purpose
-        managed-by: peeks
-    spec:
-      nodeClassRef:
-        group: eks.amazonaws.com
-        kind: NodeClass
-        name: default
-      requirements:
-        - key: "karpenter.sh/capacity-type"
-          operator: In
-          values: ["on-demand"]
-        - key: "kubernetes.io/arch"
-          operator: In
-          values: ["amd64"]
-        - key: "eks.amazonaws.com/instance-category"
-          operator: In
-          values: ["c", "m", "r"]
-        - key: "eks.amazonaws.com/instance-generation"
-          operator: Gt
-          values: ["5"]
-        - key: "eks.amazonaws.com/instance-size"
-          operator: In
-          values: ["xlarge", "2xlarge", "4xlarge", "8xlarge"]
-      terminationGracePeriod: 48h
----
-apiVersion: karpenter.sh/v1
-kind: NodePool
-metadata:
-  name: system-peeks
-spec:
-  disruption:
-    consolidationPolicy: WhenEmptyOrUnderutilized
-    consolidateAfter: 5m
-    budgets:
-    - nodes: "0"
-    - nodes: "30%"
-      schedule: "0 20 * * *"
-      duration: 2h
-  template:
-    metadata:
-      labels:
-        node-type: system
-        managed-by: peeks
-    spec:
-      nodeClassRef:
-        group: eks.amazonaws.com
-        kind: NodeClass
-        name: default
-      requirements:
-        - key: "karpenter.sh/capacity-type"
-          operator: In
-          values: ["on-demand"]
-        - key: "kubernetes.io/arch"
-          operator: In
-          values: ["amd64"]
-        - key: "eks.amazonaws.com/instance-category"
-          operator: In
-          values: ["c", "m", "r"]
-        - key: "eks.amazonaws.com/instance-generation"
-          operator: Gt
-          values: ["5"]
-        - key: "eks.amazonaws.com/instance-size"
-          operator: In
-          values: ["xlarge", "2xlarge"]
-      taints:
-        - key: CriticalAddonsOnly
-          effect: NoSchedule
-      terminationGracePeriod: 48h
+  {{- toYaml .spec | nindent 2 }}
 {{- end }}

--- a/gitops/addons/charts/platform-manifests-bootstrap/values.yaml
+++ b/gitops/addons/charts/platform-manifests-bootstrap/values.yaml
@@ -1,7 +1,10 @@
-# Gates for the bootstrap NodePools. The platform ApplicationSet overrides these
-# via the registry valuesObject; defaults here keep the chart self-contained so
-# `helm template` renders standalone.
+# Bootstrap NodePools. Defaults keep the chart self-contained for `helm template`.
+#
+# customNodepools.pools: caller-supplied custom Karpenter NodePools (default none).
+# The generic solution ships no custom pools and uses the EKS Auto Mode built-in
+# `system`/`general-purpose` NodePools. Consumers (e.g. the workshop) supply their
+# own pool definitions via their overlay.
 customNodepools:
-  enabled: true
+  pools: []
 gpu:
   enabled: true

--- a/gitops/addons/configs/argo-events/values.yaml
+++ b/gitops/addons/configs/argo-events/values.yaml
@@ -10,7 +10,7 @@ configs:
 # Override NATS clustering configuration to use full DNS names
 controller:
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/gitops/addons/configs/argo-rollouts/values.yaml
+++ b/gitops/addons/configs/argo-rollouts/values.yaml
@@ -1,6 +1,6 @@
 controller:
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"
@@ -15,7 +15,7 @@ controller:
 dashboard:
   enabled: true
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/gitops/addons/configs/argo-workflows/values.yaml
+++ b/gitops/addons/configs/argo-workflows/values.yaml
@@ -4,7 +4,7 @@ controller:
     enabled: true
     maxUnavailable: 1
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"
@@ -23,7 +23,7 @@ server:
     enabled: true
     maxUnavailable: 1
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/gitops/addons/configs/aws-efs-csi-driver/values.yaml
+++ b/gitops/addons/configs/aws-efs-csi-driver/values.yaml
@@ -3,4 +3,4 @@ controller:
   nodeSelector:
     eks.amazonaws.com/compute-type: auto
     kubernetes.io/os: linux
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system

--- a/gitops/addons/configs/cert-manager/values.yaml
+++ b/gitops/addons/configs/cert-manager/values.yaml
@@ -13,7 +13,7 @@ resources:
   limits:
     memory: 128Mi
 nodeSelector:
-  karpenter.sh/nodepool: system-peeks
+  karpenter.sh/nodepool: system
 tolerations:
 - key: "CriticalAddonsOnly"
   operator: "Exists"
@@ -39,7 +39,7 @@ cainjector:
     limits:
       memory: 512Mi
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
   - key: "CriticalAddonsOnly"
     operator: "Exists"
@@ -65,7 +65,7 @@ webhook:
     limits:
       memory: 64Mi
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
   - key: "CriticalAddonsOnly"
     operator: "Exists"

--- a/gitops/addons/configs/crossplane/values.yaml
+++ b/gitops/addons/configs/crossplane/values.yaml
@@ -9,7 +9,7 @@ resources:
     memory: 512Mi
 
 nodeSelector:
-  karpenter.sh/nodepool: system-peeks
+  karpenter.sh/nodepool: system
 
 tolerations:
 - key: "CriticalAddonsOnly"
@@ -38,7 +38,7 @@ rbacManager:
     limits:
       memory: 256Mi
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
   - key: "CriticalAddonsOnly"
     operator: "Exists"

--- a/gitops/addons/configs/efs-chart/values.yaml
+++ b/gitops/addons/configs/efs-chart/values.yaml
@@ -6,4 +6,4 @@ deployment:
   nodeSelector:
     eks.amazonaws.com/compute-type: auto
     kubernetes.io/os: linux
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system

--- a/gitops/addons/configs/external-secrets/values.yaml
+++ b/gitops/addons/configs/external-secrets/values.yaml
@@ -10,7 +10,7 @@ resources:
     memory: 128Mi
 
 nodeSelector:
-  karpenter.sh/nodepool: system-peeks
+  karpenter.sh/nodepool: system
 
 tolerations:
 - key: "CriticalAddonsOnly"
@@ -39,7 +39,7 @@ certController:
     limits:
       memory: 64Mi
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
   - key: "CriticalAddonsOnly"
     operator: "Exists"
@@ -65,7 +65,7 @@ webhook:
     limits:
       memory: 64Mi
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
   - key: "CriticalAddonsOnly"
     operator: "Exists"

--- a/gitops/addons/configs/image-prepuller/values.yaml
+++ b/gitops/addons/configs/image-prepuller/values.yaml
@@ -16,4 +16,4 @@ tolerations:
     effect: 'NoSchedule'
 
 nodeSelector:
-  karpenter.sh/nodepool: general-purpose-peeks
+  karpenter.sh/nodepool: general-purpose

--- a/gitops/addons/configs/kubevela/values.yaml
+++ b/gitops/addons/configs/kubevela/values.yaml
@@ -1,6 +1,6 @@
 vela-core:
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"
@@ -14,7 +14,7 @@ vela-core:
 
 cluster-gateway:
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"
@@ -22,7 +22,7 @@ cluster-gateway:
 
 workflow:
   nodeSelector:
-    karpenter.sh/nodepool: system-peeks
+    karpenter.sh/nodepool: system
   tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Exists"

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -566,9 +566,12 @@ ack-efs:
       jsonPointers:
         - /metadata/annotations/controller-gen.kubebuilder.io~1version
 
-# Bootstrap NodePools created EARLY (sync-wave -1) so the custom peeks nodepools
-# (system-peeks / general-purpose-peeks / gpu / trainium) exist before any addon
-# that targets them schedules. Gated by the enable_platform_manifests_bootstrap
+# Bootstrap NodePools created EARLY (sync-wave -1) so any pools exist before addons
+# that target them schedule. The generic solution creates only the GPU/Trainium pools
+# (a real capability with no built-in equivalent) and relies on the EKS Auto Mode
+# built-in system/general-purpose pools for everything else. Consumers that need tuned
+# pools supply them via their overlay as customNodepools.pools (e.g. the workshop's
+# system-peeks/general-purpose-peeks). Gated by the enable_platform_manifests_bootstrap
 # cluster annotation (default "true", wired in rg-eks-vpc.yaml). Does NOT include
 # the ClusterSecretStore — that lives in platform-manifests-post to avoid a
 # circular dependency.
@@ -584,8 +587,9 @@ platform-manifests-bootstrap:
         operator: In
         values: ['true']
   valuesObject:
-    customNodepools:
-      enabled: true
+    # Custom Karpenter NodePools are supplied by the consumer's overlay
+    # (customNodepools.pools). The generic solution creates none and relies on the
+    # EKS Auto Mode built-in system/general-purpose pools.
     gpu:
       enabled: true
 

--- a/gitops/overlays/environments/control-plane/platform-manifests/values.yaml
+++ b/gitops/overlays/environments/control-plane/platform-manifests/values.yaml
@@ -1,2 +1,8 @@
+# Control-plane platform-manifests overlay (generic).
+#
+# The generic control-plane creates NO custom Karpenter NodePools — platform
+# workloads run on the EKS Auto Mode built-in `system`/`general-purpose` pools.
+# Consumers that need tuned pools supply them via their own overlay as
+# `customNodepools.pools` (see workshop/overlay/.../platform-manifests/values.yaml).
 customNodepools:
-  enabled: true
+  pools: []

--- a/workshop/overlay/overlays/environments/control-plane/backstage/values.yaml
+++ b/workshop/overlay/overlays/environments/control-plane/backstage/values.yaml
@@ -1,0 +1,4 @@
+# Workshop pins Backstage to the tuned system-peeks pool (daytime do-not-disrupt).
+# The generic default is the built-in `system` pool.
+global:
+  systemNodepool: system-peeks

--- a/workshop/overlay/overlays/environments/control-plane/gitlab/values.yaml
+++ b/workshop/overlay/overlays/environments/control-plane/gitlab/values.yaml
@@ -1,0 +1,4 @@
+# Workshop pins GitLab to the tuned system-peeks pool (daytime do-not-disrupt).
+# The generic default is the built-in `system` pool.
+global:
+  systemNodepool: system-peeks

--- a/workshop/overlay/overlays/environments/control-plane/keycloak/values.yaml
+++ b/workshop/overlay/overlays/environments/control-plane/keycloak/values.yaml
@@ -1,0 +1,5 @@
+# Workshop pins Keycloak to the tuned system-peeks pool (daytime do-not-disrupt)
+# so login sessions aren't interrupted by node consolidation during the workshop.
+# The generic default is the built-in `system` pool.
+global:
+  systemNodepool: system-peeks

--- a/workshop/overlay/overlays/environments/control-plane/platform-manifests/values.yaml
+++ b/workshop/overlay/overlays/environments/control-plane/platform-manifests/values.yaml
@@ -1,0 +1,98 @@
+# Workshop-specific tuned Karpenter NodePools.
+#
+# These live in the WORKSHOP overlay (not the generic solution) because their
+# reconciliation policy is workshop-specific: a daytime "do-not-disrupt" budget
+# (nodes: "0") with a nightly consolidation window, plus a 48h termination grace,
+# so Karpenter does not consolidate/recycle platform nodes while a (possibly
+# pre-provisioned, multi-day) workshop is in use. Rendered by the generic
+# platform-manifests-bootstrap chart from this caller-supplied list.
+#
+# The built-in system/general-purpose pools remain enabled (they provide the
+# `default` NodeClass these pools reference); the workshop pins its critical
+# addons to these via the global.systemNodepool knob in the per-addon overlays.
+customNodepools:
+  pools:
+    - name: general-purpose-peeks
+      spec:
+        # Prefer this tuned pool over the built-in general-purpose (weight 0) so
+        # unpinned workloads land here and inherit the do-not-disrupt budget instead
+        # of the built-in's default consolidation. Adjust to your own precedence.
+        weight: 100
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 5m
+          budgets:
+            - nodes: "0"
+            - nodes: "30%"
+              schedule: "0 20 * * *"
+              duration: 2h
+        template:
+          metadata:
+            labels:
+              node-type: general-purpose
+              managed-by: peeks
+          spec:
+            nodeClassRef:
+              group: eks.amazonaws.com
+              kind: NodeClass
+              name: default
+            requirements:
+              - key: "karpenter.sh/capacity-type"
+                operator: In
+                values: ["on-demand"]
+              - key: "kubernetes.io/arch"
+                operator: In
+                values: ["amd64"]
+              - key: "eks.amazonaws.com/instance-category"
+                operator: In
+                values: ["c", "m", "r"]
+              - key: "eks.amazonaws.com/instance-generation"
+                operator: Gt
+                values: ["5"]
+              - key: "eks.amazonaws.com/instance-size"
+                operator: In
+                values: ["xlarge", "2xlarge", "4xlarge", "8xlarge"]
+            terminationGracePeriod: 48h
+    - name: system-peeks
+      spec:
+        # Prefer this tuned system pool over the built-in system (weight 0) for
+        # critical add-ons that tolerate the CriticalAddonsOnly taint. Adjust to taste.
+        weight: 100
+        disruption:
+          consolidationPolicy: WhenEmptyOrUnderutilized
+          consolidateAfter: 5m
+          budgets:
+            - nodes: "0"
+            - nodes: "30%"
+              schedule: "0 20 * * *"
+              duration: 2h
+        template:
+          metadata:
+            labels:
+              node-type: system
+              managed-by: peeks
+          spec:
+            nodeClassRef:
+              group: eks.amazonaws.com
+              kind: NodeClass
+              name: default
+            requirements:
+              - key: "karpenter.sh/capacity-type"
+                operator: In
+                values: ["on-demand"]
+              - key: "kubernetes.io/arch"
+                operator: In
+                values: ["amd64"]
+              - key: "eks.amazonaws.com/instance-category"
+                operator: In
+                values: ["c", "m", "r"]
+              - key: "eks.amazonaws.com/instance-generation"
+                operator: Gt
+                values: ["5"]
+              - key: "eks.amazonaws.com/instance-size"
+                operator: In
+                values: ["xlarge", "2xlarge"]
+            taints:
+              - key: CriticalAddonsOnly
+                effect: NoSchedule
+            terminationGracePeriod: 48h


### PR DESCRIPTION
## Summary

By default system and general-purpose node pools are used. With ability to overlay and pass your own. Workshop folder passes system-peeks and such now. 

Decouples the workshop-specific Karpenter NodePools from the generic solution. Platform addons hardcoded `karpenter.sh/nodepool: system-peeks` / `general-purpose-peeks` — workshop-tuned pools (daytime `nodes: "0"` disruption budget + 48h grace) created only when the workshop enabled them. A consumer without those pools (e.g. Open Agentic Platform) left Keycloak/Postgres and other addons **stuck `Pending`** on a non-existent pool.

The generic solution now targets the **EKS Auto Mode built-in `system`/`general-purpose` pools** (always present; per AWS they can be enabled/disabled but not modified), with an **arbitrary, overridable nodepool knob**. Workshop-specific pools + pinning live entirely under `workshop/`.

> Note: the `9090f7c3` merge of `feature/agent-platform` is already in the base, so the net change here is only the nodepool decoupling.

## Changes

**Generic solution → built-in default (`system`/`general-purpose`)**
- Our charts (keycloak, backstage, gitlab): `nodeSelector` is now `{{ (.Values.global | default dict).systemNodepool | default "system" }}` — a nil-safe, arbitrary-valued knob (unset → built-in `system`).
- Config addons (cert-manager, crossplane, argo-events/rollouts/workflows, external-secrets, efs, aws-efs-csi-driver, kubevela, image-prepuller): literal `system-peeks`→`system`, `general-purpose-peeks`→`general-purpose`.
- `platform-manifests-bootstrap`: `custom-nodepools.yaml` now renders from a caller-supplied `customNodepools.pools` list (default **none** → generic creates no custom pools). GPU/Trainium pools stay (a real capability with no built-in equivalent). Removed the forced `customNodepools.enabled` from the registry entry.

**Workshop (private case) under `workshop/overlay/`**
- `platform-manifests/values.yaml` defines `system-peeks`/`general-purpose-peeks` (daytime do-not-disrupt budget, nightly consolidation window, 48h grace, instance-size floor) each with `weight: 100` so unpinned pods prefer them over the built-ins.
- `keycloak`/`backstage`/`gitlab` overlays set `global.systemNodepool: system-peeks`.
- Seeded to the fleet-config `$overlay` by the workshop Taskfile; built-ins stay enabled (they provide the `default` NodeClass the tuned pools reference).

## How consumers use it
- **Default (OAP / any consumer):** no config — addons ride the built-in `system`/`general-purpose` pools.
- **Custom pools:** supply `customNodepools.pools` in your overlay + set `global.systemNodepool` (and per-addon `nodeSelector` for config addons); use `weight` to prefer them.

## Verification
- **Live-validated on `peeks-hub`**: the previously `Pending` `keycloak-1`/`postgresql-0` (waiting on non-existent `system-peeks`) now run on the built-in `system` pool after the StatefulSet picked up `nodeSelector: system`.
