### PR TITLE
fix(backstage): ArgoCD deep-link uses capability endpoint (+ populate aws_argocd_url on kro-ack)

### DIFF
--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -886,6 +886,10 @@ tasks:
     vars:
       CLUSTER_ARN:
         sh: aws eks describe-cluster --name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'cluster.arn' --output text 2>/dev/null
+      # ArgoCD EKS Capability server URL (host, no scheme) so Backstage links to the
+      # capability endpoint, not the CloudFront domain. Empty until the capability is ACTIVE.
+      ARGOCD_URL:
+        sh: aws eks describe-capability --cluster-name {{.HUB_CLUSTER_NAME}} --capability-name argocd --query 'capability.configuration.argoCd.serverUrl' --output text --region {{.AWS_REGION}} 2>/dev/null | sed 's|https://||' || echo ""
       VPC_ID:
         sh: aws eks describe-cluster --name {{.HUB_CLUSTER_NAME}} --region {{.AWS_REGION}} --query 'cluster.resourcesVpcConfig.vpcId' --output text
       # Private subnets + cluster SG for the devlake RDS `vpc` object (see cmds). Mirrors the
@@ -924,7 +928,7 @@ tasks:
           --arg cluster_security_group_id "{{.CLUSTER_SG}}" \
           '{id:$id, subnet_ids:$subnet_ids, cluster_security_group_id:$cluster_security_group_id}' | jq -c .)
         SECRET_VALUE=$(jq -n \
-          --arg metadata '{"addonsRepoURL":"{{.REPO_URL}}","addonsRepoRevision":"{{.REPO_REVISION}}","addonsRepoBasepath":"{{.REPO_BASEPATH}}","fleetRepoURL":"{{.REPO_URL}}","fleetRepoRevision":"{{.REPO_REVISION}}","fleetRepoBasepath":"{{.REPO_BASEPATH}}","aws_region":"{{.AWS_REGION}}","aws_account_id":"{{.AWS_ACCOUNT_ID}}","aws_cluster_name":"{{.HUB_CLUSTER_NAME}}","aws_cluster_arn":"{{.CLUSTER_ARN}}","aws_vpc_id":"{{.VPC_ID}}","aws_private_subnet_ids":"{{.PRIVATE_SUBNET_IDS}}","aws_cluster_security_group_id":"{{.CLUSTER_SG}}","alb_controller_mode":"oss","ingress_domain_name":"'"$RUNTIME_DOMAIN"'","ingress_name":"{{.HUB_CLUSTER_NAME}}-platform","ingress_security_groups":"{{.INGRESS_SECURITY_GROUPS}}","resource_prefix":"{{.RESOURCE_PREFIX}}","insecure":"{{.INSECURE}}","certificate_arn":"{{.INGRESS_CERT_ARN}}","admin_role_name":"{{.ADMIN_ROLE_NAME}}","gitlab_domain_name":"'"$GIT_DOMAIN"'","git_token":"{{.USER_PASSWORD}}","aws_argocd_url":""}' \
+          --arg metadata '{"addonsRepoURL":"{{.REPO_URL}}","addonsRepoRevision":"{{.REPO_REVISION}}","addonsRepoBasepath":"{{.REPO_BASEPATH}}","fleetRepoURL":"{{.REPO_URL}}","fleetRepoRevision":"{{.REPO_REVISION}}","fleetRepoBasepath":"{{.REPO_BASEPATH}}","aws_region":"{{.AWS_REGION}}","aws_account_id":"{{.AWS_ACCOUNT_ID}}","aws_cluster_name":"{{.HUB_CLUSTER_NAME}}","aws_cluster_arn":"{{.CLUSTER_ARN}}","aws_vpc_id":"{{.VPC_ID}}","aws_private_subnet_ids":"{{.PRIVATE_SUBNET_IDS}}","aws_cluster_security_group_id":"{{.CLUSTER_SG}}","alb_controller_mode":"oss","ingress_domain_name":"'"$RUNTIME_DOMAIN"'","ingress_name":"{{.HUB_CLUSTER_NAME}}-platform","ingress_security_groups":"{{.INGRESS_SECURITY_GROUPS}}","resource_prefix":"{{.RESOURCE_PREFIX}}","insecure":"{{.INSECURE}}","certificate_arn":"{{.INGRESS_CERT_ARN}}","admin_role_name":"{{.ADMIN_ROLE_NAME}}","gitlab_domain_name":"'"$GIT_DOMAIN"'","git_token":"{{.USER_PASSWORD}}","aws_argocd_url":"{{.ARGOCD_URL}}"}' \
           --arg config '{"tlsClientConfig":{"insecure":false}}' \
           --arg server '{{.CLUSTER_ARN}}' \
           --arg addons '{"provider":"kro-ack"}' \

--- a/gitops/addons/charts/backstage/templates/install.yaml
+++ b/gitops/addons/charts/backstage/templates/install.yaml
@@ -317,7 +317,7 @@ data:
         - type: 'config'
           instances:
             - name: in-cluster
-              url: https://${DOMAIN_NAME}/argocd
+              url: https://{{ .Values.argocd_hostname }}
               username: admin
               password: ${ARGOCD_ADMIN_PASSWORD}
     argoWorkflows:


### PR DESCRIPTION
Backstage ArgoCD links pointed to `https://<cloudfront>/applications/argocd/...` (a 404 path) instead of the ArgoCD EKS Capability endpoint (`argocd-<id>.eks-capabilities...`).

**Root cause (2 parts):**
1. `backstage/templates/install.yaml:320` set the ArgoCD instance `url: https://${DOMAIN_NAME}/argocd` (CloudFront domain + non-existent /argocd path).
2. On **kind-kro-ack**, `hub:seed` hardcoded `aws_argocd_url: ""` → Backstage's `argocd_hostname` fell back to the ingress (CloudFront) domain. (kind-crossplane populated it, but with the `https://` scheme.)

**Fix:**
- install.yaml: `url: https://{{ .Values.argocd_hostname }}` (the capability host; ArgoCD plugin appends `/applications/...`).
- kind-kro-ack `secrets-manager:seed`: add an `ARGOCD_URL` var (capability `argoCd.serverUrl`, `https://` stripped) and set `aws_argocd_url: {{.ARGOCD_URL}}`.
- kind-crossplane: strip `https://` on the metadata `ARGOCD_URL` so `argocd_hostname` is a bare host on both providers (backstage prepends `https://`).

Verified live (event adbca960, kro-ack): `aws_argocd_url` was empty → argocd_hostname = cloudfront. Note: existing events need a re-seed; and if the argocd capability isn't ACTIVE at seed time the value can still be empty (would need a post-ready refresh — follow-up).