### PR TITLE
fix(validation): make backstage-auth.sh zsh-safe (guard bash-only RETURN trap)

### DIFF
--- a/scripts/validation/backstage-auth.sh
+++ b/scripts/validation/backstage-auth.sh
@@ -12,7 +12,13 @@ set -euo pipefail
 backstage_get_token() {
   local COOKIE_JAR
   COOKIE_JAR=$(mktemp)
-  trap "rm -f ${COOKIE_JAR} /tmp/_bs_s2.txt /tmp/_bs_s3.txt /tmp/_bs_s4.txt /tmp/_bs_frame.txt" RETURN
+  # `trap ... RETURN` is bash-only. Under zsh (the workshop IDE's default shell) it
+  # errors with "trap: undefined signal: RETURN" and, with `set -e`, aborts the
+  # function so BS_TOKEN is never set. Register the cleanup only under bash; the temp
+  # files live under /tmp and are harmless if left uncleaned under zsh.
+  if [ -n "${BASH_VERSION:-}" ]; then
+    trap "rm -f ${COOKIE_JAR} /tmp/_bs_s2.txt /tmp/_bs_s3.txt /tmp/_bs_s4.txt /tmp/_bs_frame.txt" RETURN
+  fi
 
   # Step 1: Session cookie
   curl -sLk -c "${COOKIE_JAR}" "${BACKSTAGE_URL}" -o /dev/null


### PR DESCRIPTION
## Problem
`scripts/validation/backstage-auth.sh` registers a cleanup with `trap ... RETURN` (bash-only). When the helper is **sourced in the workshop IDE's default zsh shell**, zsh errors with `trap: undefined signal: RETURN` and — under `set -euo pipefail` — aborts `backstage_get_token`, so `BS_TOKEN` is never set. Automated/workshop validation then has to wrap every call in `bash -lc`.

## Fix
Register the RETURN cleanup trap **only under bash** (`[ -n "${BASH_VERSION:-}" ]`). Under zsh the function now completes and sets `BS_TOKEN`; the temp files live under /tmp and are harmless if left uncleaned. No behavior change under bash.

Validated: `bash -n` clean, and sourcing under zsh no longer raises the RETURN trap error.

## Context
Fixes the secondary finding reported in platform-engineering-on-eks issue #31 (Rust CD non-regression testing).