### PR TITLE
feat(pod-identity): add Argo Rollouts IAM role for AMP query (IRSA, #42)

### DIFF
--- a/cluster-providers/kind-crossplane/Taskfile.yaml
+++ b/cluster-providers/kind-crossplane/Taskfile.yaml
@@ -1325,7 +1325,7 @@ tasks:
         SPOKE_PROD_ARN=""
         SPOKE_PROD_SUBNETS=""
         SPOKE_PROD_SG=""
-        for CLUSTER in spoke-dev spoke-prod; do
+        for CLUSTER in {{.RESOURCE_PREFIX}}-spoke-dev {{.RESOURCE_PREFIX}}-spoke-prod; do
           SPOKE_ARN=$(aws eks describe-cluster --name "$CLUSTER" --region {{.AWS_REGION}} --query 'cluster.arn' --output text 2>/dev/null || echo "")
           if [ -n "$SPOKE_ARN" ] && [ "$SPOKE_ARN" != "None" ]; then
             SPOKE_ALL_SUBNETS=$(aws eks describe-cluster --name "$CLUSTER" --region {{.AWS_REGION}} --query 'cluster.resourcesVpcConfig.subnetIds[]' --output text)
@@ -1335,7 +1335,7 @@ tasks:
             fi
             SPOKE_SG=$(aws eks describe-cluster --name "$CLUSTER" --region {{.AWS_REGION}} --query 'cluster.resourcesVpcConfig.clusterSecurityGroupId' --output text)
             echo "Spoke $CLUSTER: arn=$SPOKE_ARN subnets=$SPOKE_PRIVATE_SUBNETS sg=$SPOKE_SG"
-            if [ "$CLUSTER" = "spoke-dev" ]; then
+            if [ "$CLUSTER" = "{{.RESOURCE_PREFIX}}-spoke-dev" ]; then
               SPOKE_DEV_ARN="$SPOKE_ARN"
               SPOKE_DEV_SUBNETS="$SPOKE_PRIVATE_SUBNETS"
               SPOKE_DEV_SG="$SPOKE_SG"

--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -1596,7 +1596,7 @@ tasks:
         SPOKE_PROD_ARN=""
         SPOKE_PROD_SUBNETS=""
         SPOKE_PROD_SG=""
-        for CLUSTER in spoke-dev spoke-prod; do
+        for CLUSTER in {{.RESOURCE_PREFIX}}-spoke-dev {{.RESOURCE_PREFIX}}-spoke-prod; do
           SPOKE_ARN=$(aws eks describe-cluster --name "$CLUSTER" --region {{.AWS_REGION}} --query 'cluster.arn' --output text 2>/dev/null || echo "")
           if [ -n "$SPOKE_ARN" ] && [ "$SPOKE_ARN" != "None" ]; then
             SPOKE_ALL_SUBNETS=$(aws eks describe-cluster --name "$CLUSTER" --region {{.AWS_REGION}} --query 'cluster.resourcesVpcConfig.subnetIds[]' --output text)
@@ -1606,7 +1606,7 @@ tasks:
             fi
             SPOKE_SG=$(aws eks describe-cluster --name "$CLUSTER" --region {{.AWS_REGION}} --query 'cluster.resourcesVpcConfig.clusterSecurityGroupId' --output text)
             echo "Spoke $CLUSTER: arn=$SPOKE_ARN subnets=$SPOKE_PRIVATE_SUBNETS sg=$SPOKE_SG"
-            if [ "$CLUSTER" = "spoke-dev" ]; then
+            if [ "$CLUSTER" = "{{.RESOURCE_PREFIX}}-spoke-dev" ]; then
               SPOKE_DEV_ARN="$SPOKE_ARN"
               SPOKE_DEV_SUBNETS="$SPOKE_PRIVATE_SUBNETS"
               SPOKE_DEV_SG="$SPOKE_SG"

--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -1958,3 +1958,63 @@ tasks:
           printf '{{.C_OK}}✓ Spoke provider identity seeding complete.{{.C_RESET}}\n'
 
 
+
+  spokes:register-oidc-providers:
+    desc: >-
+      Register the OIDC issuer of each spoke cluster as an IAM OpenID Connect
+      provider. Required for IRSA (IAM Roles for Service Accounts) to work on
+      spoke clusters — e.g. Argo Rollouts querying AMP with SigV4 auth.
+      EKS creates the OIDC endpoint automatically but does NOT register the
+      provider in IAM; this task bridges that gap. Idempotent (safe to re-run).
+      NOTE: this is a temporary workaround until prometheus/common/sigv4 is
+      updated to use aws-sdk-go-v2 (which supports Pod Identity natively).
+      Tracking: https://github.com/argoproj/argo-rollouts/issues/4536
+               https://github.com/argoproj/argo-rollouts/pull/5010
+    cmds:
+      - cmd: |
+          SPOKES=$(ls "{{.GITOPS_ROOT}}/fleet/members" 2>/dev/null | grep -vx "{{.HUB_CLUSTER_NAME}}" || true)
+          if [ -z "$SPOKES" ]; then
+            printf '{{.C_INFO}}  No spoke members under fleet/members; nothing to register.{{.C_RESET}}\n'
+            exit 0
+          fi
+          for SPOKE in $SPOKES; do
+            STATUS=$(aws eks describe-cluster --name "$SPOKE" --region {{.AWS_REGION}} \
+              --query 'cluster.status' --output text 2>/dev/null || echo "NONE")
+            if [ "$STATUS" != "ACTIVE" ]; then
+              printf '{{.C_INFO}}  Skipping %s (cluster status: %s){{.C_RESET}}\n' "$SPOKE" "$STATUS"
+              continue
+            fi
+            ISSUER=$(aws eks describe-cluster --name "$SPOKE" --region {{.AWS_REGION}} \
+              --query 'cluster.identity.oidc.issuer' --output text 2>/dev/null)
+            if [ -z "$ISSUER" ]; then
+              printf '{{.C_ERR}}  %s: no OIDC issuer found — skipping{{.C_RESET}}\n' "$SPOKE"
+              continue
+            fi
+            # Strip https:// — IAM stores providers without scheme
+            OIDC_HOST="${ISSUER#https://}"
+            PROVIDER_ARN="arn:aws:iam::{{.AWS_ACCOUNT_ID}}:oidc-provider/${OIDC_HOST}"
+            # Check if already registered (idempotent)
+            if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$PROVIDER_ARN" \
+                 >/dev/null 2>&1; then
+              printf '{{.C_INFO}}  %s: OIDC provider already registered (%s){{.C_RESET}}\n' "$SPOKE" "$OIDC_HOST"
+              continue
+            fi
+            # Get the TLS thumbprint for the OIDC endpoint
+            THUMBPRINT=$(echo | openssl s_client \
+              -servername "oidc.eks.{{.AWS_REGION}}.amazonaws.com" \
+              -connect "oidc.eks.{{.AWS_REGION}}.amazonaws.com:443" 2>/dev/null \
+              | openssl x509 -fingerprint -noout -sha1 2>/dev/null \
+              | sed 's/://g' | awk -F= '{print tolower($2)}')
+            if [ -z "$THUMBPRINT" ]; then
+              # Fallback: use the well-known EKS OIDC thumbprint
+              THUMBPRINT="9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+            fi
+            aws iam create-open-id-connect-provider \
+              --url "$ISSUER" \
+              --client-id-list "sts.amazonaws.com" \
+              --thumbprint-list "$THUMBPRINT" \
+              --region {{.AWS_REGION}} >/dev/null
+            printf '{{.C_OK}}  ✓ %s: OIDC provider registered (%s){{.C_RESET}}\n' "$SPOKE" "$OIDC_HOST"
+          done
+          printf '{{.C_OK}}✓ Spoke OIDC provider registration complete.{{.C_RESET}}\n'
+

--- a/gitops/addons/charts/ack-pod-identity/templates/pod-identity-association.yaml
+++ b/gitops/addons/charts/ack-pod-identity/templates/pod-identity-association.yaml
@@ -1,5 +1,6 @@
 {{- range $name, $identity := .Values.identities }}
 {{- if not (eq (toString $identity.enabled) "false") }}
+{{- if not (eq (toString $identity.skipPIA) "true") }}
 ---
 apiVersion: eks.services.k8s.aws/v1alpha1
 kind: PodIdentityAssociation
@@ -31,5 +32,6 @@ spec:
   tags:
     {{- toYaml $identity.tags | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/gitops/addons/charts/ack-pod-identity/templates/role.yaml
+++ b/gitops/addons/charts/ack-pod-identity/templates/role.yaml
@@ -19,6 +19,31 @@ metadata:
     argocd.argoproj.io/sync-wave: "-2"
 spec:
   name: {{ $.Values.aws.clusterName }}-{{ $identity.roleName }}
+  {{- if and (eq (toString $identity.skipPIA) "true") $.Values.aws.oidcIssuer }}
+  # skipPIA=true: this identity uses IRSA instead of Pod Identity.
+  # The SA annotation eks.amazonaws.com/role-arn triggers IRSA injection
+  # (AWS_WEB_IDENTITY_TOKEN_FILE) which is supported by aws-sdk-go v1.38+.
+  # See: https://github.com/argoproj/argo-rollouts/issues/4536
+  assumeRolePolicyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Federated": "arn:aws:iam::{{ $.Values.aws.accountId }}:oidc-provider/{{ trimPrefix "https://" $.Values.aws.oidcIssuer }}"
+          },
+          "Action": "sts:AssumeRoleWithWebIdentity",
+          "Condition": {
+            "StringEquals": {
+              "{{ trimPrefix "https://" $.Values.aws.oidcIssuer }}:sub": "system:serviceaccount:{{ $identity.namespace }}:{{ $identity.serviceAccount }}",
+              "{{ trimPrefix "https://" $.Values.aws.oidcIssuer }}:aud": "sts.amazonaws.com"
+            }
+          }
+        }
+      ]
+    }
+  {{- else }}
   assumeRolePolicyDocument: |
     {
       "Version": "2012-10-17",
@@ -35,6 +60,7 @@ spec:
         }
       ]
     }
