### PR TITLE
fix(java): official Tomcat 9 image instead of apt-get install tomcat9 (fixes Module 30 CI build 404)

### DIFF
--- a/applications/java/src/Dockerfile
+++ b/applications/java/src/Dockerfile
@@ -5,11 +5,14 @@ RUN gradle dependencies --no-daemon || true
 COPY src/ .
 RUN gradle build --no-daemon
 
-FROM public.ecr.aws/docker/library/openjdk:11.0.16-jdk
-RUN apt-get update && apt-get install -y --no-install-recommends tomcat9 tomcat9-admin libtomcat9-embed-java libtomcat9-java && \
-    rm -rf /var/lib/apt/lists/*
-WORKDIR /usr/share/tomcat9
-RUN mkdir -p webapps conf temp logs work && \
-    cp /usr/share/tomcat9/etc/* conf/
-COPY --from=BUILD /usr/app/build/libs/*.war webapps/
-CMD [ "/usr/share/tomcat9/bin/catalina.sh", "run" ]
+# Runtime: official Tomcat 9 + JDK 11 image (public ECR mirror).
+# Replaces the previous `apt-get install tomcat9` on the deprecated
+# openjdk:11.0.16-jdk (Debian bullseye) base. That approach 404s when the
+# bullseye-security mirror purges the old point-release .debs still referenced
+# by tomcat9's strict-versioned dependencies (libsystemd0, libavahi-common-data,
+# libtomcat9-embed-java) — and `apt-get update` does NOT fix it (the index lists
+# a version whose .deb is already gone from the pool). The official Tomcat image
+# ships a consistent Tomcat 9 + JDK 11 and needs no apt at all.
+FROM public.ecr.aws/docker/library/tomcat:9-jdk11
+COPY --from=BUILD /usr/app/build/libs/*.war /usr/local/tomcat/webapps/
+# CMD inherited from the base image: catalina.sh run (CATALINA_HOME=/usr/local/tomcat)


### PR DESCRIPTION
## Summary

The Java CI (kaniko) build in Module 30 fails during `apt-get install tomcat9` with 404s:

```
E: Failed to fetch .../libsystemd0_247.3-7+deb11u8_amd64.deb  404 Not Found
E: Failed to fetch .../libavahi-common-data_0.8-5+deb11u3_amd64.deb  404 Not Found
E: Failed to fetch .../libtomcat9-embed-java_9.0.118-0+deb11u1_all.deb  404 Not Found
error building image: ... exit status 100
```

This blocks all of Module 30 (Java image → dev deploy, live quality gates, Kargo). Rust builds fine in parallel, so it is java-specific, not an RGD/pipeline artifact.

## Root cause (reproduced)

`applications/java/src/Dockerfile` runtime stage runs `apt-get update && apt-get install -y tomcat9 ...` on the **deprecated** `openjdk:11.0.16-jdk` (Debian **bullseye**) base. Reproduced in the base image:

- `apt-get update` **succeeds** (fresh index).
- `apt-get install tomcat9 ...` **still 404s**: tomcat9 pulls strict-versioned deps from `debian-security bullseye-security`, and the mirror lists a point-release version whose `.deb` has already been **purged from the pool** (Debian keeps only the latest point-release).

So the common suggestion "add `apt-get update`" does **not** help — it is already there. `--fix-missing` would silently drop tomcat9 and produce a broken image.

## Fix

Replace the runtime stage with the maintained official Tomcat image and copy the WAR in — no apt:

```dockerfile
FROM public.ecr.aws/docker/library/tomcat:9-jdk11
COPY --from=BUILD /usr/app/build/libs/*.war /usr/local/tomcat/webapps/
```

- Same Tomcat 9 + JDK 11 (CATALINA_HOME=/usr/local/tomcat, JDK 11.0.32).
- WAR context unchanged (`java-app.war` → `/java-app`).
- CMD inherited (`catalina.sh run`).

## Validation

Built end-to-end on a live event IDE against the real app source:
- gradle `BUILD SUCCESSFUL`, `:war` produced
- image builds, `/usr/local/tomcat/webapps/java-app.war` present
- image pull of `public.ecr.aws/docker/library/tomcat:9-jdk11` confirmed available

functest/perftest Dockerfiles are unaffected (they use `ubuntu:latest` + `curl`/`apache2`, a consistent archive).
