### PR TITLE
fix(kro): scope ACK IAMRoleSelectors to instance-owned resources (#813)

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -51,7 +51,7 @@ spec:
        apiVersion: services.k8s.aws/v1alpha1
        kind: IAMRoleSelector
        metadata:
-          name: ${schema.metadata.namespace}-iam
+          name: ${schema.metadata.namespace}-${schema.metadata.name}-iam
        spec:
           arn: arn:aws:iam::${schema.spec.aws.accountId}:role/peeks-cluster-mgmt-iam
           namespaceSelector:
@@ -70,7 +70,7 @@ spec:
        apiVersion: services.k8s.aws/v1alpha1
        kind: IAMRoleSelector
        metadata:
-          name: ${schema.metadata.namespace}-ecr
+          name: ${schema.metadata.namespace}-${schema.metadata.name}-ecr
        spec:
           arn: arn:aws:iam::${schema.spec.aws.accountId}:role/peeks-cluster-mgmt-ecr
           namespaceSelector:
@@ -89,7 +89,7 @@ spec:
        apiVersion: services.k8s.aws/v1alpha1
        kind: IAMRoleSelector
        metadata:
-          name: ${schema.metadata.namespace}-eks
+          name: ${schema.metadata.namespace}-${schema.metadata.name}-eks
        spec:
           arn: arn:aws:iam::${schema.spec.aws.accountId}:role/peeks-cluster-mgmt-eks
           namespaceSelector:

--- a/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
@@ -28,8 +28,14 @@ spec:
             - ${schema.metadata.namespace}
         resourceTypeSelector:
           - group: s3.services.k8s.aws
-            kind: ""
-            version: ""
+            kind: Bucket
+            version: v1alpha1
+        # Scope this selector to only the Bucket owned by this Kro instance.
+        # Without this, every S3Bucket instance creates a namespace-wide selector,
+        # causing ACK to enter an infinite read loop on any second instance (bug #813).
+        resourceLabelSelector:
+          matchLabels:
+            kro.run/instance-name: ${schema.metadata.name}
   - id: s3bucket
     readyWhen:
       - ${s3bucket.status.conditions[0].status == "True"}

--- a/workshop/solutions/module1/rg-dynamodb-gen.yaml
+++ b/workshop/solutions/module1/rg-dynamodb-gen.yaml
@@ -30,8 +30,14 @@ spec:
             - ${schema.metadata.namespace}
         resourceTypeSelector:
           - group: dynamodb.services.k8s.aws
-            kind: ""
-            version: ""
+            kind: Table
+            version: v1alpha1
+        # Scope this selector to only the Table owned by this Kro instance.
+        # Without this, every DynamoDBTable instance creates a namespace-wide selector,
+        # causing ACK to enter an infinite read loop on any second instance (bug #813).
+        resourceLabelSelector:
+          matchLabels:
+            kro.run/instance-name: ${schema.metadata.name}
   - id: dynamodbtable
     readyWhen:
       - ${dynamodbtable.status.conditions.exists(x, x.type == 'ACK.ResourceSynced' && x.status == "True")}


### PR DESCRIPTION
## Problem

Related to #813 / supersedes the remaining parts of #814.

When multiple `S3Bucket` (or `DynamoDBTable`) Kro instances are deployed in the same namespace, each creates an `IAMRoleSelector` with namespace-wide scope (`kind: ""`), targeting **all** ACK resources of that service in the namespace. The ACK controller resolves the first (oldest) selector for every resource, and any subsequent instance enters an infinite read loop — polling every ~10s without ever calling the create API in AWS.

## Why a new PR instead of rebasing #814

#814 was written against the pre-#529 layout. During the #529 restructure, part of the fix already landed: the `resourceLabelSelector` blocks in `appmod-service.yaml` are already on `main`. The remaining pieces conflicted (moved/rewritten files, and `solutions/module1/rg-dynamodb-gen.yaml` moved to `workshop/solutions/module1/`), so this PR re-applies only what's still missing, against the current layout.

## Changes (only the parts not already in `main`)

- **`rg-s3-bucket.yaml`** — scope the selector to `kind: Bucket` / `version: v1alpha1` and add `resourceLabelSelector` on `kro.run/instance-name`. This is the core fix for the ACK infinite-read-loop (bug #813).
- **`workshop/solutions/module1/rg-dynamodb-gen.yaml`** — same scoping for `kind: Table`.
- **`cicd-pipeline.yaml`** — include the instance name in the three `IAMRoleSelector` names (`namespace-<name>-iam/ecr/eks`) to avoid name collisions across instances in the same namespace. (Their `resourceLabelSelector` already landed via #529.)

## Notes

- Kro automatically labels child resources with `kro.run/instance-name`; `resourceLabelSelector` is a supported field on the `IAMRoleSelector` CRD (`services.k8s.aws/v1alpha1`).
- Original fix in #814 was verified on a live cluster (ACK v46.137.1-eks-1, Kro v0.9.2-eks-3): stuck `Bucket` created within 30s once the scoped selector was applied.

## Existing stuck instances

Pre-existing stuck resources need a one-time reconcile touch:
```bash
kubectl annotate bucket.s3.services.k8s.aws <name> \
  "services.k8s.aws/force-reconcile=$(date +%s)" --overwrite
```
