### PR TITLE
fix: scope S3Bucket IAMRoleSelector to instance-specific Bucket resource

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
@@ -75,6 +75,10 @@ spec:
             - group: iam.services.k8s.aws
               kind: ""
               version: ""
+          # Scope to only ACK resources owned by this Kro instance (bug #813).
+          resourceLabelSelector:
+            matchLabels:
+              kro.run/instance-name: ${schema.metadata.name}
     - id: eksroleselector
       includeWhen:
         - ${schema.spec.components.dynamodb.enabled == true}
@@ -94,6 +98,9 @@ spec:
             - group: eks.services.k8s.aws
               kind: ""
               version: ""
+          resourceLabelSelector:
+            matchLabels:
+              kro.run/instance-name: ${schema.metadata.name}
     - id: dynamodbroleselector
       includeWhen:
         - ${schema.spec.components.dynamodb.enabled == true}
@@ -113,6 +120,9 @@ spec:
             - group: dynamodb.services.k8s.aws
               kind: ""
               version: ""
+          resourceLabelSelector:
+            matchLabels:
+              kro.run/instance-name: ${schema.metadata.name}
     - id: dynamodbtable
       includeWhen:
         - ${schema.spec.components.dynamodb.enabled == true}

--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -44,7 +44,9 @@ spec:
        apiVersion: services.k8s.aws/v1alpha1
        kind: IAMRoleSelector
        metadata:
-          name: ${schema.metadata.namespace}-iam
+          # Include instance name to avoid name collision when multiple CICDPipeline
+          # instances exist in the same namespace (bug #813).
+          name: ${schema.metadata.namespace}-${schema.metadata.name}-iam
        spec:
           arn: arn:aws:iam::${schema.spec.aws.accountId}:role/peeks-cluster-mgmt-iam
           namespaceSelector:
@@ -54,13 +56,17 @@ spec:
              - group: iam.services.k8s.aws
                kind: ""
                version: ""
+          # Scope to only the ACK resources owned by this Kro instance.
+          resourceLabelSelector:
+             matchLabels:
+                kro.run/instance-name: ${schema.metadata.name}
 
     - id: iamroleselectorEcr
       template:
        apiVersion: services.k8s.aws/v1alpha1
        kind: IAMRoleSelector
        metadata:
-          name: ${schema.metadata.namespace}-ecr
+          name: ${schema.metadata.namespace}-${schema.metadata.name}-ecr
        spec:
           arn: arn:aws:iam::${schema.spec.aws.accountId}:role/peeks-cluster-mgmt-ecr
           namespaceSelector:
@@ -70,13 +76,16 @@ spec:
              - group: ecr.services.k8s.aws
                kind: ""
                version: ""
+          resourceLabelSelector:
+             matchLabels:
+                kro.run/instance-name: ${schema.metadata.name}
 
     - id: iamroleselectorEks
       template:
        apiVersion: services.k8s.aws/v1alpha1
        kind: IAMRoleSelector
        metadata:
-          name: ${schema.metadata.namespace}-eks
+          name: ${schema.metadata.namespace}-${schema.metadata.name}-eks
        spec:
           arn: arn:aws:iam::${schema.spec.aws.accountId}:role/peeks-cluster-mgmt-eks
           namespaceSelector:
@@ -86,6 +95,9 @@ spec:
              - group: eks.services.k8s.aws
                kind: ""
                version: ""
+          resourceLabelSelector:
+             matchLabels:
+                kro.run/instance-name: ${schema.metadata.name}
 
     # ECR Repository for main application images
     - id: ecrmainrepo

--- a/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
@@ -28,8 +28,14 @@ spec:
             - ${schema.metadata.namespace}
         resourceTypeSelector:
           - group: s3.services.k8s.aws
-            kind: ""
-            version: ""
+            kind: Bucket
+            version: v1alpha1
+        # Scope this selector to only the Bucket owned by this Kro instance.
+        # Without this, every S3Bucket instance creates a namespace-wide selector,
+        # causing ACK to enter an infinite read loop on any second instance (bug #813).
+        resourceLabelSelector:
+          matchLabels:
+            kro.run/instance-name: ${schema.metadata.name}
   - id: s3bucket
     readyWhen:
       - ${s3bucket.status.conditions[0].status == "True"}

--- a/solutions/module1/rg-dynamodb-gen.yaml
+++ b/solutions/module1/rg-dynamodb-gen.yaml
@@ -30,8 +30,14 @@ spec:
             - ${schema.metadata.namespace}
         resourceTypeSelector:
           - group: dynamodb.services.k8s.aws
-            kind: ""
-            version: ""
+            kind: Table
+            version: v1alpha1
+        # Scope this selector to only the Table owned by this Kro instance.
+        # Without this, every DynamoDBTable instance creates a namespace-wide selector,
+        # causing ACK to enter an infinite read loop on any second instance (bug #813).
+        resourceLabelSelector:
+          matchLabels:
+            kro.run/instance-name: ${schema.metadata.name}
   - id: dynamodbtable
     readyWhen:
       - ${dynamodbtable.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}


### PR DESCRIPTION
## Problem

Closes #813

When multiple `S3Bucket` Kro instances are deployed in the same namespace, each creates an `IAMRoleSelector` with identical scope — targeting **all** `s3.services.k8s.aws` resources in that namespace. This causes a conflict: the ACK S3 controller resolves the first (oldest) selector for every Bucket, and any subsequent Bucket enters an infinite read loop — polling the resource every ~10s indefinitely without ever calling `CreateBucket` in AWS.

**Observed impact on a live cluster:**
- 2nd `S3Bucket` instance stuck `IN_PROGRESS` for 45+ hours
- 16,642 `GET` calls from the ACK capability role, zero `PATCH`/`UPDATE` writes
- Zero `CreateBucket` events in CloudTrail
- ACK `Bucket` resource had empty `status: {}` throughout

## Fix

Add `resourceTypeSelector` (`kind: Bucket`, `version: v1alpha1`) and `resourceLabelSelector` matching `kro.run/instance-name` to scope each `IAMRoleSelector` exclusively to the Bucket resource owned by its Kro instance:

```yaml
# Before
resourceTypeSelector:
  - group: s3.services.k8s.aws
    kind: ""
    version: ""

# After
resourceTypeSelector:
  - group: s3.services.k8s.aws
    kind: Bucket
    version: v1alpha1
resourceLabelSelector:
  matchLabels:
    kro.run/instance-name: ${schema.metadata.name}
```

Kro automatically labels all child resources with `kro.run/instance-name`, and `resourceLabelSelector` is a supported field on the `IAMRoleSelector` CRD (`services.k8s.aws/v1alpha1`).

## Testing

Verified on a live EKS cluster (EKS Capabilities: ACK v46.137.1-eks-1, Kro v0.9.2-eks-3):

1. Applied the fix — Kro immediately reconciled both existing `IAMRoleSelector` resources with the new scoped spec
2. Touched the stuck `Bucket` resource to trigger ACK re-evaluation (needed once for pre-existing stuck instances; new instances work automatically)
3. ACK selected the correct scoped selector, assumed the IAM role, and created the S3 bucket within 30 seconds
4. Kro instance transitioned from `IN_PROGRESS` → `ACTIVE`; ArgoCD app from `Progressing` → `Healthy`

## Workaround for existing stuck instances

After deploying this fix, any pre-existing stuck `Bucket` resources need a one-time annotation touch to trigger ACK re-evaluation:

```bash
kubectl annotate bucket.s3.services.k8s.aws <bucket-name> \
  "services.k8s.aws/force-reconcile=$(date +%s)" --overwrite
```
