### PR TITLE
fix(kubevela): functional gate emits 'Testing for'/PASS/FAIL (match kro, unblock shared verify step)

### DIFF
--- a/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
+++ b/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
@@ -342,7 +342,7 @@ spec:
         									command: ["sh"]
         									args: [
         										"-c",
-        										"wget -qO- http://\(previewService):\(parameter.port)\(parameter.appPath)/ | grep -q '\(parameter.functionalGate.extraArgs)'"
+        										"set -e; echo 'Fetching response...'; RESPONSE=$(wget -qO- http://\(previewService):\(parameter.port)\(parameter.appPath)/ 2>&1); echo 'Response received:'; echo \"$RESPONSE\"; echo ''; echo 'Testing for: \(parameter.functionalGate.extraArgs)'; if echo \"$RESPONSE\" | grep -q '\(parameter.functionalGate.extraArgs)'; then echo 'PASS: Found \(parameter.functionalGate.extraArgs)'; exit 0; else echo 'FAIL: \(parameter.functionalGate.extraArgs) not found'; exit 1; fi"
         									]
         								},
         							]


### PR DESCRIPTION
## Problem
The workshop's functional-gate verification step (module `30_function-performance-test-java`) is **shared across both tabs**:
```
kubectl get analysistemplate functional-gate-java-webservice -n team-java \
  -o jsonpath='{.spec.metrics[0].provider.job.spec.template.spec.containers[0].args[1]}' | grep -o "Testing for: [a-z]*"
```
- **kro** RGD command has `echo 'Testing for: ${extraArgs}'` → check works ✅
- **kubevela** component command was a silent `wget … | grep -q '<extraArgs>'` → **no 'Testing for:'** → the shared check returns nothing on the kubevela path ❌. It also produced uninformative AnalysisRun logs on failure.

## Fix
Mirror the kro functional-gate command in the kubevela `appmod-service` ComponentDefinition: `set -e`, capture the response, echo `Fetching response` / `Response received` / `Testing for: <extraArgs>` and `PASS/FAIL`. Same pass/fail semantics (`grep -q '<extraArgs>'`), now consistent with kro and with informative logs.

## Result
- The shared content verification step works on **both** delivery paths — no content change needed.
- kubevela functional-gate logs are now as diagnostic as kro's.