### PR TITLE
fix(nodepool): backstage/gitlab -> general-purpose (amd64); 2-knob nodepool tiering

### DIFF
--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -457,7 +457,7 @@ spec:
         app: backstage
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).generalPurposeNodepool | default "general-purpose" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
@@ -626,7 +626,7 @@ spec:
         app: postgresql
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).generalPurposeNodepool | default "general-purpose" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/gitops/addons/charts/gitlab/templates/gitlab.yaml
+++ b/gitops/addons/charts/gitlab/templates/gitlab.yaml
@@ -34,7 +34,7 @@ spec:
         app: gitlab
     spec:
       nodeSelector:
-        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).generalPurposeNodepool | default "general-purpose" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/gitops/addons/charts/gitlab/templates/init-job.yaml
+++ b/gitops/addons/charts/gitlab/templates/init-job.yaml
@@ -277,7 +277,7 @@ spec:
       serviceAccountName: default
       restartPolicy: OnFailure
       nodeSelector:
-        karpenter.sh/nodepool: {{ (.Values.global | default dict).systemNodepool | default "system" }}
+        karpenter.sh/nodepool: {{ (.Values.global | default dict).generalPurposeNodepool | default "general-purpose" }}
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/gitops/addons/registry/platform.yaml
+++ b/gitops/addons/registry/platform.yaml
@@ -133,6 +133,8 @@ backstage:
       accountId: '{{.metadata.annotations.aws_account_id}}'
       resource_prefix: '{{.metadata.annotations.resource_prefix}}'
       insecure: '{{default "false" .metadata.annotations.insecure}}'
+      systemNodepool: '{{ index .metadata.annotations "system_nodepool" | default "system" }}'
+      generalPurposeNodepool: '{{ index .metadata.annotations "general_purpose_nodepool" | default "general-purpose" }}'
   ignoreDifferences:
     - group: external-secrets.io
       kind: ExternalSecret

--- a/gitops/addons/registry/security.yaml
+++ b/gitops/addons/registry/security.yaml
@@ -44,6 +44,7 @@ keycloak:
       ingress_domain_name: '{{.metadata.annotations.ingress_domain_name}}'
       gitlab_domain_name: '{{ or (index .metadata.annotations "gitlab_domain_name") .metadata.annotations.ingress_domain_name }}'
       insecure: '{{default "false" .metadata.annotations.insecure}}'
+      systemNodepool: '{{ index .metadata.annotations "system_nodepool" | default "system" }}'
     aws:
       region: '{{.metadata.annotations.aws_region}}'
       cluster_name: '{{.metadata.annotations.aws_cluster_name}}'


### PR DESCRIPTION
## Problem
Addons pinned to `karpenter.sh/nodepool: system` can be scheduled on **arm64** nodes — the built-in `system` NodePool allows `["amd64","arm64"]`, while the tuned `system-peeks` pool is **amd64-only**. An amd64-only image (e.g. Backstage) landing on an arm64 node fails (`exec format error`). This is what broke Backstage.

## NodePool facts (verified live)
| pool | taint | arch |
|---|---|---|
| `system` (built-in) | `CriticalAddonsOnly` | amd64 **+ arm64** |
| `system-peeks` | `CriticalAddonsOnly` | amd64 |
| `general-purpose` (built-in) | none | amd64 |
| `general-purpose-peeks` | none | amd64 |

## Fix (tiering-aware, two knobs, generic-safe)
Templated charts already read `(.Values.global | default dict).systemNodepool | default "system"`. Add a second knob `generalPurposeNodepool` and re-tier the heavy user-facing apps off the `CriticalAddonsOnly` system pool:

- **backstage → `generalPurposeNodepool` (default `general-purpose`)** — amd64, not critical control-plane. Fixes the arch issue immediately (general-purpose is amd64), even before the tuned pools are enabled.
- **gitlab → `generalPurposeNodepool`** — heavy, not critical.
- **keycloak → stays `systemNodepool`** — critical (SSO on the platform auth path).

Registry wiring: `backstage` and `keycloak` `valuesObject.global` now source the knobs from cluster annotations, defaulting to the **built-in** pools (zero behavior change for generic clusters):
```
systemNodepool:         {{ index .metadata.annotations "system_nodepool"          | default "system" }}
generalPurposeNodepool: {{ index .metadata.annotations "general_purpose_nodepool" | default "general-purpose" }}
```
(`gitlab` has no registry addon entry — the chart default `general-purpose` covers it.)

## Activating the tuned `-peeks` pools (overlay)
Set these annotations in the **fleet-config overlay**, where the `system-peeks`/`general-purpose-peeks` NodePools are defined (`customNodepools.pools`), so the annotation and the pool stay coupled (avoids scheduling to a non-existent pool):
```
system_nodepool: system-peeks
general_purpose_nodepool: general-purpose-peeks
```
→ critical addons on `system-peeks`, backstage/gitlab on `general-purpose-peeks`.

## Not in this PR (follow-up)
The ~15 config-based addons (argo-cd, cert-manager, external-secrets, ACK controllers, crossplane, kro, kubevela…) hardcode `karpenter.sh/nodepool: system` in `configs/*/values.yaml`. Those are **static Helm valueFiles (not go-templated)**, so they can't be templatized in place; retargeting them needs per-chart `valuesObject` nodeSelector overrides. They use **multi-arch** images (no arch bug today), so this is lower priority.
