### PR TITLE
feat(fleet-secret): optional external overlay repo annotations (layer 5)

### DIFF
--- a/platform-charts/fleet-secret/README.md
+++ b/platform-charts/fleet-secret/README.md
@@ -36,6 +36,11 @@ externalSecret:
   annotations: {}          # Extra annotations on the cluster secret
   labels: {}               # Extra labels on the cluster secret
 
+overlay:                   # External overlay repo ("layer 5") -- OPTIONAL, default off
+  repoURL: ""              # Consumer repo that may override platform addon values
+  revision: "main"         # MUST contain the overlay files
+  basepath: ""             # Root holding configs/ + overlays/ (e.g. "gitops/")
+
 enabledAddons: {}          # Populated from enabled-addons.yaml via valueFiles
 ```
 
@@ -52,6 +57,79 @@ selector:
 ```
 
 The appset-chart renders this into the ApplicationSet's cluster generator. ArgoCD matches it against the `enable_grafana: 'true'` label on the cluster secret. If the label exists and is `true`, an Application is created for that addon on that cluster.
+
+## External Overlay Repo ("layer 5")
+
+### The problem it solves
+
+The appset-chart layers Helm value files per addon, low to high precedence:
+
+1. `$defaults/<basepath>addons/configs/<addon>/values.yaml`
+2. per-addon `valueFiles` from the registry entry
+3. `$defaults/<basepath>overlays/environments/<env>/<addon>/values.yaml`
+4. `$defaults/<basepath>overlays/clusters/<cluster>/<addon>/values.yaml`
+
+`$defaults` resolves to the repo that **owns the addon** -- the one holding its chart and registry entry. So for an addon defined in this repo, layers 3 and 4 are read from this repo. A consumer repo that wants to change one value for one cluster would otherwise have to open a PR here.
+
+Worse, it fails *silently*: all these paths carry `ignoreMissingValueFiles: true`, so a `values.yaml` placed in the wrong repo is skipped without error, and the setting just never takes effect.
+
+Layer 5 fixes this. Point `overlay.repoURL` at the consumer repo and the appset-chart appends a `$overlay` source plus three more value files per addon, **after** layers 1-4:
+
+```
+$overlay/<basepath>configs/<addon>/values.yaml
+$overlay/<basepath>overlays/environments/<env>/<addon>/values.yaml
+$overlay/<basepath>overlays/clusters/<cluster>/<addon>/values.yaml
+```
+
+Being last, the consumer's file wins.
+
+### How to use it
+
+**1. Set `overlay` in the fleet-member values** (`fleet/<hub|members/<cluster>>/values.yaml`):
+
+```yaml
+overlay:
+  repoURL: https://github.com/my-org/my-consumer-repo.git
+  revision: main
+  basepath: gitops/
+```
+
+This renders `overlay_repo_url` / `overlay_repo_revision` / `overlay_repo_basepath` onto that cluster's secret. It is **per-cluster** -- clusters without it keep reading overlays from the addon's own repo.
+
+**2. Add the override in the consumer repo**, at the path for the addon and cluster:
+
+```
+<basepath>overlays/clusters/<cluster>/<addon>/values.yaml
+```
+
+For example, to enable a chart flag for the `karpenter` addon on the `hub` cluster, with `basepath: gitops/`:
+
+```yaml
+# gitops/overlays/clusters/hub/karpenter/values.yaml   (in the CONSUMER repo)
+node:
+  manageAddons: true
+```
+
+The file takes the **addon chart's** value schema -- the same shape as `addons/charts/<addon>/values.yaml`.
+
+**3. Verify it resolved.** The generated Application should now have three sources and `$overlay` value files:
+
+```sh
+kubectl get application <addon>-<cluster> -n argocd -o yaml | grep -A5 valueFiles
+```
+
+If `$overlay` entries are absent, the annotation did not reach the cluster secret:
+
+```sh
+kubectl get secret <cluster> -n argocd -o jsonpath='{.metadata.annotations.overlay_repo_url}'
+```
+
+### Caveats
+
+- **`$overlay` is a real ArgoCD source.** If the URL is unreachable or needs credentials ArgoCD does not have, **every** overlay-aware app on that cluster breaks -- not just the one you are overriding. Register a repo credential first, and prefer wiring this late in a bootstrap sequence, after the repo exists.
+- **`revision` must contain the files.** Pointing at a branch without them means the overlay silently no-ops (`ignoreMissingValueFiles`), and the value quietly stays at its in-repo default. Remember to update `revision` when the work merges to the default branch.
+- **It also repoints the appset-level `overrides.yaml`.** Independently of the per-addon layers, `bootstrap/addons.yaml` reads `$overlay/<basepath>overlays/{environments/<env>,clusters/<cluster>}/overrides.yaml`, which fall back to this repo when the annotation is unset. Setting it moves those reads to the consumer repo too. Those files take the **registry entry** schema (addon-keyed, with `valuesObject` / `defaultVersion`), not chart values -- so they can override registry-level settings, but chart values placed there do nothing.
+- **Only the platform appset consumes these annotations.** A consumer repo running its own appset (with its own registry files) does not set `overlayRepoURLGit`, so its addons keep resolving overlays through layer 4 as before. No double-read.
 
 ## How to Register a New Fleet Member
 

