### PR TITLE
fix(kro): cicd-pipeline RGD — spec.aws.accountId (was spec.accountId), unblocks CI/CD

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -238,7 +238,7 @@ spec:
           annotations:
             services.k8s.aws/adoption-policy: adopt-or-create
             services.k8s.aws/adoption-fields: |
-              {"arn":"arn:aws:iam::${schema.spec.accountId}:policy/${schema.spec.aws.resourcePrefix}-${schema.spec.application.name}-ecr-policy"}
+              {"arn":"arn:aws:iam::${schema.spec.aws.accountId}:policy/${schema.spec.aws.resourcePrefix}-${schema.spec.application.name}-ecr-policy"}
           # PRODUCTION SAFETY: add services.k8s.aws/deletion-policy: retain here to retain
           # the AWS policy when deleting this Kro instance (may be referenced by other resources)
             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}


### PR DESCRIPTION
## Blocker
`cicdpipeline.kro.run` RGD is **Inactive (Ready=False)** → `kro-manifests-hub` Degraded (93/94) → the CICDPipeline never reconciles (no ECR repo / no workflow / no image) → **Module 2 (Rust) & Module 3 (Java) CI/CD scaffolding broken** (and `/unicorn`, which depends on the Rust build).

## Root cause (regression)
In `gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml:241`, the ecr-policy `adoption-fields` ARN used `${schema.spec.accountId}`, but the RGD schema defines the field under `aws` (`spec.aws.accountId`, line 21). The 3 other ARNs in the file already use the correct `${schema.spec.aws.accountId}`. The undefined-field CEL expression fails RGD validation, so the whole RGD goes Inactive.

## Fix (one line)
`${schema.spec.accountId}` → `${schema.spec.aws.accountId}`. Verified: 0 remaining `schema.spec.accountId`, YAML valid.

Applied via ArgoCD (`kro-manifests-hub`, targetRevision=branch) → once merged + synced, the RGD re-activates on the running event (no redeploy needed).