### PR TITLE
feat(ide): open_when_ready helper — wait for the ALB before opening app URLs

### DIFF
--- a/hack/.bashrc.d/app-helpers.sh
+++ b/hack/.bashrc.d/app-helpers.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Workshop app helpers — auto-sourced via ~/.bashrc.d/* (see hack/.zshrc).
+# Provide a robust way to open deployed app URLs only once the load balancer
+# (ALB) is provisioned AND serving, so participants don't hit a blank/error page.
+
+# open_when_ready <url> [timeout_seconds]
+#   Polls <url> until the ALB answers with a 2xx/3xx, then opens it in the IDE
+#   browser. Guards against an empty/half-formed URL (ingress with no address yet).
+open_when_ready() {
+  local url="$1" timeout="${2:-300}" start=$SECONDS code
+  if [ -z "$url" ] || [[ "$url" == http://*//* ]] || [[ "$url" == https://*//* ]]; then
+    echo "⚠️  Empty/incomplete URL ('$url'). The ingress may not have an ALB address yet" >&2
+    echo "    (check \$DNS_DEV / \$DNS_PROD). Re-run the export step and retry." >&2
+    return 1
+  fi
+  echo "⏳ Waiting for the load balancer to serve ${url} (can take 1-2 min)…"
+  while :; do
+    code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null || echo 000)
+    case "$code" in
+      2*|3*) echo "✅ ${url} is reachable (HTTP ${code})."; break ;;
+    esac
+    if (( SECONDS - start > timeout )); then
+      echo "⚠️  Timed out after ${timeout}s (last HTTP ${code}). The ALB may still be" >&2
+      echo "    provisioning / registering targets — wait a moment and retry." >&2
+      return 1
+    fi
+    printf '.'; sleep 10
+  done
+  if command -v xdg-open >/dev/null 2>&1; then xdg-open "$url" 2>/dev/null
+  else echo "Open in your browser: $url"; fi
+}
+
+# wait_for_ingress <kube-context> <ingress-name> [namespace] [timeout_seconds]
+#   Echoes the ingress ALB hostname once assigned (progress goes to stderr so it
+#   is safe in command substitution): DNS_DEV=$(wait_for_ingress peeks-spoke-dev next-js-app)
+wait_for_ingress() {
+  local ctx="$1" name="$2" ns="$3" timeout="${4:-300}" start=$SECONDS host
+  local nsarg=(); [ -n "$ns" ] && nsarg=(-n "$ns")
+  echo "⏳ Waiting for ingress '$name' (context $ctx) to get an ALB address…" >&2
+  while :; do
+    host=$(kubectl --context "$ctx" "${nsarg[@]}" get ingress "$name" \
+      -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
+    [ -n "$host" ] && { echo "$host"; return 0; }
+    if (( SECONDS - start > timeout )); then
+      echo "⚠️  Ingress '$name' still has no address after ${timeout}s." >&2; return 1
+    fi
+    sleep 5
+  done
+}


### PR DESCRIPTION
## Why
Across the workshop, participants run `open "http://$DNS_DEV/<path>"` right after a deploy. The ALB (ingress) often isn't provisioned/serving yet (1-2 min), so they hit a blank or error page and think it's broken.

## What
New auto-sourced helper `hack/.bashrc.d/app-helpers.sh` (loaded via the `~/.bashrc.d/*` loop in `hack/.zshrc`, copied by bootstrap — **no CFN rebuild**):
- **`open_when_ready <url> [timeout=300]`** — polls the URL until HTTP 2xx/3xx, prints a waiting message, then opens it. Guards an empty/half-formed URL (ingress without an address yet).
- **`wait_for_ingress <ctx> <name> [ns] [timeout]`** — echoes the ALB hostname once assigned (progress on stderr, safe in `$(...)`); can harden the `export DNS_DEV=…` step.

## Content
The workshop content (platform-engineering-on-eks) is updated separately to call `open_when_ready` instead of `open` at the app-open steps (rust /unicorn, progressive, java).