### PR TITLE
fix(rg-eks): merge duplicate annotations blocks in cniMetricsHelperPolicy

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -241,6 +241,7 @@ spec:
               {"arn":"arn:aws:iam::${schema.spec.accountId}:policy/${schema.spec.aws.resourcePrefix}-${schema.spec.application.name}-ecr-policy"}
           # PRODUCTION SAFETY: add services.k8s.aws/deletion-policy: retain here to retain
           # the AWS policy when deleting this Kro instance (may be referenced by other resources)
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
           ownerReferences:
              - apiVersion: kro.run/v1alpha1
                kind: ${schema.kind}
@@ -248,8 +249,6 @@ spec:
                uid: ${schema.metadata.uid}
                blockOwnerDeletion: true
                controller: false
-          annotations:
-             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
        spec:
           name: ${schema.spec.aws.resourcePrefix}-${schema.spec.application.name}-ecr-policy
           description: ECR access policy for CI/CD pipeline

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
@@ -1941,6 +1941,8 @@ spec:
               {"arn":"arn:aws:iam::${schema.spec.accountId}:policy/${schema.spec.name}-cni-metrics-helper-policy"}
             # PRODUCTION SAFETY: add services.k8s.aws/deletion-policy: retain here to retain
             # the AWS policy when deleting this Kro instance (may be referenced by other resources)
+            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
+            services.k8s.aws/region: ${schema.spec.region}
           ownerReferences:
             - apiVersion: kro.run/v1alpha1
               kind: ${schema.kind}
@@ -1948,9 +1950,6 @@ spec:
               uid: ${schema.metadata.uid}
               blockOwnerDeletion: true
               controller: false
-          annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
-            services.k8s.aws/region: ${schema.spec.region}
         spec:
           name: "${schema.spec.name}-cni-metrics-helper-policy"
           description: "Policy to allow cni metrics helper put metrics to CloudWatch"


### PR DESCRIPTION
## Problem

`cniMetricsHelperPolicy` resource in `rg-eks.yaml` had two separate `annotations:` blocks in the same `metadata` section, separated by `ownerReferences`:

```yaml
metadata:
  annotations:
    services.k8s.aws/adoption-policy: adopt-or-create  # FIRST
    services.k8s.aws/adoption-fields: ...
  ownerReferences: ...
  annotations:                                          # SECOND - overwrites first!
    argocd.argoproj.io/tracking-id: ...
    services.k8s.aws/region: ...
```

YAML merge semantics mean the second block silently overwrites the first, so `adoption-policy: adopt-or-create` was never applied to the CR.

**Consequence on reused accounts**: ACK received a Policy CR without adoption annotation, failed with `EntityAlreadyExists` (policy from a previous run still present), never populated `.status.ackResourceMetadata.arn`, causing KRO to report:
```
cniMetricsHelperPolicy.status.ackResourceMetadata.arn: no such key: arn (data pending)
```
This caused `task install` to hang indefinitely at `hub:wait-for-eks`.

**Consequence on fresh accounts**: adopt-or-create has no effect on first install since the policy doesn't exist yet, but on any re-run the policy is orphaned.

## Fix

Merged both annotation blocks into a single block with all four keys. One-line change.

## Related

PR #835 (v0.3.0-rc3 teardown validation) — discovered during install testing on reused account kro-c1.