### PR TITLE
feat: codify KRO + ACK capability IAM roles for the hub

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -435,6 +435,13 @@ tasks:
           {{.MNG_SETS}}
           | kubectl apply -f -
       - sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g" claims/argocd-capability-role.yaml | kubectl apply -f -
+      # KRO + ACK capability roles (mirror the ArgoCD one). The platform-cluster
+      # Composition creates the KRO/ACK Capability MRs when spec.capabilities.<type>.enabled
+      # is true; these roles must exist first (the Capability MR references them by the
+      # <cluster>-KROCapabilityRole / <cluster>-ACKCapabilityRole external-name). The ACK
+      # role carries a least-privilege inline policy for Flow D's GA resources (iam + s3).
+      - sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g" claims/kro-capability-role.yaml | kubectl apply -f -
+      - sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g" claims/ack-capability-role.yaml | kubectl apply -f -
       # Wait for ArgoCD capability role to be ready, then patch the composite so the access entry gets its principalArn
       - cmd: |
           kubectl -n crossplane-system wait --for=condition=Ready roles.iam.aws.upbound.io/argocd-capability-role --timeout=120s 2>/dev/null || true
@@ -1478,6 +1485,9 @@ tasks:
       - cmd: |
           sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g" claims/argocd-capability-role.yaml | kubectl delete --ignore-not-found --wait=false -f - 2>/dev/null || true
           kubectl -n crossplane-system wait --for=delete roles.iam.aws.upbound.io/argocd-capability-role --timeout=120s 2>/dev/null || true
+          sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g" claims/kro-capability-role.yaml | kubectl delete --ignore-not-found --wait=false -f - 2>/dev/null || true
+          sed "s|CLUSTER_NAME|{{.HUB_CLUSTER_NAME}}|g" claims/ack-capability-role.yaml | kubectl delete --ignore-not-found --wait=false -f - 2>/dev/null || true
+          kubectl -n crossplane-system wait --for=delete roles.iam.aws.upbound.io/kro-capability-role roles.iam.aws.upbound.io/ack-capability-role --timeout=120s 2>/dev/null || true
         ignore_error: true
       # Belt-and-suspenders: if the Job-based delete failed (e.g. parser error,
       # config drift), call the AWS API directly so the cluster delete in Phase 4

--- a/cluster-providers/kind-crossplane/claims/ack-capability-role.yaml
+++ b/cluster-providers/kind-crossplane/claims/ack-capability-role.yaml
@@ -1,0 +1,90 @@
+# IAM Role for the EKS ACK Capability
+# Mirrors argocd-capability-role.yaml. Created by Crossplane before the ACK
+# capability is created. The ACK controllers assume this role to manage AWS
+# resources; the inline RolePolicy below grants the LEAST-PRIVILEGE set the
+# Flow D (Lambda MicroVM Agent Sandbox) MicrovmSandbox RGD needs — IAM roles
+# for the MicroVM build/exec identities and the S3 code-artifact bucket only.
+# Broaden this policy if other ACK consumers are added on the hub.
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  name: ack-capability-role
+  namespace: crossplane-system
+  labels:
+    capability: ack
+  annotations:
+    crossplane.io/external-name: CLUSTER_NAME-ACKCapabilityRole
+spec:
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "capabilities.eks.amazonaws.com"
+            },
+            "Action": [
+              "sts:AssumeRole",
+              "sts:TagSession"
+            ]
+          }
+        ]
+      }
+    tags:
+      managed-by: crossplane
+      purpose: eks-ack-capability
+---
+# Least-privilege permissions for Flow D's GA ACK resources (iam + s3), scoped by
+# resource-name pattern. Attached to the ACK capability role above.
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: RolePolicy
+metadata:
+  name: ack-capability-flow-d-microvm
+  namespace: crossplane-system
+spec:
+  forProvider:
+    roleSelector:
+      matchControllerRef: false
+      matchLabels:
+        capability: ack
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "S3MicrovmArtifacts",
+            "Effect": "Allow",
+            "Action": [
+              "s3:CreateBucket", "s3:DeleteBucket",
+              "s3:PutBucketTagging", "s3:GetBucketTagging",
+              "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy",
+              "s3:PutEncryptionConfiguration", "s3:GetEncryptionConfiguration",
+              "s3:PutBucketVersioning", "s3:GetBucketVersioning",
+              "s3:PutBucketPublicAccessBlock", "s3:GetBucketPublicAccessBlock",
+              "s3:GetBucketLocation", "s3:ListBucket", "s3:ListAllMyBuckets",
+              "s3:PutObject", "s3:GetObject", "s3:DeleteObject"
+            ],
+            "Resource": [
+              "arn:aws:s3:::*-microvm-artifacts",
+              "arn:aws:s3:::*-microvm-artifacts/*"
+            ]
+          },
+          {
+            "Sid": "IAMMicrovmRoles",
+            "Effect": "Allow",
+            "Action": [
+              "iam:CreateRole", "iam:DeleteRole", "iam:GetRole",
+              "iam:TagRole", "iam:UntagRole", "iam:ListRoleTags",
+              "iam:PutRolePolicy", "iam:DeleteRolePolicy", "iam:GetRolePolicy", "iam:ListRolePolicies",
+              "iam:AttachRolePolicy", "iam:DetachRolePolicy", "iam:ListAttachedRolePolicies",
+              "iam:UpdateAssumeRolePolicy", "iam:PassRole"
+            ],
+            "Resource": [
+              "arn:aws:iam::*:role/*-microvm-build",
+              "arn:aws:iam::*:role/*-microvm-exec"
+            ]
+          }
+        ]
+      }

