### PR TITLE
fix(kro): gate extraArgs trigger a new Rollout on sync (GitLab #36)

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
@@ -421,6 +421,13 @@ spec:
                 app: ${schema.metadata.name}
               annotations:
                 replicas: "${string(schema.spec.replicas)}"
+                # Gate args live in the pod-template annotations so that changing
+                # functionalGate/performanceGate.extraArgs alters the Rollout pod spec
+                # (new pod-template hash) -> Argo Rollouts creates a new revision and
+                # re-runs the analysis on `argocd app sync`, with no manual
+                # `kubectl argo rollouts retry/restart` (mirrors KubeVela publishVersion). See GitLab #36.
+                appmod.io/functional-gate-args: "${schema.spec.functionalGate.extraArgs}"
+                appmod.io/performance-gate-args: "${schema.spec.performanceGate.extraArgs}"
             spec:
               serviceAccountName: ${serviceaccountWithDynamoDB.metadata.name}
               containers:
@@ -487,6 +494,13 @@ spec:
                 app: ${schema.metadata.name}
               annotations:
                 replicas: "${string(schema.spec.replicas)}"
+                # Gate args live in the pod-template annotations so that changing
+                # functionalGate/performanceGate.extraArgs alters the Rollout pod spec
+                # (new pod-template hash) -> Argo Rollouts creates a new revision and
+                # re-runs the analysis on `argocd app sync`, with no manual
+                # `kubectl argo rollouts retry/restart` (mirrors KubeVela publishVersion). See GitLab #36.
+                appmod.io/functional-gate-args: "${schema.spec.functionalGate.extraArgs}"
+                appmod.io/performance-gate-args: "${schema.spec.performanceGate.extraArgs}"
             spec:
               serviceAccountName: ${serviceaccountWithoutDynamoDB.metadata.name}
               containers:


### PR DESCRIPTION
## Problem (GitLab #36 — reported by Carlos Santana)
On the **kro path** (Module 3 `30_function-performance-test-java`), changing only `functionalGate.extraArgs` / `performanceGate.extraArgs` on the `AppmodService` + `argocd app sync` does **not** trigger a new Argo Rollout, so the analysis never re-runs — participants appear stuck until they manually `kubectl argo rollouts retry rollout …`.

**Root cause:** in the RGD `appmod-service.yaml`, `extraArgs` is injected only into the `AnalysisTemplate`, never the Rollout pod template. Changing only `extraArgs` leaves `spec.template` byte-identical → Argo Rollouts detects no change → no new revision. (KubeVela avoids this by bumping `app.oam.dev/publishVersion`; the kro `AppmodService` had no equivalent.)

## Fix (option 2 — RGD, preferred)
Inject both gate args as **pod-template annotations** on the two gate-enabled Rollout variants (`rolloutWithGatesAndDynamoDB`, `rolloutWithGatesWithoutDynamoDB`):
```yaml
spec:
  template:
    metadata:
      annotations:
        appmod.io/functional-gate-args: "${schema.spec.functionalGate.extraArgs}"
        appmod.io/performance-gate-args: "${schema.spec.performanceGate.extraArgs}"
```
Any `extraArgs` change now alters the pod-template hash → Argo Rollouts creates a new revision → the gates re-run on `argocd app sync`, **no manual `retry/restart`**. Static keys + CEL values (no kro#1388 annotation-key limitation). Non-gate Rollout variants are untouched.

## Follow-up (content, separate repo)
Once this lands, the manual `kubectl argo rollouts retry` step in the kro tab of `30_function-performance-test-java` becomes unnecessary and can be simplified (keep the `get rollout … -w` watch).