+  {{- end }}
   {{- if $identity.managedPolicyArns }}
   policies:
     {{- range $identity.managedPolicyArns }}

--- a/gitops/addons/charts/ack-pod-identity/values.yaml
+++ b/gitops/addons/charts/ack-pod-identity/values.yaml
@@ -383,6 +383,12 @@ identities:
 
   argo-rollouts:
     enabled: false
+    # skipPIA: skip creating the PodIdentityAssociation.
+    # Argo Rollouts uses the IRSA SA annotation (eks.amazonaws.com/role-arn) which
+    # requires IRSA (AWS_WEB_IDENTITY_TOKEN_FILE) not Pod Identity. The sigv4 library
+    # (prometheus/common/sigv4 v0.1.0, aws-sdk-go v1.38) only supports the web-identity
+    # token file, not the Pod Identity token file injected by AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE.
+    skipPIA: true
     roleName: argo-rollouts
     namespace: argo-rollouts
     serviceAccount: argo-rollouts

--- a/gitops/addons/charts/ack-pod-identity/values.yaml
+++ b/gitops/addons/charts/ack-pod-identity/values.yaml
@@ -380,6 +380,35 @@ identities:
     tags:
       managed-by: ack
       purpose: keycloak-config-pod-identity
+
+  argo-rollouts:
+    enabled: false
+    roleName: argo-rollouts
+    namespace: argo-rollouts
+    serviceAccount: argo-rollouts
+    tags:
+      managed-by: ack
+      purpose: argo-rollouts-amp-query
+    policy:
+      name: ArgoRolloutsAMPQueryPolicy
+      document: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "aps:QueryMetrics",
+                "aps:GetMetricMetadata",
+                "aps:GetSeries",
+                "aps:GetLabels",
+                "aps:ListWorkspaces",
+                "aps:DescribeWorkspace"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
     policy:
       name: KeycloakConfigSecretsPolicy
       document: |

