### PR TITLE
feat: enable Managed KRO + ACK capabilities on the hub

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -115,6 +115,32 @@
               "default": "ON_DEMAND"
             }
           }
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Managed EKS Capabilities (KRO / ACK) for the hub, created via provider-aws-eks Capability MRs in the platform-cluster Composition.",
+          "properties": {
+            "kro": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable the Managed KRO capability (serves ResourceGraphDefinitions)."
+                }
+              }
+            },
+            "ack": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable the Managed ACK capability (GA AWS service controllers: iam/s3/…)."
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/config.yaml
+++ b/config.yaml
@@ -27,17 +27,16 @@ hub:
   #   maxSize: 5
   #   diskSize: 50
   #   capacityType: "ON_DEMAND"
-  # Optional: Managed EKS Capabilities (KRO / ACK) for this cluster. AWS-managed
-  # platform controllers created via provider-aws-eks Capability MRs (already wired
-  # in the platform-cluster Composition; default disabled). Enable KRO to serve
-  # ResourceGraphDefinitions and ACK to manage GA AWS resources (iam/s3/…) as
-  # Kubernetes CRs. Consumed e.g. by Flow D (Lambda MicroVM Agent Sandbox)
-  # downstream — see docs/EKS-Capabilities-KRO-ACK-Setup.md.
-  # capabilities:
-  #   kro:
-  #     enabled: true
-  #   ack:
-  #     enabled: true
+  # Managed EKS Capabilities (KRO / ACK) for this cluster. AWS-managed platform
+  # controllers created via provider-aws-eks Capability MRs (wired in the
+  # platform-cluster Composition). KRO serves ResourceGraphDefinitions; ACK manages
+  # GA AWS resources (iam/s3/…) as Kubernetes CRs. Enabled on the hub by default;
+  # set enabled: false (or omit) to opt out. See docs/EKS-Capabilities-KRO-ACK-Setup.md.
+  capabilities:
+    kro:
+      enabled: true
+    ack:
+      enabled: true
 
 # AWS configuration
 aws:

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,17 @@ hub:
   #   maxSize: 5
   #   diskSize: 50
   #   capacityType: "ON_DEMAND"
+  # Optional: Managed EKS Capabilities (KRO / ACK) for this cluster. AWS-managed
+  # platform controllers created via provider-aws-eks Capability MRs (already wired
+  # in the platform-cluster Composition; default disabled). Enable KRO to serve
+  # ResourceGraphDefinitions and ACK to manage GA AWS resources (iam/s3/…) as
+  # Kubernetes CRs. Consumed e.g. by Flow D (Lambda MicroVM Agent Sandbox)
+  # downstream — see docs/EKS-Capabilities-KRO-ACK-Setup.md.
+  # capabilities:
+  #   kro:
+  #     enabled: true
+  #   ack:
+  #     enabled: true
 
 # AWS configuration
 aws:

--- a/docs/EKS-Capabilities-KRO-ACK-Setup.md
+++ b/docs/EKS-Capabilities-KRO-ACK-Setup.md
@@ -24,7 +24,8 @@ cluster — AWS handles installing, patching, and scaling them. Three types exis
 
 ## Enable KRO + ACK
 
