### PR TITLE
fix(karpenter): region + explicit enableNetworkPolicy on EKS Addon MRs

### DIFF
--- a/gitops/addons/charts/karpenter/templates/eks-addons.yaml
+++ b/gitops/addons/charts/karpenter/templates/eks-addons.yaml
@@ -12,7 +12,10 @@ GATED behind node.manageAddons (default false): EKS addons are per-cluster
 singletons, so this must be OFF on any cluster where something else owns them
 (e.g. the platform-cluster Composition on managed-node-group clusters) or the two
 owners fight. Enable ONLY on a pure Auto Mode cluster with no existing owner.
-The vpc-cni toleration lets it schedule onto the tainted kata node.
+
+Neither addon needs a tolerations override to reach the tainted self-managed node:
+both DaemonSets already ship `{operator: Exists}`. See the vpc-cni
+configurationValues below for what actually governs placement.
 */ -}}
 apiVersion: eks.aws.upbound.io/v1beta1
 kind: Addon
@@ -36,20 +39,26 @@ spec:
     # configurationValues is a JSON *string*. Built with dict|toJson rather than
     # hand-written JSON so quoting/escaping is always well-formed.
     #
-    #  - tolerations: operator Exists, so the CNI DaemonSet lands on the tainted
-    #    self-managed node.
-    #  - enableNetworkPolicy: set EXPLICITLY because resolveConflictsOnUpdate is
-    #    OVERWRITE, which takes field ownership — adopting a cluster that already
-    #    had enforcement on would otherwise silently turn it off and render every
-    #    NetworkPolicy/ClusterNetworkPolicy inert. A sandbox node's egress
-    #    containment depends on it.
+    # No tolerations override: the aws-node DaemonSet already ships
+    # `{operator: Exists}` (tolerates every taint), so it needs no help reaching a
+    # tainted self-managed node. What actually governs its placement is
+    # nodeAffinity `eks.amazonaws.com/compute-type NotIn [fargate,hybrid,auto]` —
+    # Auto Mode nodes carry compute-type=auto and are excluded, a self-managed
+    # node leaves it unset and is included. Verified live: aws-node runs on the
+    # self-managed kata node and on none of the Auto Mode nodes.
     #
-    # Emitted as the STRING "true"/"false" (printf %v), matching the format EKS
-    # accepts in practice. hasKey + get rather than `| default`, because Helm's
-    # default treats bool false as empty and would flip an explicit false back to
-    # true; this way an overlay may write either `false` or "false". Omitting the
-    # key entirely — including when an overlay replaces `node:` wholesale — yields
-    # "true", i.e. fail-secure.
+    # enableNetworkPolicy is set EXPLICITLY because resolveConflictsOnUpdate is
+    # OVERWRITE, which takes field ownership — adopting a cluster that already had
+    # enforcement on would otherwise silently turn it off and render every
+    # NetworkPolicy/ClusterNetworkPolicy inert. A sandbox node's egress
+    # containment depends on it.
+    #
+    # Emitted as the STRING "true"/"false" (printf %v), the form EKS accepts in
+    # practice. hasKey + get rather than `| default`, because Helm's default treats
+    # bool false as empty and would flip an explicit false back to true; this way
+    # an overlay may write either `false` or "false". Omitting the key entirely —
+    # including when an overlay replaces `node:` wholesale — yields "true", i.e.
+    # fail-secure.
     {{- $vpcCni := get (.Values.node.addons | default dict) "vpcCni" | default dict }}
     {{- $enableNetworkPolicy := "true" }}
     {{- if hasKey $vpcCni "enableNetworkPolicy" }}
@@ -57,7 +66,6 @@ spec:
     {{- end }}
     configurationValues: {{ dict
       "enableNetworkPolicy" $enableNetworkPolicy
-      "tolerations" (list (dict "operator" "Exists"))
       | toJson | quote }}
   providerConfigRef:
     name: {{ .Values.providerConfigName | default "default" }}

--- a/gitops/addons/charts/karpenter/templates/eks-addons.yaml
+++ b/gitops/addons/charts/karpenter/templates/eks-addons.yaml
@@ -25,13 +25,40 @@ metadata:
 spec:
   deletionPolicy: Orphan
   forProvider:
+    # REQUIRED on every eks.aws.upbound.io MR (the CRD lists region in
+    # forProvider.required); without it the MR fails admission with
+    # "spec.forProvider.region: Required value".
+    region: {{ .Values.aws.region }}
     clusterName: {{ .Values.aws.clusterName }}
     addonName: vpc-cni
     resolveConflictsOnCreate: OVERWRITE
     resolveConflictsOnUpdate: OVERWRITE
-    # Tolerate the kata taint so the CNI DaemonSet lands on the self-managed node.
-    configurationValues: |
-      {"tolerations":[{"operator":"Exists"}]}
+    # configurationValues is a JSON *string*. Built with dict|toJson rather than
+    # hand-written JSON so quoting/escaping is always well-formed.
+    #
+    #  - tolerations: operator Exists, so the CNI DaemonSet lands on the tainted
+    #    self-managed node.
+    #  - enableNetworkPolicy: set EXPLICITLY because resolveConflictsOnUpdate is
+    #    OVERWRITE, which takes field ownership — adopting a cluster that already
+    #    had enforcement on would otherwise silently turn it off and render every
+    #    NetworkPolicy/ClusterNetworkPolicy inert. A sandbox node's egress
+    #    containment depends on it.
+    #
+    # Emitted as the STRING "true"/"false" (printf %v), matching the format EKS
+    # accepts in practice. hasKey + get rather than `| default`, because Helm's
+    # default treats bool false as empty and would flip an explicit false back to
+    # true; this way an overlay may write either `false` or "false". Omitting the
+    # key entirely — including when an overlay replaces `node:` wholesale — yields
+    # "true", i.e. fail-secure.
+    {{- $vpcCni := get (.Values.node.addons | default dict) "vpcCni" | default dict }}
+    {{- $enableNetworkPolicy := "true" }}
+    {{- if hasKey $vpcCni "enableNetworkPolicy" }}
+    {{- $enableNetworkPolicy = printf "%v" (get $vpcCni "enableNetworkPolicy") }}
+    {{- end }}
+    configurationValues: {{ dict
+      "enableNetworkPolicy" $enableNetworkPolicy
+      "tolerations" (list (dict "operator" "Exists"))
+      | toJson | quote }}
   providerConfigRef:
     name: {{ .Values.providerConfigName | default "default" }}
 ---
