### PR TITLE
fix(nodepool): pin config addons to system-peeks (amd64) via workshop overlay

### DIFF
--- a/workshop/overlay/configs/argo-cd/values.yaml
+++ b/workshop/overlay/configs/argo-cd/values.yaml
@@ -1,0 +1,6 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+nodeSelector:
+  karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/argo-events/values.yaml
+++ b/workshop/overlay/configs/argo-events/values.yaml
@@ -1,0 +1,7 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+controller:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/argo-rollouts/values.yaml
+++ b/workshop/overlay/configs/argo-rollouts/values.yaml
@@ -1,0 +1,10 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+controller:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks
+dashboard:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/aws-efs-csi-driver/values.yaml
+++ b/workshop/overlay/configs/aws-efs-csi-driver/values.yaml
@@ -1,0 +1,7 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+controller:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/cert-manager/values.yaml
+++ b/workshop/overlay/configs/cert-manager/values.yaml
@@ -1,0 +1,12 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+nodeSelector:
+  karpenter.sh/nodepool: system-peeks
+cainjector:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks
+webhook:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/crossplane/values.yaml
+++ b/workshop/overlay/configs/crossplane/values.yaml
@@ -1,0 +1,9 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+nodeSelector:
+  karpenter.sh/nodepool: system-peeks
+rbacManager:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/dynamodb-chart/values.yaml
+++ b/workshop/overlay/configs/dynamodb-chart/values.yaml
@@ -1,0 +1,7 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+deployment:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/ec2-chart/values.yaml
+++ b/workshop/overlay/configs/ec2-chart/values.yaml
@@ -1,0 +1,7 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+deployment:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/ecr-chart/values.yaml
+++ b/workshop/overlay/configs/ecr-chart/values.yaml
@@ -1,0 +1,7 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+deployment:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/efs-chart/values.yaml
+++ b/workshop/overlay/configs/efs-chart/values.yaml
@@ -1,0 +1,6 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+nodeSelector:
+  karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/eks-chart/values.yaml
+++ b/workshop/overlay/configs/eks-chart/values.yaml
@@ -1,0 +1,6 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+nodeSelector:
+  karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/external-secrets/values.yaml
+++ b/workshop/overlay/configs/external-secrets/values.yaml
@@ -1,0 +1,12 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+nodeSelector:
+  karpenter.sh/nodepool: system-peeks
+certController:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks
+webhook:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/iam-chart/values.yaml
+++ b/workshop/overlay/configs/iam-chart/values.yaml
@@ -1,0 +1,7 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+deployment:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/image-prepuller/values.yaml
+++ b/workshop/overlay/configs/image-prepuller/values.yaml
@@ -1,0 +1,4 @@
+# Workshop: pin to general-purpose-peeks (amd64, tuned). Non-critical; the built-in
+# general-purpose is already amd64, this aligns it to the tuned pool. Generic keeps default.
+nodeSelector:
+  karpenter.sh/nodepool: general-purpose-peeks

--- a/workshop/overlay/configs/kro/values.yaml
+++ b/workshop/overlay/configs/kro/values.yaml
@@ -1,0 +1,6 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+nodeSelector:
+  karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/kubevela/values.yaml
+++ b/workshop/overlay/configs/kubevela/values.yaml
@@ -1,0 +1,13 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+vela-core:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks
+cluster-gateway:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks
+workflow:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks

--- a/workshop/overlay/configs/s3-chart/values.yaml
+++ b/workshop/overlay/configs/s3-chart/values.yaml
@@ -1,0 +1,7 @@
+# Workshop: pin to the tuned system-peeks pool (amd64, do-not-disrupt). The built-in
+# `system` pool allows arm64; this override (merged over the base config via the
+# $overlay/configs/<addon>/values.yaml source) forces amd64. CriticalAddonsOnly
+# toleration already comes from the generic base config. Generic clusters keep `system`.
+deployment:
+  nodeSelector:
+    karpenter.sh/nodepool: system-peeks


### PR DESCRIPTION
## Problem
The templated charts (backstage/keycloak/gitlab) are correctly pinned to `system-peeks` via the workshop overlay. But the **config-based addons** hardcode `karpenter.sh/nodepool: system` in `gitops/addons/configs/*/values.yaml`, and the built-in `system` NodePool allows **arm64**. Verified live: `argo-events`, `argo-rollouts`, `cert-manager`, `crossplane`, `external-secrets`, `kubevela` (and the ACK controllers) are running on **arm64** `system` nodes. They're multi-arch today (so they run), but it's the systemic arm64 exposure — a single amd64-only image/sidecar would fail (`exec format error`), and it's inconsistent with the tuned amd64 pools.

## Fix (workshop overlay only — zero generic impact)
Add `workshop/overlay/configs/<addon>/values.yaml` overrides pinning each config addon to the tuned **amd64** pool, using the existing `$overlay/configs/<addon>/values.yaml` merge source (highest precedence). Only the `nodeSelector` is set — the `CriticalAddonsOnly` toleration already comes from the base config (these addons already run on the tainted `system` pool).

**→ `system-peeks`** (critical, amd64): argo-cd, argo-events, argo-rollouts, aws-efs-csi-driver, cert-manager, crossplane, external-secrets, kro, kubevela, and the ACK controllers (iam/eks/ec2/ecr/s3/dynamodb/efs -chart).
**→ `general-purpose-peeks`** (non-critical, amd64): image-prepuller.

Each override matches the upstream chart's nodeSelector path (e.g. `deployment.nodeSelector` for ACK, `controller`/`dashboard` for argo-rollouts, top-level + `cainjector`/`webhook` for cert-manager, `vela-core`/`cluster-gateway`/`workflow` for kubevela). Multi-key nodeSelectors (compute-type/os) are deep-merged — only the nodepool key is overridden.

**Generic clusters** (no workshop overlay) keep the built-in `system`/`general-purpose` — no behavior change in the base.

## Note (already covered)
backstage/gitlab/keycloak (per-addon overlays) + argo-workflows, aws-load-balancer-controller, external-dns, kargo, kube-state-metrics, metrics-server already had `system-peeks` overlays. This PR adds the remaining config addons.

## Live rollout
Existing events need the fleet-config re-seeded (or the addon apps refreshed) to pick these up; new events get them at seed time. amd64-only pods already on arm64 need recreation.
