### PR TITLE
fix(logs): make enable-capability-logs idempotent on reused accounts

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -209,6 +209,24 @@ tasks:
           LG="/aws/eks/$C/capability/$CAP"; LG_ARN="arn:aws:logs:$REGION:$ACCT:log-group:$LG"
           aws logs create-log-group --log-group-name "$LG" --region "$REGION" 2>/dev/null || true
           aws logs put-retention-policy --log-group-name "$LG" --retention-in-days 30 --region "$REGION" >/dev/null 2>&1 || true
+          # put-delivery-source is NOT idempotent across cluster re-creation. On a REUSED
+          # account a delivery source named "$C-$CAP" can survive from a prior cluster
+          # incarnation, still pointing at the OLD capability ARN. CloudWatch then rejects
+          # the update to the new ARN with a hard error ("Update to existing Delivery Source
+          # with new ResourceId is not allowed. Please create a new Delivery Source
+          # instead."), which aborts the whole `task install` (and, in the workshop consumer
+          # flow, everything after it: overlay wiring, spokes, IDC). Reconcile first: if a
+          # stale source points elsewhere, delete its dependent delivery + the source, then
+          # (re)create. Same/absent ARN -> put is a no-op create.
+          EXISTING_SRC_ARN=$(aws logs describe-delivery-sources --region "$REGION" --query "deliverySources[?name=='$C-$CAP'].resourceArns[0] | [0]" --output text 2>/dev/null || echo "None")
+          if [ -n "$EXISTING_SRC_ARN" ] && [ "$EXISTING_SRC_ARN" != "None" ] && [ "$EXISTING_SRC_ARN" != "$CAP_ARN" ]; then
+            echo "  $C: stale '$CAP' delivery source ($EXISTING_SRC_ARN) — recreating for $CAP_ARN"
+            # A delivery source cannot be deleted while a delivery references it — delete the delivery first.
+            for D in $(aws logs describe-deliveries --region "$REGION" --query "deliveries[?deliverySourceName=='$C-$CAP'].id" --output text 2>/dev/null); do
+              [ -n "$D" ] && [ "$D" != "None" ] && aws logs delete-delivery --id "$D" --region "$REGION" >/dev/null 2>&1 || true
+            done
+            aws logs delete-delivery-source --name "$C-$CAP" --region "$REGION" >/dev/null 2>&1 || true
+          fi
           aws logs put-delivery-source --name "$C-$CAP" --resource-arn "$CAP_ARN" --log-type "$LOGTYPE" --region "$REGION" >/dev/null
           aws logs put-delivery-destination --name "$C-$CAP-cwl" --delivery-destination-configuration "destinationResourceArn=$LG_ARN" --region "$REGION" >/dev/null
           DEST_ARN=$(aws logs describe-delivery-destinations --region "$REGION" --query "deliveryDestinations[?name=='$C-$CAP-cwl'].arn | [0]" --output text)


### PR DESCRIPTION
## Problem

`enable-capability-logs` (called by `task install`) runs `aws logs put-delivery-source --name "<cluster>-<cap>" --resource-arn <cap-arn>`. `put-delivery-source` is **not idempotent across cluster re-creation**: if a delivery source of that name already exists pointing at a **different** resource ARN, CloudWatch rejects it with a hard error:

```
ConflictException: Update to existing Delivery Source with new ResourceId is not allowed.
Please create a new Delivery Source instead.
```

This is exactly the situation on a **reused AWS account**, where a prior `peeks-hub` incarnation left a stale `peeks-hub-kro` delivery source pointing at the old cluster's capability ARN.

### Blast radius (why this is more than a logs nuisance)

`enable-capability-logs` runs inside the base `task install`, which the workshop consumer invokes as `cd .platform && task install` at the **head** of `workshop:install`. The `ConflictException` makes `task install` exit non-zero, which aborts `workshop:install` **before** its subsequent steps ever run:

- `set-overlay-repo` (fleet-config overlay wiring) → never runs → overlay not wired
- `spokes:enable-*` → spokes never declared
- `post-install` → `idc:configure` skipped

Observed downstream on a reused CI account: the overlay is never wired, so `backstage`/`gitlab`/`keycloak` stay on the mixed-arch `system` nodepool instead of `system-peeks`. The amd64-only backstage image lands on an arm64 (Graviton) node → `exec /usr/local/bin/node: exec format error` → `CrashLoopBackOff` (backstage ArgoCD app `Degraded`), and the `-peeks` nodepools are never rendered. Fresh Workshop Studio accounts never hit this because there is no leftover delivery source.

## Fix

Before `put-delivery-source`, reconcile any stale delivery source: if one exists with a **different** resource ARN, delete its dependent delivery (a source can't be deleted while a delivery references it) then delete the source, and recreate. Same/absent ARN keeps `put` a no-op create. Idempotent and safe to re-run.

## Testing

- `yq` parses the Taskfile; `bash -n` on the extracted `enable-capability-logs` command passes.
- Root cause reproduced on reused CI account `586794472760`: `workshop:install` log ends at `enable-capability-logs` with the `ConflictException` (`task install` exit 201), and `set-overlay-repo` produced no output; the hub cluster secret has `overlay_repo_url` unset and no `-peeks` nodepools exist.
