### PR TITLE
fix(teardown): sweep reaps AMG workspaces, CW Logs deliveries, orphan EIPs + Crossplane/spoke VPCs

### DIFF
--- a/scripts/sweep-workshop-resources.py
+++ b/scripts/sweep-workshop-resources.py
@@ -33,6 +33,7 @@ amp = boto3.client("amp", region_name=region)
 sm = boto3.client("secretsmanager", region_name=region)
 logs = boto3.client("logs", region_name=region)
 cf = boto3.client("cloudfront")
+grafana = boto3.client("grafana", region_name=region)
 
 
 def log(msg):
@@ -364,6 +365,184 @@ try:
         log("No spoke VPCs to delete")
 except Exception as e:
     log(f"Spoke VPCs: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 11. Amazon Managed Grafana (AMG) workspaces
+#     observability-aws provisions an AMG workspace via Crossplane. Once the hub
+#     is gone the Crossplane provider can't reap it (only AMP is covered above),
+#     so delete directly. Match by workspace name prefix (e.g. peeks-observability).
+# ---------------------------------------------------------------------------
+try:
+    deleted = 0
+    for ws in grafana.list_workspaces().get("workspaces", []):
+        if (ws.get("name") or "").startswith(prefix):
+            try:
+                grafana.delete_workspace(workspaceId=ws["id"])
+                log(f"  Deleted AMG workspace {ws['id']} ({ws.get('name')})")
+                deleted += 1
+            except Exception as e:
+                log(f"  AMG workspace {ws['id']}: {e}")
+    if deleted == 0:
+        log("No AMG workspaces to delete")
+except Exception as e:
+    log(f"AMG workspaces: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 12. CloudWatch Logs deliveries (EKS capability log delivery)
+#     enable-capability-logs creates delivery-source / delivery-destination /
+#     delivery IMPERATIVELY (no controller owns them), named <prefix>-*. Section 9
+#     only removes log GROUPS, so reap the delivery objects here. Order matters:
+#     a delivery-source cannot be deleted while a delivery references it.
+# ---------------------------------------------------------------------------
+try:
+    reaped = 0
+    srcs = [
+        s["name"]
+        for s in logs.describe_delivery_sources().get("deliverySources", [])
+        if s["name"].startswith(prefix)
+    ]
+    for d in logs.describe_deliveries().get("deliveries", []):
+        if d.get("deliverySourceName", "") in srcs:
+            try:
+                logs.delete_delivery(id=d["id"])
+                reaped += 1
+            except Exception:
+                pass
+    for name in srcs:
+        try:
+            logs.delete_delivery_source(name=name)
+            reaped += 1
+        except Exception as e:
+            log(f"  delivery-source {name}: {e}")
+    for dd in logs.describe_delivery_destinations().get("deliveryDestinations", []):
+        if dd["name"].startswith(prefix):
+            try:
+                logs.delete_delivery_destination(name=dd["name"])
+                reaped += 1
+            except Exception:
+                pass
+    log(f"Reaped {reaped} CloudWatch Logs delivery object(s)" if reaped else "No CW Logs deliveries to delete")
+except Exception as e:
+    log(f"CW Logs deliveries: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 13. Orphaned Elastic IPs
+#     Spoke NAT-gateway EIPs (<prefix>-spoke-*-eip*) survive when the NAT is torn
+#     down out of order — they persist UNASSOCIATED and keep billing. Release only
+#     UNASSOCIATED addresses carrying the workshop prefix in a tag value.
+# ---------------------------------------------------------------------------
+try:
+    released = 0
+    for a in ec2.describe_addresses().get("Addresses", []):
+        if a.get("AssociationId"):
+            continue  # still attached — never touch
+        tags = {t["Key"]: t["Value"] for t in a.get("Tags", [])}
+        if any(prefix in str(v) for v in tags.values()):
+            try:
+                ec2.release_address(AllocationId=a["AllocationId"])
+                log(f"  Released EIP {a.get('PublicIp')} ({tags.get('Name', '-')})")
+                released += 1
+            except Exception as e:
+                log(f"  EIP {a.get('PublicIp')}: {e}")
+    if released == 0:
+        log("No orphaned EIPs to release")
+except Exception as e:
+    log(f"Elastic IPs: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 14. Orphan VPC reaper (spoke + Crossplane) — backstop for section 10
+#     Section 10 can leave a spoke VPC behind because Auto Mode / KRO ENIs are
+#     still detaching right after cluster deletion (delete_vpc fails non-fatally).
+#     Also handles Crossplane-provisioned VPCs (tag platform.gitops.io/cluster),
+#     which section 10 does not match. Force-clears ENIs and RETRIES delete_vpc.
+#     NEVER touches a CFN-owned VPC (aws:cloudformation:* tag) — that is the IDE
+#     VPC, which CloudFormation deletes itself.
+# ---------------------------------------------------------------------------
+try:
+    def _reap_vpc(vpc_id):
+        for eni in ec2.describe_network_interfaces(
+            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+        )["NetworkInterfaces"]:
+            try:
+                ec2.delete_network_interface(NetworkInterfaceId=eni["NetworkInterfaceId"])
+            except Exception:
+                pass
+        for nat in ec2.describe_nat_gateways(
+            Filter=[{"Name": "vpc-id", "Values": [vpc_id]}]
+        ).get("NatGateways", []):
+            if nat["State"] not in ("deleted", "deleting"):
+                try:
+                    ec2.delete_nat_gateway(NatGatewayId=nat["NatGatewayId"])
+                except Exception:
+                    pass
+        for igw in ec2.describe_internet_gateways(
+            Filters=[{"Name": "attachment.vpc-id", "Values": [vpc_id]}]
+        )["InternetGateways"]:
+            try:
+                ec2.detach_internet_gateway(InternetGatewayId=igw["InternetGatewayId"], VpcId=vpc_id)
+                ec2.delete_internet_gateway(InternetGatewayId=igw["InternetGatewayId"])
+            except Exception:
+                pass
+        for sn in ec2.describe_subnets(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])["Subnets"]:
+            try:
+                ec2.delete_subnet(SubnetId=sn["SubnetId"])
+            except Exception:
+                pass
+        for rt in ec2.describe_route_tables(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])["RouteTables"]:
+            if any(a.get("Main", False) for a in rt.get("Associations", [])):
+                continue
+            for a in rt.get("Associations", []):
+                if a.get("RouteTableAssociationId") and not a.get("Main", False):
+                    try:
+                        ec2.disassociate_route_table(AssociationId=a["RouteTableAssociationId"])
+                    except Exception:
+                        pass
+            try:
+                ec2.delete_route_table(RouteTableId=rt["RouteTableId"])
+            except Exception:
+                pass
+        for sg in ec2.describe_security_groups(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])["SecurityGroups"]:
+            if sg["GroupName"] == "default":
+                continue
+            try:
+                ec2.delete_security_group(GroupId=sg["GroupId"])
+            except Exception:
+                pass
+        for attempt in range(6):  # retry while ENIs finish detaching (~2 min)
+            try:
+                ec2.delete_vpc(VpcId=vpc_id)
+                log(f"  Deleted orphan VPC {vpc_id}")
+                return
+            except Exception as e:
+                if attempt == 5:
+                    log(f"  Orphan VPC {vpc_id}: {e}")
+                else:
+                    time.sleep(20)
+
+    seen, targets = set(), []
+    for flt in (
+        {"Name": "tag:eks:kubernetes-resource-name",
+         "Values": [f"{prefix}-spoke-dev-vpc", f"{prefix}-spoke-prod-vpc"]},
+        {"Name": "tag:Name", "Values": [f"{prefix}-spoke-*-vpc"]},
+        {"Name": "tag:platform.gitops.io/cluster", "Values": [hub, f"{prefix}-spoke-*"]},
+    ):
+        for v in ec2.describe_vpcs(Filters=[flt]).get("Vpcs", []):
+            if v["VpcId"] in seen:
+                continue
+            if any(t["Key"].startswith("aws:cloudformation:") for t in v.get("Tags", [])):
+                continue  # CFN-owned (IDE VPC) — leave it to CloudFormation
+            seen.add(v["VpcId"])
+            targets.append(v["VpcId"])
+    for vpc_id in targets:
+        _reap_vpc(vpc_id)
+    if not targets:
+        log("No orphan spoke/Crossplane VPCs to reap")
+except Exception as e:
+    log(f"Orphan VPC reaper: {e}")
 
 
 log("Extended sweep complete.")


### PR DESCRIPTION
## Problem

The extended teardown sweep (`sweep-workshop-resources.py`, run by the `ClustersStackDeploy` CodeBuild on CFN stack delete) is scoped to clearing **IDE-VPC ENI blockers** + AMP. On a reused account, several resource classes leak because the controllers that own them (KRO/ACK/Crossplane on the hub) are torn down **before** they finish reaping:

- **AMG (Grafana) workspaces** — only AMP was swept (§5); the `observability-aws` AMG workspace persisted `ACTIVE` (billable).
- **CloudWatch Logs delivery** source/destination/delivery — created **imperatively** by `enable-capability-logs` (no controller owns them); §9 only removed log **groups**, so `<prefix>-hub-<cap>` delivery objects leaked.
- **Unassociated Elastic IPs** — spoke NAT EIPs kept billing after VPC teardown.
- **Crossplane-provisioned VPCs** (tag `platform.gitops.io/cluster`) — §10 only matched `eks:kubernetes-resource-name` spoke VPCs.
- **Spoke VPC delete (§10) is racy** — Auto Mode/KRO ENIs are still detaching right after cluster deletion, so `delete_vpc` fails non-fatally and the VPC is left behind.

Observed end-state after a real `taskcat-delete` on the reused CI account: stack `DELETE_FAILED` aside, these orphans remained → AMG `g-0c96d5ebc5`, delivery source `peeks-hub-kro`, 4 unattached EIPs, `peeks-spoke-dev/prod-vpc` + a Crossplane hub VPC.

## Fix

Additive — keeps §1–§10, adds:
- **§11 AMG workspaces**: delete workspaces whose name starts with the prefix.
- **§12 CW Logs deliveries**: delete deliveries → delivery-sources → delivery-destinations named `<prefix>-*` (correct order — a source can't be deleted while a delivery references it).
- **§13 orphaned EIPs**: release **unassociated** addresses carrying the prefix in a tag value (attached EIPs untouched).
- **§14 orphan VPC reaper** (spoke + Crossplane): force-clears ENIs/NAT/IGW/subnets/RTs/SGs and **retries** `delete_vpc` (~2 min) to beat the ENI-detach race; also matches Crossplane VPCs. **Never** touches a CFN-owned VPC (`aws:cloudformation:*` tag) so the IDE VPC is left to CloudFormation.

All best-effort / non-fatal (exit stays 0). Adds the `grafana` boto3 client.

## Testing
- `python3 -c "import ast; ast.parse(...)"` passes.
- The exact orphans above were reaped by hand on the CI account with the same API calls before writing this (AMG delete, delivery-source/destination/delivery delete, `release-address`, VPC dependency teardown), confirming the sequence works.

## Note
A companion fix is needed on the workshop CDK side (`platform-engineering-on-eks`): the `PEEKSClustersClusterStack` CodeBuild custom resource hung on delete (build SUCCEEDED but the resource didn't finalize → 1h timeout → `DELETE_FAILED`), and both the clusters and gitlab-common custom resources redundantly run `task destroy` via SSM. That is tracked separately.
