### PR TITLE
fix(kargo): update redirect URI and admin group claim for basePath /k…

### DIFF
--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -291,10 +291,10 @@ data:
         "oidc.ciba.grant.enabled": false
       },
       "alwaysDisplayInConsole": false,
-      "rootUrl": "https://${DOMAIN_NAME}",
+      "rootUrl": "https://${DOMAIN_NAME}/kargo",
       "baseUrl": "",
       "redirectUris": [
-        "https://${DOMAIN_NAME}/login",
+        "https://${DOMAIN_NAME}/kargo/login",
         "https://localhost/auth/callback"
       ],
       "webOrigins": [

--- a/gitops/addons/registry/gitops.yaml
+++ b/gitops/addons/registry/gitops.yaml
@@ -124,7 +124,7 @@ kargo:
         admins:
           claims:
             groups:
-              - /admin
+              - admin
       secret:
         name: kargo-admin-credentials
     extraObjects:


### PR DESCRIPTION
…argo

1. Keycloak kargo client: update redirectUris from /login to /kargo/login (Kargo 1.11.0 with basePath sends redirect_uri with the prefix)

2. OIDC admins claim: change /admin to admin (without leading slash) The Keycloak groups mapper has full.path=false, so group names in the token are 'admin' not '/admin'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
