### PR TITLE
chore: add CODEOWNERS with core contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code owners for aws-samples/appmod-blueprints
+#
+# Every path is owned by the core contributors listed below. Combined with branch
+# protection on `main` set to require 1 approving review AND code owner review, a
+# single approval from any one of these people is enough to merge.
+#
+# Two constraints to keep in mind:
+#   - A code owner must retain write access to this repository, otherwise their
+#     approval does not count toward the requirement.
+#   - A code owner cannot approve their own pull request, so a PR opened by one of
+#     these five needs an approval from one of the other four.
+
+* @shapirov103 @allamand @hmuthusamy @punkwalker @elamaran11


### PR DESCRIPTION
Lists the core contributors as owners of all paths. Paired with a branch protection change on main (required approving reviews 2 -> 1, plus require code owner review), this makes a single approval from any core contributor sufficient to merge.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
