### PR TITLE
fix(spoke): unblock <cluster>/config secret on reused accounts (scheduled-for-deletion + ACK adoption)

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
@@ -665,6 +665,7 @@ spec:
           annotations:
             services.k8s.aws/region: ${schema.spec.managementRegion}
             services.k8s.aws/owner-account-id: "${schema.spec.accountId}"
+            services.k8s.aws/adoption-policy: adopt-or-create
           ownerReferences:
             - apiVersion: kro.run/v1alpha1
               kind: ${schema.kind}
@@ -724,6 +725,7 @@ spec:
           annotations:
             services.k8s.aws/region: ${schema.spec.managementRegion}
             services.k8s.aws/owner-account-id: "${schema.spec.accountId}"
+            services.k8s.aws/adoption-policy: adopt-or-create
           ownerReferences:
             - apiVersion: kro.run/v1alpha1
               kind: ${schema.kind}

--- a/scripts/sweep-workshop-resources.py
+++ b/scripts/sweep-workshop-resources.py
@@ -257,11 +257,25 @@ except Exception as e:
 #    Workshop secrets (peeks/*) that may survive task destroy.
 # ---------------------------------------------------------------------------
 try:
-    for s in sm.list_secrets(Filters=[{"Key": "name", "Values": [prefix]}])["SecretList"]:
-        try:
-            sm.delete_secret(SecretId=s["ARN"], ForceDeleteWithoutRecovery=True)
-        except Exception:
-            pass
+    # IncludePlannedDeletion=True is critical: a secret already SCHEDULED for
+    # deletion (from a prior teardown that used the default recovery window — e.g.
+    # the ACK-managed <cluster>/config secrets) is INVISIBLE to a normal
+    # list_secrets, yet its name stays reserved for the whole recovery window and
+    # blocks the next deploy's CreateSecret ("a secret with this name is already
+    # scheduled for deletion"). Force-delete active AND scheduled ones so redeploys
+    # on a reused account are not blocked.
+    _reaped = 0
+    for _page in sm.get_paginator("list_secrets").paginate(
+        IncludePlannedDeletion=True,
+        Filters=[{"Key": "name", "Values": [prefix]}],
+    ):
+        for s in _page.get("SecretList", []):
+            try:
+                sm.delete_secret(SecretId=s["ARN"], ForceDeleteWithoutRecovery=True)
+                _reaped += 1
+            except Exception:
+                pass
+    log(f"Secrets Manager: force-deleted {_reaped} secret(s) (incl. scheduled-for-deletion)")
 except Exception as e:
     log(f"Secrets Manager: {e}")
 


### PR DESCRIPTION
## Problem

On a **reused account**, a redeploy's spoke cluster gets stuck. The ACK `secretsmanager/Secret` node `clusterConfigSecret`/`clusterConfigSecretFleet` (which creates the `<cluster>/config` secret in Secrets Manager) fails:

```
ACK.Recoverable: InvalidRequestException: You can't create this secret because a secret
with this name is already scheduled for deletion.
ACK.ResourceSynced=Unknown
```

Because that SM secret is never created:
- the **`EksCluster` kro instance stays `IN_PROGRESS`** (`readyWhen` on `clusterConfigSecretFleet.status ... ACK.ResourceSynced == True` never satisfied), and
- the hub's **`fleet-secret-<spoke>` ExternalSecret** stays `SecretSyncedError` → the fleet-secret ArgoCD app is `Degraded` and the spoke is never registered.

### Root cause
1. A prior teardown deleted `<cluster>/config` **with the default recovery window** (not force-delete), so the name stays reserved for ~30 days.
2. The ACK Secret template has **no `adoption-policy`** (create-only), so it can't reconcile onto an existing name — it always tries `CreateSecret`, which collides.

## Fixes
1. **`scripts/sweep-workshop-resources.py` (§8)** — list with `IncludePlannedDeletion=True` (paginated) and force-delete **active AND already-scheduled-for-deletion** `<prefix>*` secrets. A normal `list_secrets` hides scheduled-for-deletion secrets, so the sweep previously left them to block the next deploy; force-deleting frees the name.
2. **`rg-eks.yaml`** — add `services.k8s.aws/adoption-policy: adopt-or-create` to the `clusterConfigSecret` and `clusterConfigSecretFleet` ACK Secret templates, so a redeploy that finds an existing (active) secret **adopts** it instead of failing to create.

## Testing
Verified on kro-c1: `peeks-spoke-{dev,prod}/config` were scheduled-for-deletion (2026-09-01). Force-deleting them + recreating the ACK CRs synced the secrets, flipped **both `EksCluster` instances to `ACTIVE`** and the **`fleet-secret-peeks-spoke-{dev,prod}` apps to `Synced/Healthy`**. Python `ast.parse` + YAML load pass.