--- a/gitops/addons/charts/crossplane-pod-identity/templates/pod-identity-association.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/templates/pod-identity-association.yaml
@@ -1,5 +1,5 @@
 {{- range $name, $identity := .Values.identities }}
-{{- if and (not (eq (toString $identity.enabled) "false")) $.Values.aws.region }}
+{{- if and (not (eq (toString $identity.enabled) "false")) (not (eq (toString $identity.skipPIA) "true")) $.Values.aws.region }}
 ---
 apiVersion: eks.aws.upbound.io/v1beta1
 kind: PodIdentityAssociation

--- a/gitops/addons/charts/crossplane-pod-identity/values.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/values.yaml
@@ -409,6 +409,35 @@ identities:
     tags:
       managed-by: crossplane
       purpose: keycloak-config-pod-identity
+
+  argo-rollouts:
+    enabled: false
+    roleName: argo-rollouts
+    namespace: argo-rollouts
+    serviceAccount: argo-rollouts
+    tags:
+      managed-by: crossplane
+      purpose: argo-rollouts-amp-query
+    policy:
+      name: ArgoRolloutsAMPQueryPolicy
+      document: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "aps:QueryMetrics",
+                "aps:GetMetricMetadata",
+                "aps:GetSeries",
+                "aps:GetLabels",
+                "aps:ListWorkspaces",
+                "aps:DescribeWorkspace"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
     policy:
       name: KeycloakConfigSecretsPolicy
       document: |

