### PR TITLE
fix(kro-ack): participant adminRoleName + drop pod-identity-agent addon on Auto Mode

### DIFF
--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -64,7 +64,7 @@ vars:
   INGRESS_CERT_ARN:
     sh: yq '.certificateArn // ""' {{.CONFIG_FILE}}
   ADMIN_ROLE_NAME:
-    sh: yq '.hub.adminRoleName // "Admin"' {{.CONFIG_FILE}}
+    sh: yq '.hub.adminRoleName // .adminRoleName // "Admin"' {{.CONFIG_FILE}}
   CAPABILITY_NAME:
     sh: yq '.argocdCapability.name // "argocd"' {{.CONFIG_FILE}}
   IDC_INSTANCE_ARN:

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
@@ -386,29 +386,14 @@ spec:
             tenant: ${schema.spec.tenant}
             environment: ${schema.spec.environment}
 
-    - id: podIdentityAddon
-      template:
-        apiVersion: eks.services.k8s.aws/v1alpha1
-        kind: Addon
-        metadata:
-          name: eks-pod-identity-agent
-          namespace: "${schema.spec.name}"
-          ownerReferences:
-            - apiVersion: kro.run/v1alpha1
-              kind: ${schema.kind}
-              name: ${schema.metadata.name}
-              uid: ${schema.metadata.uid}
-              blockOwnerDeletion: true
-              controller: false
-          annotations:
-            argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
-            clusterArn: "${ekscluster.status.ackResourceMetadata.arn}"
-            services.k8s.aws/region: ${schema.spec.region}
-            services.k8s.aws/adoption-policy: adopt-or-create
-        spec:
-          name: eks-pod-identity-agent
-          addonVersion: v1.3.4-eksbuild.1
-          clusterName: "${schema.spec.name}"
+    # NOTE: The eks-pod-identity-agent Addon node was intentionally removed.
+    # Every cluster provisioned by this RGD runs in EKS Auto Mode
+    # (compute.enabled=true), where the Pod Identity Agent is built into the
+    # managed nodes and cannot be installed as a self-managed addon. Applying it
+    # fails with "InvalidParameterException: Addon version specified is not
+    # supported" and leaves the resource ACK.ResourceSynced=Unknown, which held
+    # the whole EksCluster instance in IN_PROGRESS. The PodIdentityAssociation
+    # nodes below work without this addon in Auto Mode.
 
     ###########################################################
     # IAM OIDC provider (IRSA) — created in the spoke's OWN account
@@ -476,8 +461,7 @@ spec:
             services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
             #force dependency on ekscluster
             eksclusterArn: "${ekscluster.status.ackResourceMetadata.arn}"
-            #force dependency on podIdentityAddon so that we create argo cluster secret after podIdentity correctly configured
-            # Pod Identity enabled by default in EKS Auto Mode
+            # Pod Identity is enabled by default in EKS Auto Mode (no addon needed).
         spec:
           name: "${schema.spec.name}-argocd-role"
           assumeRolePolicyDocument: |

--- a/workshop/create-config.sh
+++ b/workshop/create-config.sh
@@ -286,6 +286,7 @@ if [ -n "${HUB_VPC_ID:-}" ] && [ -n "${HUB_SUBNET_IDS:-}" ]; then
   SUBNET3=$(echo "$SUBNETS" | sed -n '3p')
   printf 'hub:\n'                                      >> "$OUTPUT_FILE"
   printf '  clusterName: "%s-hub"\n' "$RESOURCE_PREFIX" >> "$OUTPUT_FILE"
+  printf '  adminRoleName: "%s"\n' "$ADMIN_ROLE_NAME"   >> "$OUTPUT_FILE"
   printf '  kubernetesVersion: "%s"\n' "$K8S_VERSION"  >> "$OUTPUT_FILE"
   printf '  autoMode: true\n'                          >> "$OUTPUT_FILE"
   printf '  network:\n'                                >> "$OUTPUT_FILE"
@@ -299,6 +300,7 @@ if [ -n "${HUB_VPC_ID:-}" ] && [ -n "${HUB_SUBNET_IDS:-}" ]; then
 else
   printf 'hub:\n'                                      >> "$OUTPUT_FILE"
   printf '  clusterName: "%s-hub"\n' "$RESOURCE_PREFIX" >> "$OUTPUT_FILE"
+  printf '  adminRoleName: "%s"\n' "$ADMIN_ROLE_NAME"   >> "$OUTPUT_FILE"
   printf '  kubernetesVersion: "%s"\n' "$K8S_VERSION"  >> "$OUTPUT_FILE"
   printf '  vpcCidr: "%s"\n'      "$VPC_CIDR"          >> "$OUTPUT_FILE"
   printf '  autoMode: true\n'                          >> "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary

Fixes two independent, non-IAM defects found while validating a fresh Workshop Studio **kind-kro-ack** deploy. Both left the hub `ekscluster/<prefix>-hub` stuck in `IN_PROGRESS` (its `podIdentityAddon` / admin `AccessEntry` sub-resources never reached `ACK.ResourceSynced=True`), which timed out `kind-kro-ack:hub:wait-for-eks` → `task install` **exit 201**.

Discovered on event `5f1aa6a6` (account 242671986717): the EKS cluster itself reached `ACTIVE`, but the kro graph never became `Ready` because of these two sub-resources.

## 1. Admin `AccessEntry` used a non-existent `role/Admin`

`accessEntryAdmin` builds `principalARN: …:role/${schema.spec.adminRoleName}`. On Workshop Studio the admin role is **`WSParticipantRole`**, not `Admin`, so EKS rejected it with `InvalidParameterException: The specified principalArn is invalid: invalid principal.`

Root cause: `workshop/create-config.sh` already derives the participant role from `WS_PARTICIPANT_ROLE_ARN` (falling back to `WSParticipantRole`) and writes it as **top-level** `adminRoleName`, but the kind-kro-ack Taskfile only reads `.hub.adminRoleName`, so it fell back to `"Admin"`.

**Fix:**
- `create-config.sh`: also write `adminRoleName` under the `hub:` block (both VPC and non-VPC branches).
- `cluster-providers/kind-kro-ack/Taskfile.yaml`: `.hub.adminRoleName // .adminRoleName // "Admin"` (use the correctly-detected top-level value as a robust fallback).

## 2. `eks-pod-identity-agent` addon unsupported on EKS Auto Mode

The RGD pinned `addonVersion: v1.3.4-eksbuild.1`. All clusters here run **EKS Auto Mode** (`compute.enabled=true`), where the Pod Identity Agent is built into the managed nodes and cannot be installed as a self-managed addon → `InvalidParameterException: Addon version specified is not supported`.

**Fix:** remove the `podIdentityAddon` node (no active dependents). `PodIdentityAssociation`s continue to work in Auto Mode.

## Validation

- `bash -n workshop/create-config.sh` ✓
- `yq` parses the RGD (40 → 39 resources) and the Taskfile ✓
- Live on event `5f1aa6a6`: after correcting the admin role and removing the addon path, the remaining ACK resources reconcile and `ekscluster/peeks-hub` reaches `ACTIVE`/`Ready=True`.

> Note: the companion least-privilege SharedRole fix (adding `iam:ListRoleTags`, `iam:ListOpenIDConnectProviderTags`, `secretsmanager:ListSecrets`) lives in the **platform-engineering-on-eks** CDK, not here.
