### PR TITLE
fix(keycloak): HA node-spread + working split-brain detector

### DIFF
--- a/gitops/addons/charts/keycloak/templates/install.yaml
+++ b/gitops/addons/charts/keycloak/templates/install.yaml
@@ -73,10 +73,24 @@ spec:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
         effect: "NoSchedule"
+      # HA scheduling: force the two replicas onto SEPARATE nodes so a single node
+      # rollout / EKS Auto Mode consolidation / upgrade can never take both down at once.
+      # (Root cause of the intermittent Backstage OIDC 502: both replicas were co-located
+      # on one node in one AZ, so a node disruption caused a full Keycloak outage during
+      # which OIDC discovery failed.)
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: keycloak
+            topologyKey: kubernetes.io/hostname
+      # Prefer spreading across AZs, but do not block scheduling if only one AZ has
+      # capacity (hostname anti-affinity above already guarantees separate nodes).
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: DoNotSchedule
+        whenUnsatisfiable: ScheduleAnyway
         labelSelector:
           matchLabels:
             app: keycloak
@@ -255,6 +269,10 @@ metadata:
   name: keycloak-pdb
   namespace: keycloak
 spec:
+  # At replicas=2 this allows only one pod down at a time during voluntary disruptions
+  # (equivalent to minAvailable: 1). Combined with the hostname anti-affinity on the
+  # StatefulSet, a node rollout evicts one pod at a time across two nodes, so Keycloak
+  # is never fully unavailable.
   maxUnavailable: 1
   selector:
     matchLabels:


### PR DESCRIPTION
## Problems

1. **Recurring Backstage OIDC login 502** (`Issuer.discover: expected 200 OK, got: 502 Bad Gateway`).
2. **split-brain detector never worked** — it always read cluster size `0` and never healed.

## Root causes

**(1) Keycloak replicas co-located on one node.** Both StatefulSet replicas landed on a single `system-peeks` node in one AZ. The zone-based topologySpreadConstraint can't separate pods within one AZ and there was no host anti-affinity, so a node rollout / EKS Auto Mode consolidation / upgrade could take **both** pods down at once. During that window Keycloak OIDC discovery is unavailable, and Backstage's OIDC provider (which runs discovery once at startup and does not self-heal) stays broken until restarted. Infinispan HA itself works (jdbc-ping, 2-member view, mTLS) — the gap was purely placement.

**(2) Detector implementation broken.** `get_cluster_members()` ran `kubectl exec <pod> -- kubectl logs`, i.e. kubectl *inside* the keycloak container, which has no kubectl → always failed → always returned `0`. Even fixing that, it grepped the boot-time "Received new cluster view (N)" log line, which ages out of the buffer.

## Fixes

**`install.yaml`** — `requiredDuringScheduling` `podAntiAffinity` on `kubernetes.io/hostname` so the two replicas always run on separate nodes; zone spread relaxed to `ScheduleAnyway`. `replicas: 2`, PDB (`maxUnavailable: 1`), and Infinispan replication unchanged.

**`split-brain-detector.yaml`** — rewritten to read the authoritative, always-current `jgroups_ping` JDBC_PING table (in the `postgres` DB Keycloak actually uses). Detects split-brain via `>1 coordinator` or stale member IPs with no live pod; heals by restarting only the non-coordinator pod(s). Runs on `postgres:17.4-alpine` (psql), uses the k8s API via the SA token for pod list/delete (adds curl+jq at start), and no longer needs `pods/exec` RBAC.

## Testing

- `helm template` renders cleanly.
- Detector logic run **live** against the running cluster: correctly reports `Ready pods: 2 | members: 2 | coordinators: 1 => healthy` (old script reported 0).
- Confirmed both replicas were co-located (the failure condition) and that discovery returns 200 when Keycloak is healthy.

## Follow-up (not in this PR)

Backstage OIDC lacks startup resilience — a single discovery failure permanently breaks auth until restart. Suggest an init-container gate on the discovery endpoint or a liveness probe that fails when the provider isn't configured.