### PR TITLE
fix(observability): Bump aws-for-fluent-bit to 3.4.13 for CVE-2026-16118

### DIFF
--- a/gitops/addons/registry/observability.yaml
+++ b/gitops/addons/registry/observability.yaml
@@ -267,7 +267,7 @@ aws-for-fluentbit:
       # Track the latest aws-for-fluent-bit 3.x image (AL2023, fluent-bit v5.x).
       # Bump as new patch/minor releases ship with CVE fixes:
       # https://github.com/aws/aws-for-fluent-bit/releases
-      tag: 3.4.11
+      tag: 3.4.13
 
 cni-metrics-helper:
   namespace: kube-system


### PR DESCRIPTION
Upgrade from 3.4.11 to 3.4.13 to resolve:
- CVE-2026-16118 (glib2, High severity)
- CVE-2026-11979 (libxml2, Medium severity)

New base image: AL2023 2023.12.20260803.3

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
