### PR TITLE
fix: make platform region-agnostic (ClusterSecretStore + AppmodService ingress)

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
@@ -29,7 +29,10 @@ spec:
           sortKey: string | default="sort_key"
           sortKeyType: string | default="S"
       ingress:
-        host: string | default="*.elb.us-west-2.amazonaws.com"
+        # host is reserved for optional future host-based routing. Routing is
+        # path-based, so this value is intentionally NOT applied to the Ingress
+        # rule, which keeps the RGD region-agnostic (no hardcoded region).
+        host: string | default=""
         enabled: boolean | default=false
         path: string | default="/"
         rewrite: boolean | default=true
@@ -614,8 +617,10 @@ spec:
         spec:
           ingressClassName: nginx
           rules:
-            - host: ${schema.spec.ingress.host}
-              http:
+            # Region-agnostic: no host pinning. Routing is path-based on the shared
+            # ingress-nginx load balancer, so the app is reachable via any hostname
+            # (the NLB DNS in any region, CloudFront, or a custom domain).
+            - http:
                 paths:
                   - path: "${schema.spec.ingress.path + \"(/|$)(.*)\"}"
                     pathType: ImplementationSpecific
@@ -647,8 +652,10 @@ spec:
         spec:
           ingressClassName: nginx
           rules:
-            - host: ${schema.spec.ingress.host}
-              http:
+            # Region-agnostic: no host pinning. Routing is path-based on the shared
+            # ingress-nginx load balancer, so the app is reachable via any hostname
+            # (the NLB DNS in any region, CloudFront, or a custom domain).
+            - http:
                 paths:
                   - path: "${schema.spec.ingress.path + \"(/|$)(.*)\"}"
                     pathType: ImplementationSpecific

--- a/gitops/addons/charts/platform-manifests-bootstrap/templates/cluster-secret-store.yaml
+++ b/gitops/addons/charts/platform-manifests-bootstrap/templates/cluster-secret-store.yaml
@@ -1,7 +1,18 @@
-{{- $region := "us-west-2" }}
-{{- if .Values.aws }}
-{{- $region = .Values.aws.region | default "us-west-2" }}
+{{- /*
+  Resolve the AWS region from the actual deployment region.
+  The addons ApplicationSet propagates the cluster's region (annotation aws_region)
+  under .Values.global.aws_region. Fall back to .Values.aws.region for backward
+  compatibility. Do NOT silently default to a fixed region: a wrong region here makes
+  External Secrets query Secrets Manager in the wrong region, which fails with
+  AccessDenied (the IAM policy is scoped to the deployment region). Fail loudly instead.
+*/}}
+{{- $region := "" }}
+{{- if and .Values.global .Values.global.aws_region }}
+{{-   $region = .Values.global.aws_region }}
+{{- else if and .Values.aws .Values.aws.region }}
+{{-   $region = .Values.aws.region }}
 {{- end }}
+{{- $region = required "platform-manifests-bootstrap: AWS region is required. Set global.aws_region (propagated from the cluster annotation aws_region)." $region }}
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:


### PR DESCRIPTION
## Summary

Make the platform deployable in **any AWS region**. Two GitOps manifests hardcoded `us-west-2`, so a non‑us‑west‑2 deployment (e.g. eu-central-1) left the platform broken:

1. **External Secrets never synced** → Backstage, Keycloak, Grafana, Kargo, JupyterHub, Spark all stuck (no secrets → pods never created).
2. **Deployed apps were unreachable** via ingress in other regions.

## Root causes & fixes

### 1. `platform-manifests-bootstrap` ClusterSecretStore region
The ClusterSecretStore read `.Values.aws.region` with a hardcoded `us-west-2` default, but the addons ApplicationSet only propagates the region under `global.aws_region`. So the stores silently targeted `us-west-2`. External Secrets then called Secrets Manager in `us-west-2`, which failed with `secretsmanager:GetSecretValue AccessDenied` because the ESO IAM policy is scoped to the actual deployment region.

**Fix:** read the region from `global.aws_region` (with `.Values.aws.region` backward‑compat) and `required` it — fail loudly instead of silently defaulting to a fixed region.

### 2. `AppmodService` RGD ingress host
The Ingress rule host defaulted to the region‑specific wildcard `*.elb.us-west-2.amazonaws.com`. No AppmodService instance sets `ingress.host`, so every app fell back to this default and was only reachable via the us‑west‑2 NLB DNS.

**Fix:** routing is path‑based (`/rust-app`, `/java-app`, `/unicorn`) behind the shared ingress‑nginx LB, so host pinning is unnecessary. Drop the host from both Ingress rules (match any host) and neutralize the schema default. Apps are now reachable via any hostname in any region.

## Testing
- `helm template` on `platform-manifests-bootstrap`: renders `region: <deploy-region>` from `global.aws_region`, honors `aws.region` for backward‑compat, and fails with a clear message when no region is set.
- `AppmodService` RGD validated with `yq`.

## Impact
No behavior change for us‑west‑2 deployments; unblocks all other regions.
