### PR TITLE
fix(hack): don't share zsh history between parallel terminals

### DIFF
--- a/hack/.p10k.zsh
+++ b/hack/.p10k.zsh
@@ -168,24 +168,24 @@
   fi
 
   # Separator between same-color segments on the left.
-  typeset -g POWERLEVEL9K_LEFT_SUBSEGMENT_SEPARATOR='\u2502'
+  typeset -g POWERLEVEL9K_LEFT_SUBSEGMENT_SEPARATOR='\uE0B1'
   # Separator between same-color segments on the right.
-  typeset -g POWERLEVEL9K_RIGHT_SUBSEGMENT_SEPARATOR='\u2502'
+  typeset -g POWERLEVEL9K_RIGHT_SUBSEGMENT_SEPARATOR='\uE0B3'
   # Separator between different-color segments on the left.
-  typeset -g POWERLEVEL9K_LEFT_SEGMENT_SEPARATOR=''
+  typeset -g POWERLEVEL9K_LEFT_SEGMENT_SEPARATOR='\uE0B0'
   # Separator between different-color segments on the right.
-  typeset -g POWERLEVEL9K_RIGHT_SEGMENT_SEPARATOR=''
+  typeset -g POWERLEVEL9K_RIGHT_SEGMENT_SEPARATOR='\uE0B2'
   # To remove a separator between two segments, add "_joined" to the second segment name.
   # For example: POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(os_icon context_joined)
 
   # The right end of left prompt.
-  typeset -g POWERLEVEL9K_LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL=''
+  typeset -g POWERLEVEL9K_LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL='\uE0B0'
   # The left end of right prompt.
-  typeset -g POWERLEVEL9K_RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL=''
+  typeset -g POWERLEVEL9K_RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL='\uE0B2'
   # The left end of left prompt.
-  typeset -g POWERLEVEL9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL=''
+  typeset -g POWERLEVEL9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL='\uE0B2'
   # The right end of right prompt.
-  typeset -g POWERLEVEL9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL=''
+  typeset -g POWERLEVEL9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL='\uE0B0'
   # Left prompt terminator for lines without any segments.
   typeset -g POWERLEVEL9K_EMPTY_LINE_LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL=
 

--- a/hack/.p10k.zsh
+++ b/hack/.p10k.zsh
@@ -168,24 +168,24 @@
   fi
 
   # Separator between same-color segments on the left.
-  typeset -g POWERLEVEL9K_LEFT_SUBSEGMENT_SEPARATOR='\uE0B1'
+  typeset -g POWERLEVEL9K_LEFT_SUBSEGMENT_SEPARATOR='\u2502'
   # Separator between same-color segments on the right.
-  typeset -g POWERLEVEL9K_RIGHT_SUBSEGMENT_SEPARATOR='\uE0B3'
+  typeset -g POWERLEVEL9K_RIGHT_SUBSEGMENT_SEPARATOR='\u2502'
   # Separator between different-color segments on the left.
-  typeset -g POWERLEVEL9K_LEFT_SEGMENT_SEPARATOR='\uE0B0'
+  typeset -g POWERLEVEL9K_LEFT_SEGMENT_SEPARATOR=''
   # Separator between different-color segments on the right.
-  typeset -g POWERLEVEL9K_RIGHT_SEGMENT_SEPARATOR='\uE0B2'
+  typeset -g POWERLEVEL9K_RIGHT_SEGMENT_SEPARATOR=''
   # To remove a separator between two segments, add "_joined" to the second segment name.
   # For example: POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(os_icon context_joined)
 
   # The right end of left prompt.
-  typeset -g POWERLEVEL9K_LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL='\uE0B0'
+  typeset -g POWERLEVEL9K_LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL=''
   # The left end of right prompt.
-  typeset -g POWERLEVEL9K_RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL='\uE0B2'
+  typeset -g POWERLEVEL9K_RIGHT_PROMPT_FIRST_SEGMENT_START_SYMBOL=''
   # The left end of left prompt.
-  typeset -g POWERLEVEL9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL='\uE0B2'
+  typeset -g POWERLEVEL9K_LEFT_PROMPT_FIRST_SEGMENT_START_SYMBOL=''
   # The right end of right prompt.
-  typeset -g POWERLEVEL9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL='\uE0B0'
+  typeset -g POWERLEVEL9K_RIGHT_PROMPT_LAST_SEGMENT_END_SYMBOL=''
   # Left prompt terminator for lines without any segments.
   typeset -g POWERLEVEL9K_EMPTY_LINE_LEFT_PROMPT_LAST_SEGMENT_END_SYMBOL=
 

--- a/hack/.zshrc
+++ b/hack/.zshrc
@@ -45,9 +45,10 @@ plugins=(
 
 export TERM="xterm-256color"
 
-#I don't want to share history between terminals
-setopt no_share_history
-unsetopt share_history
+# History: don't share live history between parallel terminals.
+# The actual override lives AFTER `source $ZSH/oh-my-zsh.sh` (see below), because
+# oh-my-zsh's lib/history.zsh forces `setopt share_history` and would override
+# anything set here before the source.
 
 
 alias k=kubectl
@@ -57,6 +58,13 @@ alias emacs=emacs-nox
 alias kns=kubens
 alias kctx=kubectx
 source $ZSH/oh-my-zsh.sh
+
+# Disable live history sharing between parallel terminals (override oh-my-zsh's
+# lib/history.zsh which forces share_history). Each session keeps its own live
+# history; commands are appended to HISTFILE but are NOT imported into other
+# already-running sessions.
+unsetopt share_history
+setopt inc_append_history
 
 alias python=python3
 alias pip=pip3


### PR DESCRIPTION
## Change
`hack/.zshrc` set `no_share_history` / `unsetopt share_history` **before** `source $ZSH/oh-my-zsh.sh`. oh-my-zsh's `lib/history.zsh` runs during that source and forces `setopt share_history`, silently overriding the earlier setting — so parallel terminals ended up sharing live history anyway.

Move the history-sharing override to **after** the oh-my-zsh source so it actually takes effect:

- `unsetopt share_history` — each session keeps its own live history (commands from one terminal are not injected into other already-running sessions).
- `setopt inc_append_history` — commands are still appended to `HISTFILE` as they run, so history is persisted across sessions.

A comment is added at the original (pre-source) location pointing to where the real override now lives, to prevent this from being reintroduced.

## Scope
Touches only `hack/.zshrc`. No prompt/theme changes.

> Note: an earlier revision of this PR also changed `hack/.p10k.zsh` separators; that part has been reverted and is no longer included.

## Testing
- Opened multiple parallel terminals in the workshop IDE (Amazon Linux 2023, code-editor-server) and confirmed each session keeps independent live history while `HISTFILE` still accumulates commands across sessions.