### PR TITLE
fix(iam): allow cluster-mgmt-eks to PassRole any pod-identity app role

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -586,7 +586,9 @@ tasks:
           "Version": "2012-10-17",
           "Statement": [
             {"Effect": "Allow", "Action": ["eks:*"], "Resource": "*"},
-            {"Effect": "Allow", "Action": ["iam:PassRole","iam:GetRole","iam:ListRoleTags"], "Resource": ["arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/{{.RESOURCE_PREFIX}}-*","arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*-microservice-*"]}
+            {"Effect": "Allow", "Action": ["iam:PassRole","iam:GetRole","iam:ListRoleTags"], "Resource": ["arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/{{.RESOURCE_PREFIX}}-*","arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*-microservice-*"]},
+            {"Effect": "Allow", "Action": ["iam:GetRole","iam:ListRoleTags"], "Resource": "arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*"},
+            {"Effect": "Allow", "Action": "iam:PassRole", "Resource": "arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*", "Condition": {"StringEquals": {"iam:PassedToService": "pods.eks.amazonaws.com"}}}
           ]
         }'
         # Allow ACK capability role to assume cluster-mgmt roles

--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -1757,7 +1757,9 @@ tasks:
           "Version": "2012-10-17",
           "Statement": [
             {"Effect": "Allow", "Action": ["eks:*"], "Resource": "*"},
-            {"Effect": "Allow", "Action": ["iam:PassRole","iam:GetRole"], "Resource": ["arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/{{.RESOURCE_PREFIX}}-*","arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*-microservice-*"]}
+            {"Effect": "Allow", "Action": ["iam:PassRole","iam:GetRole"], "Resource": ["arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/{{.RESOURCE_PREFIX}}-*","arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*-microservice-*"]},
+            {"Effect": "Allow", "Action": ["iam:GetRole","iam:ListRoleTags"], "Resource": "arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*"},
+            {"Effect": "Allow", "Action": "iam:PassRole", "Resource": "arn:aws:iam::{{.AWS_ACCOUNT_ID}}:role/*", "Condition": {"StringEquals": {"iam:PassedToService": "pods.eks.amazonaws.com"}}}
           ]
         }'
         # Allow ACK capability role to assume cluster-mgmt roles


### PR DESCRIPTION
## Problem
Deploying an app with DynamoDB / Pod Identity fails:
```
AccessDeniedException: peeks-cluster-mgmt-eks is not authorized to perform: iam:PassRole on rust-app-role
```
The AppmodService stays `IN_PROGRESS` and no pods are created.

## Root cause
The `eks-access-management` inline policy on `${RESOURCE_PREFIX}-cluster-mgmt-eks` only allowed `iam:PassRole` on `role/${PREFIX}-*` and `role/*-microservice-*`. App pod roles created across the two abstractions use different names:
- **kro** RGDs (`appmod-service`, `cicd-pipeline`) → PodIdentityAssociation roles
- **kubevela** components (`dp-service-account.yaml`) → `<name>-iam-role`
- observed in test: `rust-app-role`, `java-app-role`

None match the two allowed patterns → PassRole denied.

## Fix
All these are **EKS Pod Identity** roles (passed to `pods.eks.amazonaws.com`). Instead of enumerating fragile name patterns, add a `PassRole` statement scoped to `role/*` gated by `Condition: iam:PassedToService = pods.eks.amazonaws.com`. This covers every app role for **both kro and kubevela**, current and future, while staying safe (the role can only be assigned to EKS pod identities).

- Keep the existing `role/${PREFIX}-*` + `role/*-microservice-*` PassRole (no condition) for eks/nodegroup role passes.
- Add read-only `iam:GetRole` / `iam:ListRoleTags` on `role/*`.
- Applied to **both** `cluster-providers/kind-kro-ack` and `cluster-providers/kind-crossplane` (the two providers that define this policy; this workshop uses `kind-kro-ack`).

## Validation
- Taskfile YAML parses (`yq`).
- The `eks-access-management` policy document is valid JSON (4 statements) with the new conditioned PassRole.