### PR TITLE
chore(gitlab): disable native GitLab CI/CD and Auto DevOps

### DIFF
--- a/gitops/addons/charts/gitlab/templates/gitlab.yaml
+++ b/gitops/addons/charts/gitlab/templates/gitlab.yaml
@@ -87,8 +87,11 @@ spec:
             prometheus_monitoring['enable'] = false
 
             # Disable CI/CD features
-            # gitlab_ci['enable'] = false
-            # gitlab_rails['gitlab_default_projects_features_builds'] = false
+            # CI/CD is handled by Argo Workflows (GitLab webhook -> argo-events -> workflows),
+            # not GitLab's native CI. No GitLab runners are deployed, so leaving native
+            # CI/CD enabled makes Auto DevOps fire on the first push and fail (no runner).
+            gitlab_ci['enable'] = false
+            gitlab_rails['gitlab_default_projects_features_builds'] = false
 
             # Disable container registry
             registry['enable'] = false


### PR DESCRIPTION
## Summary

Disable GitLab's native CI/CD (and Auto DevOps) in the GitLab omnibus config by uncommenting two directives that have shipped **disabled-but-commented** since `1bc26e19` (2026-01-23):

\`\`\`ruby
gitlab_ci['enable'] = false
gitlab_rails['gitlab_default_projects_features_builds'] = false
\`\`\`

File: \`gitops/addons/charts/gitlab/templates/gitlab.yaml\`

## Why

- CI/CD on this platform runs through **Argo Workflows** (GitLab webhook → argo-events → workflows), **not** GitLab's native CI.
- **No GitLab runners are deployed.** With native CI/CD left enabled, GitLab **Auto DevOps** fires on the first push to a project and fails immediately (no runner), leaving a spurious **failed** pipeline in the GitLab UI (observed on \`user1/rust\`, pipeline #1: build/test/code_quality failed, scans skipped, \`NO RUNNERS\`).
- There is no \`.gitlab-ci.yml\` committed anywhere in this repo's history — the pipeline was purely Auto DevOps.

## What changed

Only the two omnibus directives are activated (plus an explanatory comment). No other behavior changes.

## Testing

- \`helm template\` renders the \`gitlab\` chart cleanly with the directives present and active in \`GITLAB_OMNIBUS_CONFIG\`.
- No \`.gitlab-ci.yml\` in the repo (verified across full git history), so nothing else references native CI.

## Rollout note

Applies on next reconcile of the \`gitlab\` addon (ArgoCD). Existing already-failed pipelines in the UI are historical and unaffected; this prevents new Auto DevOps pipelines from being created.