### PR TITLE
fix(backstage): dedupe EKS cluster template JSON write

### DIFF
--- a/platform/backstage/templates/eks-cluster-template/template.yaml
+++ b/platform/backstage/templates/eks-cluster-template/template.yaml
@@ -281,13 +281,6 @@ spec:
             owner: user:guest
             lifecycle: experimental
             type: service
-    - id: addClusterJsonForAppSet
-      name: Add cluster JSON for ApplicationSet discovery
-      action: roadiehq:utils:fs:write
-      input:
-        path: ./repo/gitops/fleet/spoke-values/tenants/${{ parameters.tenant }}/kro-clusters/clusters/${{ parameters.clusterName }}.json
-        content: |
-          {"clusterName": "${{ parameters.clusterName }}"}
     - id: createGitlabMergeRequest
       name: Create a Merge Request
       action: publish:gitlab:merge-request


### PR DESCRIPTION
## Problem

The `eks-cluster-template` writes the KRO cluster marker JSON **twice**:
- `addKroClusterJson` → `gitops/fleet/spoke-values/.../kro-clusters/clusters/<name>.json`
- `addClusterJsonForAppSet` → same path (redundant)

Only one write is needed. In older revisions (still present on `main` and in already-deployed GitLab `fleet-config` copies seeded from an older commit) the second step wrote to `gitops/fleet/kro-values/.../kro-clusters/clusters/<name>.json` — a path **no ApplicationSet generator reads** (the `clusters-kro` generator globs `fleet/spoke-values/tenants/*/kro-clusters/clusters/*.json`, see `gitops/bootstrap/clusters-kro.yaml`). That produced a stray dead duplicate file in every generated cluster MR (observed on `peeks-spoke-staging`).

## Fix

Remove the redundant `addClusterJsonForAppSet` step. The correct marker is still written once by `addKroClusterJson` to the `spoke-values` path the generator actually reads.

## Testing

- YAML validated (`yaml.safe_load_all`).
- Confirmed exactly one `clusters/<name>.json` write remains, on the `spoke-values` path; no `kro-values` write.

## Note

`main` still has the older variant where this step writes to the dead `kro-values` path — this PR targets `release/v0.3.0-rc3` (which already had it pointing at `spoke-values`, just duplicated). A separate cherry-pick/backport to `main` may be warranted.