### PR TITLE
fix: derive APP_BASE_PATH from app path (kro + kubevela) — #4b rust image 404 on custom path

### DIFF
--- a/applications/rust/deployment/templates/kro/application.yaml
+++ b/applications/rust/deployment/templates/kro/application.yaml
@@ -13,8 +13,6 @@ spec:
   clusterName: <cluster_name>
   accountId: "${AWS_ACCOUNT_ID}"
   env:
-    - name: APP_BASE_PATH
-      value: "/rust-app"
     - name: TABLE_NAME
       value: rust-app-table-<environment>
     - name: AWS_REGION

--- a/applications/rust/deployment/templates/kubevela/application.yaml
+++ b/applications/rust/deployment/templates/kubevela/application.yaml
@@ -16,6 +16,8 @@ spec:
         port: 8080
         targetPort: 8080
         replicas: 2
+        # appPath drives APP_BASE_PATH (image URL prefix); keep it EQUAL to the
+        # path-based-ingress trait path below, else prefixed assets 404.
         appPath: "/rust-app"
         serviceAccount: rust-service-account-<environment>
         env:
@@ -48,7 +50,7 @@ spec:
             # unhealthy targets on the OSS LBC). Uses the healthcheckPath trait param.
             healthcheckPath: /collection/FRONT_PAGE
             http:
-              /rust-app: 8080
+              /rust-app: 8080  # keep in sync with appPath above
 
     - name: rust-service-account-<environment>
       type: dp-service-account

--- a/applications/rust/deployment/templates/kubevela/application.yaml
+++ b/applications/rust/deployment/templates/kubevela/application.yaml
@@ -21,8 +21,6 @@ spec:
         env:
           - name: APP_ENV
             value: "DEV"
-          - name: APP_BASE_PATH
-            value: "/rust-app"
           - name: TABLE_NAME
             value: rust-app-table-<environment>
           - name: AWS_REGION

--- a/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
@@ -309,7 +309,7 @@ spec:
                   imagePullPolicy: Always
                   ports:
                     - containerPort: ${schema.spec.targetPort}
-                  env: "${size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]}"
+                  env: "${(size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]).filter(e, e.name != \"APP_BASE_PATH\") + [{\"name\": \"APP_BASE_PATH\", \"value\": schema.spec.ingress.path}]}"
 
     - id: rolloutWithoutDynamoDB
       includeWhen:
@@ -363,7 +363,7 @@ spec:
                   imagePullPolicy: Always
                   ports:
                     - containerPort: ${schema.spec.targetPort}
-                  env: "${size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]}"
+                  env: "${(size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]).filter(e, e.name != \"APP_BASE_PATH\") + [{\"name\": \"APP_BASE_PATH\", \"value\": schema.spec.ingress.path}]}"
 
     - id: rolloutWithGatesAndDynamoDB
       includeWhen:
@@ -429,7 +429,7 @@ spec:
                   imagePullPolicy: Always
                   ports:
                     - containerPort: ${schema.spec.targetPort}
-                  env: "${size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]}"
+                  env: "${(size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]).filter(e, e.name != \"APP_BASE_PATH\") + [{\"name\": \"APP_BASE_PATH\", \"value\": schema.spec.ingress.path}]}"
 
     - id: rolloutWithGatesWithoutDynamoDB
       includeWhen:
@@ -495,7 +495,7 @@ spec:
                   imagePullPolicy: Always
                   ports:
                     - containerPort: ${schema.spec.targetPort}
-                  env: "${size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]}"
+                  env: "${(size(schema.spec.env) > 0 ? schema.spec.env : [{\"name\": \"ENVIRONMENT\", \"value\": \"production\"}]).filter(e, e.name != \"APP_BASE_PATH\") + [{\"name\": \"APP_BASE_PATH\", \"value\": schema.spec.ingress.path}]}"
 
     # Services removed from Kro - Argo Rollouts will create and manage them automatically
     # - id: service

--- a/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
+++ b/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
@@ -170,7 +170,11 @@ spec:
         						}]
         					}
         					env: [
-        						if parameter.env != _|_ for _, e in parameter.env {e},
+        						if parameter.env != _|_ for _, e in parameter.env if e.name != "APP_BASE_PATH" {e},
+        						{
+        							name:  "APP_BASE_PATH"
+        							value: parameter.appPath
+        						},
         						if parameter.serviceAccount != "default" {
         							{
         								name:  "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"

--- a/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
+++ b/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
@@ -171,6 +171,10 @@ spec:
         					}
         					env: [
         						if parameter.env != _|_ for _, e in parameter.env if e.name != "APP_BASE_PATH" {e},
+        						// APP_BASE_PATH is derived from appPath so prefixed asset/image URLs follow the app path.
+        						// NOTE (kubevela): appPath and the path-based-ingress trait path are SEPARATE inputs and
+        						// MUST be set to the same value, or prefixed assets 404. (The kro RGD derives both from
+        						// a single ingress.path; on the OAM path the manifest/scaffolder must keep them in sync.)
         						{
         							name:  "APP_BASE_PATH"
         							value: parameter.appPath


### PR DESCRIPTION
## Problem (#4b — rust app images 404 on a custom path)
The rust backend builds catalog image URLs as `<APP_BASE_PATH>/product-images/<file>` (`applications/rust/src/api/setup.rs:33`) while the pod serves images unprefixed at `/product-images`. So `APP_BASE_PATH` **must equal the app/ingress path prefix** (the ALB strips it via the url-rewrite transform). `APP_BASE_PATH` was set **manually** in `env`, so deploying under a different path (e.g. `/unicorn`) than the hardcoded `/rust-app` made them diverge → catalog emits `/rust-app/product-images/...`, app lives under `/unicorn` → **images 404**.

## Fix — single source of truth (both delivery paths)
Derive `APP_BASE_PATH` from the app path so it can never diverge:

**kro (`AppmodService` RGD, `appmod-service.yaml`)** — inject `APP_BASE_PATH = ${schema.spec.ingress.path}` into the container env of all 4 Deployment/Rollout variants (filtering any manual `APP_BASE_PATH`). The RGD already couples `ingress.path` ↔ rewrite regex, so all three now derive from one field.

**KubeVela (`appmod-service` ComponentDefinition)** — inject `APP_BASE_PATH = parameter.appPath` into the container env (filtering any manual `APP_BASE_PATH`), so the image-URL prefix follows `appPath`.

Also removed the redundant manual `APP_BASE_PATH: /rust-app` from both rust manifests (kro + kubevela) — now derived.

## Notes
- Harmless for java/golang/dotnet/next-js (they don't read APP_BASE_PATH; extra env ignored).
- rust trims a trailing `/`, so `path: "/"` → empty prefix (unprefixed) — behavior unchanged for the default.
- More robust long-term alternative: have the app read `X-Forwarded-Prefix` instead of a static env (rust code change).

Fixes #4b for both the kro and KubeVela progressive-delivery paths.

## kubevela: single-source caveat (by design, Option A)
kro derives ingress-path + rewrite + `APP_BASE_PATH` from one field (`ingress.path`) → cannot diverge.
On the KubeVela/OAM path the ingress lives in the separate `path-based-ingress` trait, so `APP_BASE_PATH` is derived from the **component** `appPath`, which must be kept **equal to the trait path**. A trait-side env injection was rejected (the trait would have to patch the container by name, which the component sets to `image_name`, unknown to the trait). Documented via comments in the component + rust manifest; the reference manifest and Kiro prompt already set both to the same value. A stricter single-source fix (component owns the ingress, like kro) is a larger follow-up across all AppmodService apps.