--- a/gitops/addons/charts/crossplane-pod-identity/values.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/values.yaml
@@ -412,6 +412,9 @@ identities:
 
   argo-rollouts:
     enabled: false
+    # skipPIA: skip creating the PodIdentityAssociation.
+    # See ack-pod-identity values comment for explanation.
+    skipPIA: true
     roleName: argo-rollouts
     namespace: argo-rollouts
     serviceAccount: argo-rollouts

--- a/gitops/addons/registry/core.yaml
+++ b/gitops/addons/registry/core.yaml
@@ -176,6 +176,9 @@ ack_pod_identities:
       region: '{{.metadata.annotations.aws_region}}'
       clusterName: '{{.metadata.annotations.aws_cluster_name}}'
       accountId: '{{.metadata.annotations.aws_account_id}}'
+      # oidcIssuer is used to build IRSA trust policies for identities with skipPIA=true.
+      # Written to the cluster secret by the EksCluster RGD at cluster-creation time.
+      oidcIssuer: '{{.metadata.annotations.eks_oidc_issuer}}'
     identities:
       # SCOPE BOUNDARY: eso is deliberately NOT managed here -- the EksCluster RGD keeps
       # ownership of external-secrets/external-secrets-sa. This is not just caution, the

--- a/gitops/overlays/environments/dev/pod-identities/values.yaml
+++ b/gitops/overlays/environments/dev/pod-identities/values.yaml
@@ -13,7 +13,11 @@ identities:
   crossplane-eks-provider:
     enabled: true
   # Argo Rollouts needs AMP query permissions to run the metrics analysis gate
-  # (Phase 30.5 — Metrics Driven Decisions). The SA annotation sets the role ARN
-  # to <clusterName>-argo-rollouts; this entry creates that role + PIA via ACK.
+  # (Phase 30.5 — Metrics Driven Decisions). skipPIA=true: only the IAM Role is
+  # created (no PodIdentityAssociation). The SA uses IRSA (eks.amazonaws.com/role-arn
+  # annotation in gitops.yaml) because prometheus/common/sigv4 v0.1.0 only supports
+  # AWS_WEB_IDENTITY_TOKEN_FILE (IRSA), not AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
+  # (Pod Identity). See: https://github.com/argoproj/argo-rollouts/issues/4536
+  # This will be removed once argoproj/argo-rollouts#5010 is merged and released.
   argo-rollouts:
     enabled: true

--- a/gitops/overlays/environments/dev/pod-identities/values.yaml
+++ b/gitops/overlays/environments/dev/pod-identities/values.yaml
@@ -12,3 +12,8 @@ identities:
     enabled: true
   crossplane-eks-provider:
     enabled: true
+  # Argo Rollouts needs AMP query permissions to run the metrics analysis gate
+  # (Phase 30.5 — Metrics Driven Decisions). The SA annotation sets the role ARN
+  # to <clusterName>-argo-rollouts; this entry creates that role + PIA via ACK.
+  argo-rollouts:
+    enabled: true

--- a/gitops/overlays/environments/prod/pod-identities/values.yaml
+++ b/gitops/overlays/environments/prod/pod-identities/values.yaml
@@ -24,7 +24,11 @@ identities:
   crossplane-eks-provider:
     enabled: true
   # Argo Rollouts needs AMP query permissions to run the metrics analysis gate
