### PR TITLE
fix(kubevela ingress): remove bogus host-header domain so path rules match (progressive, dotnet, examples)

### DIFF
--- a/applications/dotnet/deployment/dev/application.yaml
+++ b/applications/dotnet/deployment/dev/application.yaml
@@ -21,7 +21,7 @@ spec:
       traits: 
         - type: path-based-ingress
           properties:
-            domain: "*.elb.us-west-2.amazonaws.com"
+            domain: ""
             rewritePath: true 
             http:
               /northwind-app: 80

--- a/applications/java/progressive-app-kubevela.yaml
+++ b/applications/java/progressive-app-kubevela.yaml
@@ -14,7 +14,7 @@ spec:
       traits:
         - type: path-based-ingress
           properties:
-            domain: "*.elb.us-west-2.amazonaws.com" 
+            domain: ""
             rewritePath: true
             http:
               /progressive: 8080

--- a/applications/rust/platform-meta/examples/ddb-example.yaml
+++ b/applications/rust/platform-meta/examples/ddb-example.yaml
@@ -32,7 +32,7 @@ spec:
       traits:
         - type: path-based-ingress
           properties:
-            domain: "*.elb.us-west-2.amazonaws.com"
+            domain: ""
             rewritePath: true
             http:
               "/my-app": 8080

--- a/applications/rust/platform-meta/examples/service-example-1.yaml
+++ b/applications/rust/platform-meta/examples/service-example-1.yaml
@@ -15,7 +15,7 @@ spec:
       traits:
         - type: path-based-ingress
           properties:
-            domain: "*.elb.us-west-2.amazonaws.com"
+            domain: ""
             rewritePath: true
             http:
               /northwind-app: 80


### PR DESCRIPTION
## What
Several KubeVela `path-based-ingress` traits set `domain: "*.elb.us-west-2.amazonaws.com"`. That value renders as the Ingress **host** → an ALB **host-header condition** that never matches the real ALB DNS (`...us-west-2.elb.amazonaws.com`) → the path rule never fires → **404**.

The `rust`/`java` real manifests already use `domain: ""` (no host condition) and work. This aligns the rest.

## Fixed (all set to `domain: ""`)
| file | app / path | note |
|---|---|---|
| `applications/java/progressive-app-kubevela.yaml` | progressive `/progressive` | real 404 |
| `applications/dotnet/deployment/dev/application.yaml` | northwind `/northwind-app` | real 404 |
| `applications/rust/platform-meta/examples/ddb-example.yaml` | example | consistency (users copy these) |
| `applications/rust/platform-meta/examples/service-example-1.yaml` | example | consistency |

## Validation
Verified live: a `curl` with a matching `Host` header returns 200, confirming the path/rewrite transform is correct — the only problem was the bogus host-header condition. Removing the domain lets the path rule match on the real ALB DNS.

Targets `release/v0.3.0-rc3`.
