### PR TITLE
fix(idc): fail-fast SAML wait (30min->5min) + greppable IDC-skip markers (#856)

### DIFF
--- a/scripts/configure_identity_center.py
+++ b/scripts/configure_identity_center.py
@@ -620,7 +620,11 @@ async def configure_identity_center(
             # --- Step 6: Wait for Keycloak SAML descriptor ---
             print("Waiting for Keycloak SAML descriptor...", file=sys.stderr)
             saml_url = f"https://{keycloak_dns}/keycloak/realms/platform/protocol/saml/descriptor"
-            deadline = time.time() + 1800
+            # 5 min is ample: the caller (task idc:configure) already waits for the
+            # SAML descriptor (HTTP 200) before invoking this script, so the realm
+            # exists and the descriptor responds in seconds. Fail fast otherwise
+            # (was 1800s / 30 min — a 30-minute hang on failure, see #821/#856).
+            deadline = time.time() + 300
             while True:
                 try:
                     resp = requests.get(saml_url, verify=False, timeout=10)
@@ -631,7 +635,7 @@ async def configure_identity_center(
                 except Exception:
                     pass
                 if time.time() > deadline:
-                    raise TimeoutError("Keycloak SAML endpoint not available after 30 minutes")
+                    raise TimeoutError("Keycloak SAML endpoint not available after 5 minutes")
                 print("Keycloak not ready, retrying in 30s...", file=sys.stderr)
                 time.sleep(30)
 

--- a/workshop/Taskfile.yaml
+++ b/workshop/Taskfile.yaml
@@ -630,7 +630,7 @@ tasks:
         # don't waste time curling — skip immediately with a clear message.
         case "{{.KEYCLOAK_DNS}}" in
           ""|null|None)
-            printf '{{.C_ERR}}⚠ KEYCLOAK_DNS is empty — platform CloudFront domain not set.{{.C_RESET}}\n'
+            printf '{{.C_ERR}}⚠ IDC skipped: KEYCLOAK_DNS is empty — platform CloudFront domain not set.{{.C_RESET}}\n'
             printf '{{.C_INFO}}  Fix: ensure private/async-domain exists, then run: task idc:configure{{.C_RESET}}\n'
           ;;
           *)
@@ -639,7 +639,7 @@ tasks:
         KC_STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "https://{{.KEYCLOAK_DNS}}/keycloak/realms/master" --max-time 30 2>/dev/null || echo "000")
         case "$KC_STATUS" in
           000|000000|404)
-            printf '{{.C_ERR}}⚠ Keycloak not reachable (HTTP %s) — skipping IDC config. Run: task idc:configure{{.C_RESET}}\n' "$KC_STATUS"
+            printf '{{.C_ERR}}⚠ IDC skipped: Keycloak not reachable (HTTP %s). Run: task idc:configure{{.C_RESET}}\n' "$KC_STATUS"
           ;;
           *)
             # Also wait for the platform realm SAML descriptor — Keycloak needs extra time
@@ -658,7 +658,7 @@ tasks:
               sleep 15
             done
             if [ "$SAML_OK" = "false" ]; then
-              printf '{{.C_ERR}}⚠ Keycloak platform SAML descriptor not available after 5min — skipping IDC config. Run: task idc:configure{{.C_RESET}}\n'
+              printf '{{.C_ERR}}⚠ IDC skipped: Keycloak platform SAML descriptor not available after 5min. Run: task idc:configure{{.C_RESET}}\n'
             else
             printf '{{.C_INFO}}  Keycloak reachable (HTTP %s) — running IDC configuration...{{.C_RESET}}\n' "$KC_STATUS"
             if python3 {{.REPO}}/scripts/configure_identity_center.py \


### PR DESCRIPTION
Closes #856 (IDC config hardening).

## Finding
The current `idc:configure` task **already** implements the core of #856's Idea #1 + #3: it waits on the **platform SAML descriptor** (HTTP 200, context-free) — not ArgoCD app health — and **skips with a visible ⚠** at each gate (empty DNS, master realm unreachable, descriptor missing). So the 'wait on the real signal' concern was already satisfied (better than the `keycloak-clients` secret proxy).

## Changes
1. **Idea #2 — kill the 30-min hang.** `configure_identity_center.py` re-waited **1800s** on the same descriptor internally. Reduced to **300s** (the caller already gated on HTTP 200 → descriptor is up; fail fast otherwise).
2. **Idea #3 (log) — greppable skips.** Aligned every IDC skip to a consistent `⚠ IDC skipped: <reason>` marker so deep-validation heuristics can catch a silently-unconfigured IDC/SCIM (missing Identity Center users).

## Intentionally NOT done
- **`kubectl wait secret/keycloak-clients`**: at `idc:configure` the hub kube-context isn't restored yet (the 'Restore hub context' step runs *after*), so a kubectl wait could hit the wrong cluster. The context-free SAML HTTP wait is the correct signal. (The realm-config Job does create that K8s secret in ns `keycloak` — confirmed in `keycloak-config.yaml` — but it's not the right gate here.)
- **Surfacing the skip in the CFN `InitScriptStatus`**: cross-repo (the SSM SetupIDE flow in platform-engineering-on-eks reads pipefail exit; the IDC skip is intentionally non-fatal). Tracked as a follow-up.