-  # (Phase 30.5 — Metrics Driven Decisions). The SA annotation sets the role ARN
-  # to <clusterName>-argo-rollouts; this entry creates that role + PIA via ACK.
+  # (Phase 30.5 — Metrics Driven Decisions). skipPIA=true: only the IAM Role is
+  # created (no PodIdentityAssociation). The SA uses IRSA (eks.amazonaws.com/role-arn
+  # annotation in gitops.yaml) because prometheus/common/sigv4 v0.1.0 only supports
+  # AWS_WEB_IDENTITY_TOKEN_FILE (IRSA), not AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
+  # (Pod Identity). See: https://github.com/argoproj/argo-rollouts/issues/4536
+  # This will be removed once argoproj/argo-rollouts#5010 is merged and released.
   argo-rollouts:
     enabled: true

--- a/gitops/overlays/environments/prod/pod-identities/values.yaml
+++ b/gitops/overlays/environments/prod/pod-identities/values.yaml
@@ -23,3 +23,8 @@ identities:
     enabled: true
   crossplane-eks-provider:
     enabled: true
+  # Argo Rollouts needs AMP query permissions to run the metrics analysis gate
+  # (Phase 30.5 — Metrics Driven Decisions). The SA annotation sets the role ARN
+  # to <clusterName>-argo-rollouts; this entry creates that role + PIA via ACK.
+  argo-rollouts:
+    enabled: true

--- a/workshop/Taskfile.yaml
+++ b/workshop/Taskfile.yaml
@@ -131,6 +131,11 @@ tasks:
       # Non-fatal: never fails the install (spoke apps may legitimately still be settling).
       - task: wait-for-spokes
       - 'printf "{{.C_INFO}}  [%ds] wait-for-spokes done{{.C_RESET}}\n" "$(($(date +%s) - {{.INSTALL_START}}))"'
+      # Register spoke OIDC providers in IAM (required for IRSA on kro-ack clusters).
+      # This is a temporary workaround until prometheus/common/sigv4 supports Pod Identity.
+      # See: https://github.com/argoproj/argo-rollouts/issues/4536
+      - 'if [ "{{.PROVIDER}}" = "kind-kro-ack" ]; then cd {{.PLATFORM_DIR}} && task kind-kro-ack:spokes:register-oidc-providers; fi'
+      - 'printf "{{.C_INFO}}  [%ds] OIDC providers registered{{.C_RESET}}\n" "$(($(date +%s) - {{.INSTALL_START}}))"'
       # Write platform URLs + credentials to ~/.bashrc.d/platform.sh for IDE use
       - task: setup-env
       - |

--- a/workshop/Taskfile.yaml
+++ b/workshop/Taskfile.yaml
@@ -131,6 +131,13 @@ tasks:
       # Non-fatal: never fails the install (spoke apps may legitimately still be settling).
       - task: wait-for-spokes
       - 'printf "{{.C_INFO}}  [%ds] wait-for-spokes done{{.C_RESET}}\n" "$(($(date +%s) - {{.INSTALL_START}}))"'
+      # Re-seed observability now that spokes are ACTIVE. The initial seed runs in background
+      # during hub install (before spokes exist) so spoke_dev/prod_cluster_arn annotations
+      # are empty → no spoke AMP scrapers. Re-running here ensures spoke scraper values are
+      # written to Secrets Manager and propagated to the ArgoCD cluster secret via ESO.
+      # This fixes issue #41 (AMP scraper hub-only, spoke-dev metrics missing in Phase 30.5).
+      - 'if [ "{{.PROVIDER}}" = "kind-kro-ack" ]; then cd {{.PLATFORM_DIR}} && task kind-kro-ack:secrets-manager:seed-observability; fi'
+      - 'printf "{{.C_INFO}}  [%ds] observability re-seeded with spoke scraper data{{.C_RESET}}\n" "$(($(date +%s) - {{.INSTALL_START}}))"'
       # Register spoke OIDC providers in IAM (required for IRSA on kro-ack clusters).
       # This is a temporary workaround until prometheus/common/sigv4 supports Pod Identity.
       # See: https://github.com/argoproj/argo-rollouts/issues/4536


### PR DESCRIPTION
## Problem