--- a/cluster-providers/kind-crossplane/claims/kro-capability-role.yaml
+++ b/cluster-providers/kind-crossplane/claims/kro-capability-role.yaml
@@ -1,0 +1,33 @@
+# IAM Role for the EKS KRO Capability
+# Mirrors argocd-capability-role.yaml. Created by Crossplane before the KRO
+# capability is created. KRO orchestrates in-cluster Kubernetes resources
+# (ResourceGraphDefinitions); the underlying AWS calls are made by the ACK
+# controllers, so this role needs only the capability trust — no AWS permissions.
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  name: kro-capability-role
+  namespace: crossplane-system
+  annotations:
+    crossplane.io/external-name: CLUSTER_NAME-KROCapabilityRole
+spec:
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "capabilities.eks.amazonaws.com"
+            },
+            "Action": [
+              "sts:AssumeRole",
+              "sts:TagSession"
+            ]
+          }
+        ]
+      }
+    tags:
+      managed-by: crossplane
+      purpose: eks-kro-capability


### PR DESCRIPTION
## Codify KRO + ACK capability IAM roles for the hub

Follow-up to #796 (which enabled the `capabilities.kro/ack` toggle). Adds the **IAM capability roles** those capabilities need, mirroring the existing `argocd-capability-role.yaml`, so a hub bootstrap creates them **declaratively** instead of by hand.

### Why
The platform-cluster Composition creates the KRO/ACK `Capability` MRs when `spec.capabilities.<type>.enabled` is true, but each Capability references an IAM role by external-name (`<cluster>-KROCapabilityRole` / `<cluster>-ACKCapabilityRole`). Those role manifests didn't exist (only ArgoCD's did) — so the roles would have been drift.

### Changes
- **`claims/kro-capability-role.yaml`** — Crossplane IAM `Role` MR, `capabilities.eks.amazonaws.com` trust only (KRO orchestrates in-cluster resources; the ACK controllers make the AWS calls, so KRO needs no AWS perms).
- **`claims/ack-capability-role.yaml`** — IAM `Role` MR + a **least-privilege inline `RolePolicy`** scoped to Flow D's GA resources: `iam` (roles matching `*-microvm-build`/`*-microvm-exec`) + `s3` (buckets matching `*-microvm-artifacts`). No broad managed policies.
- **`kind-crossplane/Taskfile.yaml`** — apply both roles after the ArgoCD role in `hub:seed`, and delete them in teardown (mirrors the ArgoCD wiring).

### Applied to the live hub
These MRs were applied to the running hub (its bootstrap KIND cluster is gone, so the composition couldn't retro-create them) and reconciled **Ready** — adopting the roles via external-name. KRO + ACK capabilities are now **ACTIVE** on the hub (`kubectl get crd | grep -E 'kro.run|services.k8s.aws'` shows `resourcegraphdefinitions.kro.run` + `iam`/`s3` groups). This PR makes that reproducible for future hub builds.

### Consumer
These capabilities back **Flow D — Lambda MicroVM Agent Sandbox** in `sample-open-agentic-platform` (PR #41).

Generated with Claude Code.