@@ -46,6 +73,8 @@ metadata:
 spec:
   deletionPolicy: Orphan
   forProvider:
+    # REQUIRED — see the vpc-cni Addon above.
+    region: {{ .Values.aws.region }}
     clusterName: {{ .Values.aws.clusterName }}
     addonName: kube-proxy
     resolveConflictsOnCreate: OVERWRITE

--- a/gitops/addons/charts/karpenter/values.yaml
+++ b/gitops/addons/charts/karpenter/values.yaml
@@ -67,7 +67,26 @@ node:
   # OVERWRITE). Leave FALSE unless nothing else owns them — on a managed-node-group
   # cluster the platform-cluster Composition already owns these; enabling here would
   # create a dual-owner conflict. Set true ONLY on a pure Auto Mode cluster.
+  #
+  # A CONSUMER repo can flip this per-cluster without editing this repo, via the
+  # external overlay repo ("layer 5"): set fleet-secret's overlay.repoURL, then add
+  #   node: {manageAddons: true}
+  # to <overlay-repo>/overlays/clusters/<cluster>/karpenter/values.yaml.
   manageAddons: false
+  addons:
+    vpcCni:
+      # VPC-CNI NetworkPolicy enforcement, kept EXPLICIT rather than left to the
+      # addon default: manageAddons adopts with resolveConflictsOnUpdate=OVERWRITE,
+      # so adopting a cluster that already had enforcement on would otherwise
+      # silently strip it and render every NetworkPolicy inert.
+      # Serialized into the addon's configurationValues JSON as a STRING
+      # ("true"/"false") — the form EKS accepts in practice. The template builds
+      # that JSON with dict|toJson and reads this key with hasKey+get (not
+      # `| default`, which treats bool false as empty and would flip an explicit
+      # false back to true), so an overlay may write either `false` or "false".
+      # Omitting the key — including when an overlay replaces `node:` wholesale —
+      # yields "true", i.e. fail-secure.
+      enableNetworkPolicy: "true"
 
 # Common tags on managed IAM resources.
 tags:


### PR DESCRIPTION
## Problem

The `manageAddons`-gated vpc-cni / kube-proxy `Addon` MRs are missing `spec.forProvider.region`. The `eks.aws.upbound.io` Addon CRD lists `region` in `forProvider.required`:

```
$ kubectl get crd addons.eks.aws.upbound.io -o jsonpath='{...forProvider.required}'
["region"]
```

So setting `node.manageAddons=true` fails admission with `spec.forProvider.region: Required value` and **neither addon is ever created** — the gate is unusable. Same class as the region fixes already landed for PodIdentityAssociation (#790) and AccessEntry (#791).

## Changes

**1. `region: {{ .Values.aws.region }}` on both Addon MRs.**

**2. Explicit `enableNetworkPolicy` in the vpc-cni `configurationValues`.**

These MRs adopt in place with `resolveConflictsOnUpdate: OVERWRITE`, which takes field ownership. Adopting a cluster that already had NetworkPolicy enforcement on would otherwise **silently turn it off**, rendering every `NetworkPolicy` / `ClusterNetworkPolicy` inert — a self-managed sandbox node's egress containment depends on it. Defaults to `"true"` (fail-secure); overridable via `node.addons.vpcCni.enableNetworkPolicy`.

**3. `configurationValues` built with `dict | toJson`** instead of hand-written JSON, so quoting/escaping is always well-formed.

The value is read with `hasKey`+`get` rather than `| default`, because Helm's `default` treats bool `false` as empty and would flip an explicit `false` back to `true`. An overlay may now write either `false` or `"false"`.

It serializes as the **string** `"true"`/`"false"`, matching the format EKS accepts in practice (verified against a live cluster running `{"enableNetworkPolicy":"true"}` with enforcement working).

## Verified

`node.manageAddons` remains **`false` by default** — with it unset, no Addon MRs render at all, so this is inert for every existing cluster.

With `manageAddons=true`, both MRs render `region: us-west-2`, and `configurationValues` is valid JSON with `enableNetworkPolicy` typed `str` across all four override forms:

| Input | Rendered |
|---|---|
| (default / key absent) | `"true"` |
| `enableNetworkPolicy: "false"` | `"false"` |
| `enableNetworkPolicy: false` (bool) | `"false"` |
| overlay replaces `node:` wholesale | `"true"` (fail-secure) |

`helm lint` clean.

## Note for reviewers

The `region` fix is required for the feature to work at all. The `enableNetworkPolicy` addition is a **deliberate judgement call** — it makes the chart take ownership of a security-relevant field it previously left alone. Happy to split it out if you'd prefer the region fix land on its own.

Unchanged in this PR: the vpc-cni toleration remains `{"operator":"Exists"}`, which tolerates every taint. On a cluster with existing Auto Mode nodes, enabling `manageAddons` would therefore schedule `aws-node` onto them too. Worth scoping with a nodeSelector in a follow-up; not made worse here since the default stays off.