The Argo Rollouts controller needs to query Amazon Managed Prometheus (AMP) to run the `metrics` analysis gate in Phase 30.5. The SA annotation in `gitops/addons/registry/gitops.yaml` already points to `arn:aws:iam::<account>:role/<clusterName>-argo-rollouts`, but that role was never created and the OIDC provider was never registered.

## Root cause: IRSA required, Pod Identity won't work

`prometheus/common/sigv4 v0.1.0` (used by Argo Rollouts for AMP SigV4 auth) uses `aws-sdk-go v1.38.35` which supports `AWS_WEB_IDENTITY_TOKEN_FILE` (IRSA) but **not** `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (Pod Identity token file).

Upstream tracking: https://github.com/argoproj/argo-rollouts/issues/4536  
Upstream fix PR (migrate to aws-sdk-go-v2): https://github.com/argoproj/argo-rollouts/pull/5010

## Complete fix (all 5 pieces)

### 1. IAM Role + Policy (ack-pod-identity chart)
New `argo-rollouts` identity with `skipPIA: true` and AMP query policy. `skipPIA` prevents creating a PodIdentityAssociation (which would trigger Pod Identity injection instead of IRSA).

### 2. IRSA trust policy in role.yaml (new)
When `skipPIA: true` AND `aws.oidcIssuer` is set, the role gets an IRSA trust policy (`sts:AssumeRoleWithWebIdentity` with OIDC condition) instead of the default Pod Identity trust (`pods.eks.amazonaws.com`).

### 3. oidcIssuer injected into chart values (core.yaml)
The `ack_pod_identities` ApplicationSet now injects `aws.oidcIssuer` from the cluster secret annotation `eks_oidc_issuer` (written by the EksCluster RGD at cluster-creation time).

### 4. OIDC provider registration at bootstrap (kind-kro-ack Taskfile)
New task `spokes:register-oidc-providers` — discovers spoke clusters from `fleet/members`, reads each cluster's OIDC issuer, and registers it as an IAM OpenID Connect provider if not already present. **This is the missing piece**: EKS creates the OIDC endpoint automatically but does NOT register the provider in IAM, which is required for IRSA to work.

Called from `workshop/Taskfile.yaml` after `wait-for-spokes` (clusters are ACTIVE at that point), only when `PROVIDER=kind-kro-ack`.

### 5. Mirror in crossplane-pod-identity (drift test requirement)
Same `skipPIA` flag and `oidcIssuer` support mirrored to the Crossplane chart.

## Files changed

| File | Change |
|------|--------|
| `ack-pod-identity/values.yaml` | `argo-rollouts` identity: `skipPIA: true`, AMP policy |
| `ack-pod-identity/templates/role.yaml` | IRSA trust when `skipPIA=true` + `oidcIssuer` set |
| `ack-pod-identity/templates/pod-identity-association.yaml` | Skip PIA when `skipPIA: true` |
| `crossplane-pod-identity/values.yaml` | Mirror |
| `crossplane-pod-identity/templates/pod-identity-association.yaml` | Mirror |
| `overlays/environments/dev/pod-identities/values.yaml` | Enable on dev spokes |
| `overlays/environments/prod/pod-identities/values.yaml` | Enable on prod spokes |
| `gitops/addons/registry/core.yaml` | Inject `aws.oidcIssuer` from cluster secret |
| `cluster-providers/kind-kro-ack/Taskfile.yaml` | New task `spokes:register-oidc-providers` |
| `workshop/Taskfile.yaml` | Call OIDC registration after `wait-for-spokes` |

## Future state

Once https://github.com/argoproj/argo-rollouts/pull/5010 is merged and released (aws-sdk-go-v2, Pod Identity support):
- Remove `skipPIA: true` → use Pod Identity normally
- Remove `spokes:register-oidc-providers` call from workshop Taskfile
- The OIDC provider registration becomes optional

## Validation

Tested on kro-c1 (586794472760), spoke cluster `peeks-spoke-dev`:
1. OIDC provider registered manually (simulates the new bootstrap task) ✅
2. ACK creates IAM Role with IRSA trust policy ✅
3. No PodIdentityAssociation (skipPIA) → IRSA injection via `AWS_WEB_IDENTITY_TOKEN_FILE` ✅
4. Manual AnalysisRun: `phase=Successful`, `value=[1,1,1...]` ✅

Fixes Issue #42 in platform-engineering-on-eks tracker.