-Set the capability flags on the cluster in your platform config. For the hub:
+The capability flags are set on the cluster in your platform config. **This platform now
+enables KRO + ACK on the hub by default** (`config.yaml` hub block):
 
 ```yaml
 # config.yaml  (hub cluster block)
@@ -44,37 +45,21 @@ This flows into the `PlatformCluster` claim
 `spec.capabilities`), which un-gates the KRO/ACK `Capability` MRs in the Composition.
 `hub:seed` waits for the `Capability` MRs to become `Ready`.
 
-### What ACK provides (and what it does *not*)
+> To **disable** a capability on a cluster, set its `enabled: false` (or omit the block —
+> the XRD default is `false`). Spokes do not get KRO/ACK unless their per-cluster entry
+> opts in.
+
+### What Managed ACK provides
 
 Managed ACK bundles the ACK service controllers whose upstream service is **Generally
-Available** — this includes `iam`, `s3`, `rds`, `dynamodb`, `lambda`, `eks`, and
-[50+ others](https://aws-controllers-k8s.github.io/community/docs/community/services/).
+Available** — `iam`, `s3`, `rds`, `dynamodb`, `lambda`, `eks`, and many more — so those
+AWS resources can be managed as Kubernetes custom resources without operating the
+controllers yourself.
 
-> **Pre-GA controllers are NOT in Managed ACK.** A controller must be GA upstream to be
-> bundled. Newer, `v1alpha1` controllers (for example the **Lambda MicroVM** controller,
-> `lambdamicrovms.services.k8s.aws`) are **not** included and must be **self-managed**
-> (installed as their own Helm chart / GitOps addon) until they graduate. Managed ACK and
-> a self-managed controller **coexist** cleanly because they reconcile different CRD
-> groups — there is no conflict as long as two controllers never own the same service.
-
-## Consumer: Flow D — Lambda MicroVM Agent Sandbox (downstream repo)
-
-The first consumer of Managed KRO + Managed ACK on this platform is **Flow D** in the
-**`sample-open-agentic-platform`** repo (where the Dark Factory / Agent Sandbox lives).
-Flow D adds a second Agent-Sandbox substrate — an **AWS Lambda MicroVM** — using:
-
-- **Managed KRO** — a single `MicrovmSandbox` `ResourceGraphDefinition` that composes all
-  the primitives behind one CRD.
-- **Managed ACK** — the **GA** `iam` (Role) + `s3` (Bucket) controllers the MicroVM image
-  and instance depend on.
-- **Self-managed ACK** — the **pre-GA** `lambdamicrovms` controller (`MicrovmImage` +
-  `Microvm`), installed as its own addon in that repo because Managed ACK can't bundle it
-  yet. When it goes GA, the self-managed addon is removed and Managed ACK adopts it — the
-  RGD is unchanged.
-
-So this repo owns the **platform capabilities** (Managed KRO + Managed ACK); the downstream
-repo owns the **pre-GA controller + the RGD + the sandbox shim**. See that repo's
-`docs/dark-factory/README.md` §4.5 (Flow D).
+> **Scope note:** non-GA ACK controllers are not part of the managed set. A consumer that
+> needs one installs it as its own GitOps addon (self-managed); it coexists with Managed
+> ACK because they reconcile different CRD groups. That is a **consumer** concern,
+> documented by whichever workload needs it — not by this capability-enablement guide.
 
 ## Verification
 
@@ -106,11 +91,8 @@ kubectl get crd | grep -E "kro\.run|services\.k8s\.aws"
 ### ACK custom resource not reconciling
 - Confirm the ACK capability is `ACTIVE` and the specific service controller (e.g. `s3`)
   is part of the managed set (GA services only).
-- For a **pre-GA** service (e.g. `lambdamicrovms`), it will *never* appear under Managed
-  ACK — it must be self-managed downstream (see Flow D above).
 
 ## References
 
 - [EKS ACK Capability](https://docs.aws.amazon.com/eks/latest/userguide/ack.html)
-- [ACK community services (GA list)](https://aws-controllers-k8s.github.io/community/docs/community/services/)
 - [EKS Capabilities ArgoCD Setup](./EKS-Capabilities-ArgoCD-Setup.md)

--- a/docs/EKS-Capabilities-KRO-ACK-Setup.md
+++ b/docs/EKS-Capabilities-KRO-ACK-Setup.md
@@ -1,0 +1,116 @@
+# EKS Capabilities: Managed KRO + Managed ACK Setup
+
+This document describes how to enable the **Managed KRO** and **Managed ACK** EKS
+Capabilities on this platform, alongside the existing **Managed ArgoCD** capability
+(see [`EKS-Capabilities-ArgoCD-Setup.md`](./EKS-Capabilities-ArgoCD-Setup.md)).
+
+## Overview
+
+**EKS Capabilities** are AWS-managed platform controllers that run *outside* the
+cluster — AWS handles installing, patching, and scaling them. Three types exist:
+
+| Type | What it provides |
+|---|---|
+| `ARGOCD` | Managed Argo CD for GitOps (already enabled on the hub) |
+| `KRO` | Kube Resource Orchestrator — serves `ResourceGraphDefinition`s that compose many resources behind one custom CRD |
+| `ACK` | AWS Controllers for Kubernetes — manage AWS resources (IAM, S3, RDS, …) as Kubernetes custom resources |
+
+> **This platform already wires all three declaratively.** The `platform-cluster`
+> Crossplane Composition contains `Capability` managed resources (provider-aws-eks
+> v2.6.1) for `KRO`, `ACK`, and `ARGOCD`, each gated by
+> `spec.capabilities.<type>.enabled` via a `function-cel-filter` step, plus the IAM
+> roles they assume (`capabilities.eks.amazonaws.com` trust). Enabling a capability is
+> therefore a **config toggle**, not new infrastructure.
+
+## Enable KRO + ACK
+
+Set the capability flags on the cluster in your platform config. For the hub:
+
+```yaml
+# config.yaml  (hub cluster block)
+hub:
+  clusterName: "<unique-cluster-name>"
+  # ...
+  capabilities:
+    kro:
+      enabled: true
+    ack:
+      enabled: true
+    # argocd is enabled separately (needs IDC config — see the ArgoCD capability doc)
+```
+
+This flows into the `PlatformCluster` claim
+(`gitops/abstractions/crossplane/platform-cluster/templates/claim.yaml` →
+`spec.capabilities`), which un-gates the KRO/ACK `Capability` MRs in the Composition.
+`hub:seed` waits for the `Capability` MRs to become `Ready`.
+
+### What ACK provides (and what it does *not*)
+
+Managed ACK bundles the ACK service controllers whose upstream service is **Generally
+Available** — this includes `iam`, `s3`, `rds`, `dynamodb`, `lambda`, `eks`, and
+[50+ others](https://aws-controllers-k8s.github.io/community/docs/community/services/).
+
+> **Pre-GA controllers are NOT in Managed ACK.** A controller must be GA upstream to be
+> bundled. Newer, `v1alpha1` controllers (for example the **Lambda MicroVM** controller,
+> `lambdamicrovms.services.k8s.aws`) are **not** included and must be **self-managed**
+> (installed as their own Helm chart / GitOps addon) until they graduate. Managed ACK and
+> a self-managed controller **coexist** cleanly because they reconcile different CRD
+> groups — there is no conflict as long as two controllers never own the same service.
+
+## Consumer: Flow D — Lambda MicroVM Agent Sandbox (downstream repo)
+
+The first consumer of Managed KRO + Managed ACK on this platform is **Flow D** in the
+**`sample-open-agentic-platform`** repo (where the Dark Factory / Agent Sandbox lives).
+Flow D adds a second Agent-Sandbox substrate — an **AWS Lambda MicroVM** — using:
+
+- **Managed KRO** — a single `MicrovmSandbox` `ResourceGraphDefinition` that composes all
+  the primitives behind one CRD.
+- **Managed ACK** — the **GA** `iam` (Role) + `s3` (Bucket) controllers the MicroVM image
+  and instance depend on.
+- **Self-managed ACK** — the **pre-GA** `lambdamicrovms` controller (`MicrovmImage` +
+  `Microvm`), installed as its own addon in that repo because Managed ACK can't bundle it
+  yet. When it goes GA, the self-managed addon is removed and Managed ACK adopts it — the
+  RGD is unchanged.
+
+So this repo owns the **platform capabilities** (Managed KRO + Managed ACK); the downstream
+repo owns the **pre-GA controller + the RGD + the sandbox shim**. See that repo's
+`docs/dark-factory/README.md` §4.5 (Flow D).
+
+## Verification
+
+1. Confirm the Capability MRs are Ready:
+```bash
+kubectl get capability.eks.aws.upbound.io -A
+```
+
+2. Confirm the capabilities exist at the AWS level:
+```bash
+aws eks list-capabilities --cluster-name <cluster-name> --region <region>
+# expect type ARGOCD (existing) + KRO + ACK once enabled
+```
+
+3. Confirm the KRO + ACK CRDs are served on the cluster:
+```bash
+kubectl get crd | grep -E "kro\.run|services\.k8s\.aws"
+# kro.run/ResourceGraphDefinition + the enabled ACK service groups (iam/s3/…)
+```
+
+## Troubleshooting
+
+### Capability MR stuck (not Ready)
+- Check the capability IAM role trust is `capabilities.eks.amazonaws.com` and the role
+  ARN selector matches (`matchLabels.capability: kro|ack`).
+- `aws eks describe-capability --cluster-name <c> --capability-name kro|ack` for the
+  AWS-side status/health.
+
+### ACK custom resource not reconciling
+- Confirm the ACK capability is `ACTIVE` and the specific service controller (e.g. `s3`)
+  is part of the managed set (GA services only).
+- For a **pre-GA** service (e.g. `lambdamicrovms`), it will *never* appear under Managed
+  ACK — it must be self-managed downstream (see Flow D above).
+
+## References
+
+- [EKS ACK Capability](https://docs.aws.amazon.com/eks/latest/userguide/ack.html)
+- [ACK community services (GA list)](https://aws-controllers-k8s.github.io/community/docs/community/services/)
+- [EKS Capabilities ArgoCD Setup](./EKS-Capabilities-ArgoCD-Setup.md)


### PR DESCRIPTION
## Enable Managed KRO + Managed ACK capabilities on the hub

Enables the **Managed KRO** and **Managed ACK** EKS Capabilities on the hub, alongside the existing **Managed ArgoCD** capability.

### Context
The `Capability` MRs for KRO / ACK / ARGOCD already exist in the `platform-cluster` Crossplane Composition (provider-aws-eks v2.6.1), gated by `spec.capabilities.<type>.enabled` via `function-cel-filter`, with their IAM roles. This PR **turns KRO + ACK on** for the hub and documents/validates the toggle.

### Changes
- **`config.yaml`** — hub `capabilities: { kro.enabled: true, ack.enabled: true }` (enabled by default; spokes stay opt-in via the XRD default `false`).
- **`config.schema.json`** — adds the `hub.capabilities` schema (kro/ack `enabled` booleans).
- **`docs/EKS-Capabilities-KRO-ACK-Setup.md`** (new) — how to enable/verify/troubleshoot the KRO+ACK capabilities; mirrors the ArgoCD capability doc. **Generic** — no consumer specifics.

### Scope
This PR is **purely capability enablement**. Consumer-specific details (which non-GA controllers a workload self-manages, the ACK GA services list, Flow D / Lambda MicroVM) live with the **consumer** in `sample-open-agentic-platform` (the Flow D PR), not here.

- **KRO** → serves `ResourceGraphDefinition`s.
- **ACK** → manages **GA** AWS resources (iam/s3/rds/…) as Kubernetes CRs. Non-GA controllers are a consumer's self-managed concern.

### Verification
- `config.schema.json` + `config.yaml` parse; the new `hub.capabilities` block validates (the only schema-validation miss is the pre-existing `<prefix>` template placeholder, unrelated).
- Capabilities remain default-disabled on spokes; hub un-gates the KRO/ACK Capability MRs → `kubectl get capability.eks.aws.upbound.io -A` should reach Ready after sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
