### PR TITLE
fix(pod-identity): keycloak identity missing its policy (duplicate YAML key)

### DIFF
--- a/gitops/addons/charts/ack-pod-identity/values.yaml
+++ b/gitops/addons/charts/ack-pod-identity/values.yaml
@@ -380,41 +380,6 @@ identities:
     tags:
       managed-by: ack
       purpose: keycloak-config-pod-identity
-
-  argo-rollouts:
-    enabled: false
-    # skipPIA: skip creating the PodIdentityAssociation.
-    # Argo Rollouts uses the IRSA SA annotation (eks.amazonaws.com/role-arn) which
-    # requires IRSA (AWS_WEB_IDENTITY_TOKEN_FILE) not Pod Identity. The sigv4 library
-    # (prometheus/common/sigv4 v0.1.0, aws-sdk-go v1.38) only supports the web-identity
-    # token file, not the Pod Identity token file injected by AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE.
-    skipPIA: true
-    roleName: argo-rollouts
-    namespace: argo-rollouts
-    serviceAccount: argo-rollouts
-    tags:
-      managed-by: ack
-      purpose: argo-rollouts-amp-query
-    policy:
-      name: ArgoRolloutsAMPQueryPolicy
-      document: |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Action": [
-                "aps:QueryMetrics",
-                "aps:GetMetricMetadata",
-                "aps:GetSeries",
-                "aps:GetLabels",
-                "aps:ListWorkspaces",
-                "aps:DescribeWorkspace"
-              ],
-              "Resource": "*"
-            }
-          ]
-        }
     policy:
       name: KeycloakConfigSecretsPolicy
       document: |
@@ -454,6 +419,41 @@ identities:
                 "identitystore:CreateGroupMembership",
                 "identitystore:ListGroupMemberships",
                 "identitystore:ListGroups"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+
+  argo-rollouts:
+    enabled: false
+    # skipPIA: skip creating the PodIdentityAssociation.
+    # Argo Rollouts uses the IRSA SA annotation (eks.amazonaws.com/role-arn) which
+    # requires IRSA (AWS_WEB_IDENTITY_TOKEN_FILE) not Pod Identity. The sigv4 library
+    # (prometheus/common/sigv4 v0.1.0, aws-sdk-go v1.38) only supports the web-identity
+    # token file, not the Pod Identity token file injected by AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE.
+    skipPIA: true
+    roleName: argo-rollouts
+    namespace: argo-rollouts
+    serviceAccount: argo-rollouts
+    tags:
+      managed-by: ack
+      purpose: argo-rollouts-amp-query
+    policy:
+      name: ArgoRolloutsAMPQueryPolicy
+      document: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "aps:QueryMetrics",
+                "aps:GetMetricMetadata",
+                "aps:GetSeries",
+                "aps:GetLabels",
+                "aps:ListWorkspaces",
+                "aps:DescribeWorkspace"
               ],
               "Resource": "*"
             }

--- a/gitops/addons/charts/crossplane-pod-identity/values.yaml
+++ b/gitops/addons/charts/crossplane-pod-identity/values.yaml
@@ -409,38 +409,6 @@ identities:
     tags:
       managed-by: crossplane
       purpose: keycloak-config-pod-identity
-
-  argo-rollouts:
-    enabled: false
-    # skipPIA: skip creating the PodIdentityAssociation.
-    # See ack-pod-identity values comment for explanation.
-    skipPIA: true
-    roleName: argo-rollouts
-    namespace: argo-rollouts
-    serviceAccount: argo-rollouts
-    tags:
-      managed-by: crossplane
-      purpose: argo-rollouts-amp-query
-    policy:
-      name: ArgoRolloutsAMPQueryPolicy
-      document: |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Action": [
-                "aps:QueryMetrics",
-                "aps:GetMetricMetadata",
-                "aps:GetSeries",
-                "aps:GetLabels",
-                "aps:ListWorkspaces",
-                "aps:DescribeWorkspace"
-              ],
-              "Resource": "*"
-            }
-          ]
-        }
     policy:
       name: KeycloakConfigSecretsPolicy
       document: |
@@ -480,6 +448,38 @@ identities:
                 "identitystore:CreateGroupMembership",
                 "identitystore:ListGroupMemberships",
                 "identitystore:ListGroups"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+
+  argo-rollouts:
+    enabled: false
+    # skipPIA: skip creating the PodIdentityAssociation.
+    # See ack-pod-identity values comment for explanation.
+    skipPIA: true
+    roleName: argo-rollouts
+    namespace: argo-rollouts
+    serviceAccount: argo-rollouts
+    tags:
+      managed-by: crossplane
+      purpose: argo-rollouts-amp-query
+    policy:
+      name: ArgoRolloutsAMPQueryPolicy
+      document: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "aps:QueryMetrics",
+                "aps:GetMetricMetadata",
+                "aps:GetSeries",
+                "aps:GetLabels",
+                "aps:ListWorkspaces",
+                "aps:DescribeWorkspace"
               ],
               "Resource": "*"
             }


### PR DESCRIPTION
## Problem (blocker on the v0.3.0-rc3 build)

The Keycloak config Job's Pod Identity role `<cluster>-KeycloakConfigPodIdentityRole` has **no policy attached**, so `secretsmanager:CreateSecret` on `<cluster>/keycloak-clients` fails with `AccessDenied`. The `<cluster>/keycloak-clients` secret is never created → the OIDC ExternalSecrets for **Backstage, Argo Workflows, and JupyterHub** fail (`could not get secret data from provider`) → those apps get 0 pods / Degraded (Modules 20/30/40).

## Root cause — duplicate YAML `policy:` key

In both `ack-pod-identity` and `crossplane-pod-identity` `values.yaml`, the `KeycloakConfigSecretsPolicy` block was placed under the **`argo-rollouts`** identity as a **second `policy:` key**, and the `keycloak` identity had **no `policy:` at all`**:

```yaml
argo-rollouts:
  policy:                 # ArgoRolloutsAMPQueryPolicy (aps:*)
  policy:                 # KeycloakConfigSecretsPolicy (secretsmanager:*)  <-- duplicate key
keycloak:
  # (no policy)
```

YAML "last key wins", so:
1. `keycloak` rendered **no Policy** (`{{- if $identity.policy }}` false) → role without policy → the AccessDenied above.
2. `argo-rollouts` silently got the **secretsmanager** policy instead of `ArgoRolloutsAMPQueryPolicy` → its AMP SigV4 queries would also fail (regression of #831).

## Fix

Move the `KeycloakConfigSecretsPolicy` block to the `keycloak` identity and leave `argo-rollouts` with only `ArgoRolloutsAMPQueryPolicy` — in **both** charts (kept in parity per the drift test).

Verified by parsing both `values.yaml`:
- `identities.keycloak.policy.name = KeycloakConfigSecretsPolicy` (has `secretsmanager:CreateSecret`)
- `identities.argo-rollouts.policy.name = ArgoRolloutsAMPQueryPolicy` (has `aps:QueryMetrics`)

Fixes the Keycloak/Backstage/Argo-Workflows/JupyterHub cascade **and** restores the #831 Argo Rollouts AMP policy.

> Note: already-provisioned event accounts need the policy attached to the existing role manually (or a re-provision) — this fix corrects new deployments.
