### PR TITLE
fix(java): official Tomcat 9 image (backport to v0.2.18 — fixes Module 30 CI build 404)

### DIFF
--- a/applications/java/src/Dockerfile
+++ b/applications/java/src/Dockerfile
@@ -5,11 +5,14 @@ RUN gradle dependencies --no-daemon || true
 COPY src/ .
 RUN gradle build --no-daemon
 
-FROM public.ecr.aws/docker/library/openjdk:11.0.16-jdk
-RUN apt-get update && apt-get install -y --no-install-recommends tomcat9 tomcat9-admin libtomcat9-embed-java libtomcat9-java && \
-    rm -rf /var/lib/apt/lists/*
-WORKDIR /usr/share/tomcat9
-RUN mkdir -p webapps conf temp logs work && \
-    cp /usr/share/tomcat9/etc/* conf/
-COPY --from=BUILD /usr/app/build/libs/*.war webapps/
-CMD [ "/usr/share/tomcat9/bin/catalina.sh", "run" ]
+# Runtime: official Tomcat 9 + JDK 11 image (public ECR mirror).
+# Replaces the previous `apt-get install tomcat9` on the deprecated
+# openjdk:11.0.16-jdk (Debian bullseye) base. That approach 404s when the
+# bullseye-security mirror purges the old point-release .debs still referenced
+# by tomcat9's strict-versioned dependencies (libsystemd0, libavahi-common-data,
+# libtomcat9-embed-java) — and `apt-get update` does NOT fix it (the index lists
+# a version whose .deb is already gone from the pool). The official Tomcat image
+# ships a consistent Tomcat 9 + JDK 11 and needs no apt at all.
+FROM public.ecr.aws/docker/library/tomcat:9-jdk11
+COPY --from=BUILD /usr/app/build/libs/*.war /usr/local/tomcat/webapps/
+# CMD inherited from the base image: catalina.sh run (CATALINA_HOME=/usr/local/tomcat)


### PR DESCRIPTION
## Summary

Backport of the Java Dockerfile fix to the **v0.2.x** maintenance line, to cut **v0.2.18** (= v0.2.17 + this fix). The Java CI build is broken on the published **v0.2.17** exactly as on the 0.3 line.

## Bug (present on v0.2.17)

`applications/java/src/Dockerfile` runtime stage runs `apt-get update && apt-get install -y tomcat9 ...` on the deprecated `openjdk:11.0.16-jdk` (Debian **bullseye**). The kaniko build fails with 404s:

```
E: Failed to fetch .../libsystemd0_247.3-7+deb11u8_amd64.deb  404 Not Found
E: Failed to fetch .../libtomcat9-embed-java_9.0.118-0+deb11u1_all.deb  404 Not Found
```

Reproduced: `apt-get update` **succeeds** but the install still 404s — `bullseye-security` lists point-release versions whose `.deb` files have been purged from the pool (tomcat9's strict-versioned deps). Adding `apt-get update` does not help (already present); `--fix-missing` would drop tomcat9.

## Fix

Replace the runtime stage with the maintained official Tomcat image (no apt):

```dockerfile
FROM public.ecr.aws/docker/library/tomcat:9-jdk11
COPY --from=BUILD /usr/app/build/libs/*.war /usr/local/tomcat/webapps/
```

Same Tomcat 9 + JDK 11; WAR context unchanged (`java-app.war`); CMD inherited. Cherry-pick of the fix already merged to `release/v0.3.0-rc3` (PR #867), validated end-to-end there (gradle build + image build + WAR present).

## After merge

Tag **v0.2.18** from `release/v0.2.18`; the workshop repo will bump `WORKSHOP_GIT_BRANCH` to v0.2.18.
