### PR TITLE
feat(#588): enable kyverno-policy-reporter on dev/prod spokes

### DIFF
--- a/gitops/overlays/environments/dev/enabled-addons.yaml
+++ b/gitops/overlays/environments/dev/enabled-addons.yaml
@@ -9,6 +9,7 @@ enabledAddons:
   # Security
   kyverno: true
   kyverno_policies: true
+  kyverno_policy_reporter: true
   # Observability
   kube_state_metrics: true
   prometheus_node_exporter: true

--- a/gitops/overlays/environments/prod/enabled-addons.yaml
+++ b/gitops/overlays/environments/prod/enabled-addons.yaml
@@ -10,6 +10,7 @@ enabledAddons:
   # Security
   kyverno: true
   kyverno_policies: true
+  kyverno_policy_reporter: true
   # Observability
   kube_state_metrics: true
   prometheus_node_exporter: true


### PR DESCRIPTION
## What
Enables `kyverno-policy-reporter` on the dev/prod spokes by adding `kyverno_policy_reporter: true` to `gitops/overlays/environments/{dev,prod}/enabled-addons.yaml`.

The addon is already registered in `security.yaml` (policy-reporter chart 3.7.4, ns `kyverno`); it was simply disabled everywhere.

## Why / validation
Completes the last item of #588 (security addons). Validated **live** on a kro-c1 deployment: enabling the same flag via the overlay caused ArgoCD to render the `enable_kyverno_policy_reporter=true` cluster-secret label and deploy `kyverno-policy-reporter-peeks-spoke-{dev,prod}` → **Synced/Healthy**.

Additive; only affects clusters where kyverno already runs (dev/prod spokes).

Closes #588 (with keycloak/kyverno/kyverno-policies already verified healthy).
