### PR TITLE
fix(ray): HuggingFace model download — bucket prefix (peeks) + disable HF Xet

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/huggingface/rg-huggingface-model.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/huggingface/rg-huggingface-model.yaml
@@ -172,6 +172,10 @@ spec:
                 args:
                   - |
                     set -e
+                    # gpt2 and other Xet-backed HF repos fail to download when the hf_xet
+                    # backend is used in this minimal pod (missing xet deps / restricted
+                    # egress). Force the classic HTTP transfer.
+                    export HF_HUB_DISABLE_XET=1
                     echo "Installing dependencies..."
                     pip install -q huggingface_hub
                     

--- a/gitops/addons/charts/platform-manifests-post/templates/huggingface-models.yaml
+++ b/gitops/addons/charts/platform-manifests-post/templates/huggingface-models.yaml
@@ -4,7 +4,7 @@
 {{- $region := "us-west-2" }}
 {{- $clusterName := "peeks-hub" }}
 {{- if .Values.global }}
-{{- $resourcePrefix = .Values.global.clusterName | default "peeks" }}
+{{- $resourcePrefix = .Values.global.resourcePrefix | default "peeks" }}
 {{- $accountId = .Values.global.accountId | default "123456789012" }}
 {{- $region = .Values.global.region | default "us-west-2" }}
 {{- $clusterName = .Values.global.clusterName | default "peeks-hub" }}

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -653,5 +653,6 @@ platform-manifests-post:
   valuesObject:
     global:
       clusterName: '{{.metadata.annotations.aws_cluster_name}}'
+      resourcePrefix: '{{.metadata.annotations.resource_prefix}}'
       accountId: '{{.metadata.annotations.aws_account_id}}'
       region: '{{.metadata.annotations.aws_region}}'


### PR DESCRIPTION
Two fixes to the HuggingFace model download flow (all 3 downloads — gpt2-neuron, mistral-7b-neuron, tinyllama — fail today).

## 1. Bucket name prefix (clusterName vs resourcePrefix)
`platform-manifests-post/templates/huggingface-models.yaml` derived the model bucket from `global.clusterName` (`peeks-hub`) → `peeks-hub-ray-models-<acct>` which does not exist (and is outside the ray SA IAM scope). `ray:setup` creates `peeks-ray-models-<acct>` (RESOURCE_PREFIX=peeks), `prestage-models` uploads there, and the RayService serving default is `peeks-ray-models`. Fix: use `global.resourcePrefix | default "peeks"` and pass `resourcePrefix` (from the `resource_prefix` annotation = peeks) into platform-manifests-post's global. → `peeks-ray-models-<acct>`.

## 2. HF Xet backend (gpt2)
`rg-huggingface-model.yaml` download step ran `pip install huggingface_hub` and `snapshot_download` with the default **hf_xet** transfer, which fails for Xet-backed repos (gpt2) in the minimal pod. Set `HF_HUB_DISABLE_XET=1` to force classic HTTP transfer.

Validated live (event adbca960): `resource_prefix=peeks`, `peeks-ray-models-<acct>` exists with the tinyllama model already prestaged; the RGD builds `S3_PATH` from `${schema.spec.s3Bucket}`.