### PR TITLE
fix(install): run hub:create-mgmt-roles before hub:claim (ACK IAM prerequisite)

### DIFF
--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -152,6 +152,15 @@ tasks:
       - task: kro:install-cluster-secret-store-bootstrap
       - task: kro:apply-rgds
       - task: hub:wait-for-domain
+      # Create the cluster-mgmt IAM roles BEFORE hub:claim.
+      # The eksclusterwithvpc RGD immediately tries to create ACK-managed IAM resources
+      # (cniMetricsHelperPolicy, adotCollectorPolicy, etc.) when KRO reconciles the claim.
+      # ACK EKS Capability assumes the peeks-cluster-mgmt-iam role (created here) to create
+      # those AWS IAM resources. Without these roles, ACK cannot reconcile the Policy CRs and
+      # KRO stays stuck reporting:
+      #   "cniMetricsHelperPolicy.status.ackResourceMetadata.arn: no such key: arn (data pending)"
+      # Running this before hub:claim ensures the roles exist when ACK first processes the CRs.
+      - task: hub:create-mgmt-roles
       - task: hub:claim
       - task: hub:wait-for-eks
       - task: hub:authorize-ide-access
@@ -2210,7 +2219,7 @@ tasks:
     desc: Create cluster-mgmt IAM roles assumed by ACK controllers (single-account prereq)
     vars:
       ACK_CAPABILITY_ROLE:
-        sh: aws eks describe-capability --cluster-name {{.HUB_CLUSTER_NAME}} --capability-name ack --region {{.AWS_REGION}} --query 'capability.roleArn' --output text 2>/dev/null | sed 's|.*/||' || echo "{{.HUB_CLUSTER_NAME}}-argocd-capability-role"
+        sh: aws eks describe-capability --cluster-name {{.HUB_CLUSTER_NAME}} --capability-name ack --region {{.AWS_REGION}} --query 'capability.roleArn' --output text 2>/dev/null | sed 's|.*/||' || echo "{{.HUB_CLUSTER_NAME}}-ack-capability-role"
     cmds:
       - printf '{{.C_STEP}}▸ Creating cluster-mgmt IAM roles for ACK...{{.C_RESET}}\n'
       - |


### PR DESCRIPTION
## Problem

`task install` fails at `hub:wait-for-eks` after ~40 min with:
```
cniMetricsHelperPolicy.status.ackResourceMetadata.arn: no such key: arn (data pending)
```

**Root cause**: The `eksclusterwithvpc` RGD immediately creates ACK-managed IAM resources (Policy, Role, PodIdentityAssociation for cni-metrics-helper, adot-collector etc.) when KRO starts reconciling the claim. ACK EKS Capability assumes the `peeks-cluster-mgmt-iam` role (created by `hub:create-mgmt-roles`) to create those AWS resources. But `hub:create-mgmt-roles` was called inside `hub:seed`, which runs **after** `hub:wait-for-eks`. Without the cluster-mgmt-iam role, ACK cannot create `cniMetricsHelperPolicy`, so `.status.ackResourceMetadata.arn` stays empty, KRO cannot evaluate the expression, and the install hangs indefinitely.

Note: ACK in `kind-kro-ack` is an **EKS Capability** (runs AWS-side), not pods in the cluster.

## Fix

1. **Move `hub:create-mgmt-roles` before `hub:claim`** in the install DAG. The task is idempotent so running it twice (here + inside `hub:seed`) is safe.

2. **Fix the fallback role name** in `hub:create-mgmt-roles`: was `...-argocd-capability-role` (wrong), now `...-ack-capability-role` (correct). This fallback is used when the task runs before the hub EKS exists (`aws eks describe-capability` returns empty).

## Related
PR #835 (v0.3.0-rc3 teardown validation) — install failure observed on fresh account