### PR TITLE
fix(kargo): use single-line annotation to avoid YAML parse error

### DIFF
--- a/gitops/addons/registry/gitops.yaml
+++ b/gitops/addons/registry/gitops.yaml
@@ -100,8 +100,7 @@ kargo:
           alb.ingress.kubernetes.io/ssl-redirect: '443'
           # ALB URL rewrite: strip /kargo prefix before forwarding to the API server
           # (Kargo API serves at root; basePath is cosmetic for URL generation only)
-          alb.ingress.kubernetes.io/transforms.kargo-rewrite: |
-            [{"type":"url-rewrite","urlRewriteConfig":{"rewrites":[{"regex":"^\\/kargo\\/?(.*)$","replace":"/$1"}]}}]
+          alb.ingress.kubernetes.io/transforms.kargo-rewrite: '[{"type":"url-rewrite","urlRewriteConfig":{"rewrites":[{"regex":"^/kargo/?(.*)$","replace":"/$1"}]}}]'
         pathType: Prefix
       argocd:
         urls:


### PR DESCRIPTION
The multi-line pipe literal with escaped backslashes in the ALB transforms annotation was being mangled through the ApplicationSet Go template → Helm values pipeline, causing a YAML parse error in the Kargo chart template rendering. Switch to a single-line quoted string with unescaped regex.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