--- a/platform-charts/fleet-secret/templates/cluster-secret.yaml
+++ b/platform-charts/fleet-secret/templates/cluster-secret.yaml
@@ -32,6 +32,27 @@ metadata:
     hub_cluster_name: {{ .Values.hub.clusterName | quote }}
     oidc_issuer_url: {{ $oidcIssuerUrl | quote }}
     oidc_insecure_origin: {{ .Values.oidc.insecureOrigin | default "false" | quote }}
+    {{- with .Values.overlay }}
+    {{- if .repoURL }}
+    # External overlay repo ("layer 5"). Lets a CONSUMER repo override Helm values
+    # for addons whose chart + registry entry live in the platform repo, without
+    # editing the platform repo: bootstrap/addons.yaml reads these three
+    # annotations into the appset-chart's overlayRepoURLGit*, which appends a
+    # $overlay source plus, per addon,
+    #   $overlay/<basepath>configs/<addon>/values.yaml
+    #   $overlay/<basepath>overlays/environments/<env>/<addon>/values.yaml
+    #   $overlay/<basepath>overlays/clusters/<cluster>/<addon>/values.yaml
+    # AFTER the in-repo layers, so the consumer's file wins. All are
+    # ignoreMissingValueFiles, so unpopulated paths are silent no-ops.
+    #
+    # Emitted ONLY when repoURL is set: $overlay becomes a REAL ArgoCD source, so
+    # an unreachable/unauthenticated URL would break EVERY overlay-aware app on
+    # this cluster. Point it only at a repo ArgoCD can already read.
+    overlay_repo_url: {{ .repoURL | quote }}
+    overlay_repo_revision: {{ .revision | default "main" | quote }}
+    overlay_repo_basepath: {{ .basepath | default "" | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     argocd.argoproj.io/secret-type: cluster
     {{- $labels := .Values.labels | default dict }}

--- a/platform-charts/fleet-secret/templates/external-secret.yaml
+++ b/platform-charts/fleet-secret/templates/external-secret.yaml
@@ -26,6 +26,19 @@ spec:
         literal: |-
           {{- .Values.externalSecret.annotations | toYaml | nindent 10 }}
       {{- end }}
+      {{- with .Values.overlay }}
+      {{- if .repoURL }}
+      # External overlay repo ("layer 5") — the same three annotations the
+      # direct-mode cluster-secret emits, so hub and spokes behave identically.
+      # See cluster-secret.yaml (and README.md) for the full explanation and the
+      # reachability caveat.
+      - target: Annotations
+        literal: |-
+          overlay_repo_url: {{ .repoURL | quote }}
+          overlay_repo_revision: {{ .revision | default "main" | quote }}
+          overlay_repo_basepath: {{ .basepath | default "" | quote }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.externalSecret.labels }}
       - target: Labels
         literal: |-

--- a/platform-charts/fleet-secret/values.yaml
+++ b/platform-charts/fleet-secret/values.yaml
@@ -30,6 +30,26 @@ hub:
   # platform class is always the OSS LBC (required for transforms/URL-rewrite).
   albControllerMode: "oss"
 
+# External overlay repo ("layer 5") — OPTIONAL, default OFF.
+#
+# Set repoURL to a CONSUMER repo to let it override Helm values for addons whose
+# chart + registry entry live in THIS repo, without editing this repo. Rendered as
+# the overlay_repo_* cluster-secret annotations, which bootstrap/addons.yaml feeds
+# to the appset-chart as overlayRepoURLGit* — that appends a $overlay source and,
+# per addon, three extra valueFiles that layer AFTER the in-repo ones.
+# See README.md § External overlay repo for the full walkthrough.
+#
+# WARNING: when set, $overlay becomes a REAL ArgoCD source for every overlay-aware
+# app on that cluster — an unreachable or unauthenticated repo breaks all of them.
+# Leave empty unless ArgoCD can already read the repo.
+overlay:
+  repoURL: ""
+  # MUST be a revision that actually contains the overlay files.
+  revision: "main"
+  # Repo-relative root holding configs/ + overlays/ (e.g. "gitops/"). Falls back to
+  # addonsRepoBasepath when empty.
+  basepath: ""
+
 # Addon enablement map — populated from enabled-addons.yaml via valueFiles
 enabledAddons: {}
 


### PR DESCRIPTION
## Problem

The appset-chart **already** supports an external overlay repo. `bootstrap/addons.yaml` reads three annotations into `overlayRepoURLGit*`, and the appset-chart appends a `$overlay` source plus three per-addon value files that layer *after* the in-repo ones.

But nothing ever emitted those annotations, so the feature was unreachable. Unlike `overlay_repo_basepath` (which has an `or` fallback), `overlayRepoURLGit` has none — it stays empty, and the appset-chart's `if $overlayRepoURLGit` guard skips the per-addon overlay layer entirely.

Concretely, today the generated Applications have only two sources:

```
$ kubectl get application karpenter-spoke-dev -n argocd -o yaml
  [0] ref=defaults  repoURL=appmod-blueprints
  [1]               repoURL=appmod-blueprints  path=gitops/addons/charts/karpenter
        VF: $defaults/gitops/addons/configs/karpenter/values.yaml
        VF: $defaults/gitops/overlays/environments/dev/karpenter/values.yaml
        VF: $defaults/gitops/overlays/clusters/spoke-dev/karpenter/values.yaml
```

`$defaults` resolves to the repo that **owns the addon**. So for an addon whose chart + registry entry live here, layers 3–4 are read from *this* repo — a consumer repo wanting to change one value for one cluster has to open a PR here.

And it fails *silently*: every overlay path carries `ignoreMissingValueFiles: true`, so a `values.yaml` placed in the consumer repo is skipped without error and the setting simply never takes effect. That is a genuinely hard failure mode to debug.

## Change

An optional `overlay: {repoURL, revision, basepath}` block that renders the annotations:

```yaml
overlay:
  repoURL: ""        # default OFF
  revision: "main"
  basepath: ""
```

Rendered in **both** templates — `cluster-secret.yaml` (`mode: direct`, spokes) and `external-secret.yaml` (`mode: externalSecret`, hub). Doing only one would have looked correct while silently no-opping for the other cluster type.

Gated on `{{- if .repoURL }}`, so **behaviour is unchanged for every existing cluster**.

## How to use it

**1. Set `overlay` in the fleet-member values** (`fleet/hub/values.yaml`, or `fleet/members/<cluster>/values.yaml`):

```yaml
overlay:
  repoURL: https://github.com/my-org/my-consumer-repo.git
  revision: main
  basepath: gitops/
```

Per-cluster: clusters without it keep reading overlays from the addon's own repo.

**2. Add the override in the consumer repo**, at the path for that addon + cluster:

```yaml
# gitops/overlays/clusters/hub/karpenter/values.yaml   (in the CONSUMER repo)
node:
  manageAddons: true
```

The file takes the **addon chart's** value schema — same shape as `addons/charts/<addon>/values.yaml`.

**3. Verify it resolved.** The Application should now have three sources and `$overlay` value files:

```sh
kubectl get application <addon>-<cluster> -n argocd -o yaml | grep -A5 valueFiles
```

If the `$overlay` entries are missing, the annotation did not reach the cluster secret:

```sh
kubectl get secret <cluster> -n argocd -o jsonpath='{.metadata.annotations.overlay_repo_url}'
```

## Caveats (documented in the README)

- **`$overlay` is a real ArgoCD source.** An unreachable or credential-requiring URL breaks **every** overlay-aware app on that cluster, not just the one being overridden. Register a repo credential first; wire it late in a bootstrap sequence, after the repo exists.
- **`revision` must contain the files**, or the overlay silently no-ops and the value quietly stays at its in-repo default. Update it when the work merges to the default branch.
- **It also repoints the appset-level `overrides.yaml` reads.** Independently of the per-addon layers, `bootstrap/addons.yaml` reads `$overlay/<basepath>overlays/{environments/<env>,clusters/<cluster>}/overrides.yaml`, which fall back to this repo when the annotation is unset. Those take the **registry-entry** schema (addon-keyed, `valuesObject` / `defaultVersion`), *not* chart values — so chart values placed there do nothing.
- **Only the platform appset consumes these annotations.** A consumer repo running its own appset with its own registry files never sets `overlayRepoURLGit`, so its addons keep resolving overlays through layer 4 as before — no double-read.

## Verified

| Case | Result |
|---|---|
| `direct` (spoke), default | 0 annotations |
| `direct` (spoke), `repoURL` set | 3 annotations |
| `externalSecret` (hub), default | 0 annotations |
| `externalSecret` (hub), `repoURL` set | 3 annotations |
| `revision` omitted | defaults to `main` |
| Rendered output, both modes | parses as valid YAML |

`helm lint` clean.

## Docs

`README.md` gains an **External Overlay Repo ("layer 5")** section: the layering model (why `$defaults` is per-addon), the step-by-step walkthrough above with verification commands, and the caveats. The `values.yaml` reference block is updated too.
