### PR TITLE
fix(kargo): fix argocd.urls format (map not list) and restore URL rew…

### DIFF
--- a/gitops/addons/registry/gitops.yaml
+++ b/gitops/addons/registry/gitops.yaml
@@ -104,7 +104,7 @@ kargo:
         pathType: Prefix
       argocd:
         urls:
-          - https://{{.metadata.annotations.ingress_domain_name}}/argocd
+          argocd: https://{{.metadata.annotations.ingress_domain_name}}/argocd
       oidc:
         # Kargo SSO via Keycloak (public client 'kargo' is seeded in the platform
         # realm by the keycloak-config job; PKCE flow, no client secret required).


### PR DESCRIPTION
…rite

Root cause: argocd.urls changed from a list to a map in Kargo 1.11.0. The chart renders urls as key=value pairs in the configmap and a list caused Go fmt to emit invalid YAML.

Verified with helm template --version 1.11.0 (199 resources, clean).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
