### PR TITLE
fix(#585): parameterize remaining hardcoded values in addon charts (devlake, ray-system, keycloak)

### DIFF
--- a/gitops/addons/charts/devlake/templates/external-secret.yaml
+++ b/gitops/addons/charts/devlake/templates/external-secret.yaml
@@ -80,13 +80,13 @@ spec:
     match:
       secretKey: EXTERNAL_URL
       remoteRef:
-        remoteKey: peeks-devlake/mysql-connection
+        remoteKey: {{ .Values.resourcePrefix | default "peeks" }}-devlake/mysql-connection
         property: db_url
   - conversionStrategy: None
     match:
       secretKey: MYSQL_ROOT_PASSWORD
       remoteRef:
-        remoteKey: peeks-devlake/mysql-connection
+        remoteKey: {{ .Values.resourcePrefix | default "peeks" }}-devlake/mysql-connection
         property: root_password
 
 

--- a/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
+++ b/gitops/addons/charts/keycloak/templates/keycloak-config.yaml
@@ -817,8 +817,8 @@ spec:
                 keycloak_post "/admin/realms" "/var/config/realm-payload.json" "${REALM_NAME} realm"
               fi
 
-              # Download kubectl
-              curl -sS -LO "https://s3.us-west-2.amazonaws.com/amazon-eks/1.32.0/2024-12-20/bin/linux/amd64/kubectl"
+              # Download kubectl (latest stable, consistent with the rest of the repo)
+              curl -sS -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
               chmod +x kubectl
 
 

--- a/gitops/addons/charts/platform-manifests/templates/ray-system-iamroleselectors.yaml
+++ b/gitops/addons/charts/platform-manifests/templates/ray-system-iamroleselectors.yaml
@@ -9,7 +9,7 @@ metadata:
     services.k8s.aws/adoption-policy: adopt-or-create
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  arn: arn:aws:iam::{{ $accountId }}:role/peeks-cluster-mgmt-iam
+  arn: arn:aws:iam::{{ $accountId }}:role/{{ .Values.global.resourcePrefix | default "peeks" }}-cluster-mgmt-iam
   namespaceSelector:
     names:
       - ray-system
@@ -26,7 +26,7 @@ metadata:
     services.k8s.aws/adoption-policy: adopt-or-create
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  arn: arn:aws:iam::{{ $accountId }}:role/peeks-cluster-mgmt-eks
+  arn: arn:aws:iam::{{ $accountId }}:role/{{ .Values.global.resourcePrefix | default "peeks" }}-cluster-mgmt-eks
   namespaceSelector:
     names:
       - ray-system


### PR DESCRIPTION
## What
Parameterizes / removes the remaining hardcoded `peeks` / `us-west-2` / pinned values in the **non-KRO addon charts** flagged by #585:

| file | before | after |
|---|---|---|
| `devlake/templates/external-secret.yaml` (x2) | `peeks-devlake/mysql-connection` | `{{ .Values.resourcePrefix \| default "peeks" }}-devlake/mysql-connection` |
| `platform-manifests/templates/ray-system-iamroleselectors.yaml` (x2) | `role/peeks-cluster-mgmt-{iam,eks}` | `role/{{ .Values.global.resourcePrefix \| default "peeks" }}-cluster-mgmt-{iam,eks}` |
| `keycloak/templates/keycloak-config.yaml` | `curl ... s3.us-west-2.amazonaws.com/amazon-eks/1.32.0/2024-12-20/.../kubectl` | `curl ... dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/.../kubectl` |

## Why
- **devlake / ray-system**: use `| default "peeks"`, so rendering is byte-identical when unset (no behavior change on existing deployments). devlake is aligned with the `grafana-dashboards` sibling that reads the **same** SM secret.
- **keycloak**: the old URL hardcoded the region **and** pinned kubectl `1.32.0` coupled to an EKS build date (`2024-12-20`) — not renovate-trackable (a version bump would leave a broken date). Switched to the **`dl.k8s.io/release/stable` pattern already used everywhere else in the repo** (cicd-pipeline x5, kubeflow) → removes the hardcoded region and the version pin, always fetches the current stable kubectl, no renovate customManager needed, and makes the repo consistent.

Verified live (read-only) on kro-c1 that these were the charts still carrying hardcoded values; already-fixed items (backstage `system-peeks`, huggingface-models, image-prepuller, grafana-dashboards) confirmed clean.

## Deferred / for discussion
- **KRO resource-groups manifests** (`kro/.../appmod-service.yaml`: `peeks-cluster-mgmt-*`, `key: peeks/platform/amp`; `kro/.../ray-service.yaml`) — left to **#597** (resourcePrefix -> clusterName alignment). The `peeks`/`us-west-2` values there that are **KRO schema defaults** are explicitly allowed by #585's acceptance.

Partially addresses #585 (non-KRO charts); KRO portion tracked in #597.
