### PR TITLE
fix(kro): flag-drive deletion-policy (default delete) + adopt-or-create on PIAs/Capabilities

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
@@ -216,6 +216,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
+            services.k8s.aws/adoption-policy: adopt-or-create
             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
         spec:
           clusterName: ${schema.spec.clusterName}

--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -357,6 +357,7 @@ spec:
                blockOwnerDeletion: true
                controller: false
           annotations:
+             services.k8s.aws/adoption-policy: adopt-or-create
              argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
              # Implicit dependencies through template references
              roleArn: ${iamrole.status.ackResourceMetadata.arn}

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
@@ -962,6 +962,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
             argocd.argoproj.io/sync-options: Prune=false
         spec:
@@ -1102,7 +1103,7 @@ spec:
             # PodIdentityAssociation (bootstrap/prior run); adopt it instead of a bare
             # Create that would 409. retain keeps it on prune (never de-auth a controller).
             services.k8s.aws/adoption-policy: adopt-or-create
-            services.k8s.aws/deletion-policy: retain
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
         spec:
           clusterName: "${ekscluster.spec.name}"
           namespace: external-secrets
@@ -1706,7 +1707,7 @@ spec:
             # its roleARN to the unified crossplane-provider role. retain keeps the live
             # association on prune so a running provider is never de-authenticated.
             services.k8s.aws/adoption-policy: adopt-or-create
-            services.k8s.aws/deletion-policy: retain
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
         spec:
           clusterName: "${ekscluster.spec.name}"
           namespace: crossplane-system
@@ -1742,7 +1743,7 @@ spec:
             # its roleARN to the unified crossplane-provider role. retain keeps the live
             # association on prune so a running provider is never de-authenticated.
             services.k8s.aws/adoption-policy: adopt-or-create
-            services.k8s.aws/deletion-policy: retain
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
         spec:
           clusterName: "${ekscluster.spec.name}"
           namespace: crossplane-system
@@ -1819,7 +1820,7 @@ spec:
             # adopt-or-create by default: adopt any live association on this SA instead
             # of a bare Create that would 409; retain keeps it on prune.
             services.k8s.aws/adoption-policy: adopt-or-create
-            services.k8s.aws/deletion-policy: retain
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
         spec:
           clusterName: "${ekscluster.spec.name}"
           namespace: "${schema.spec.addons.adot_collector_namespace}"
@@ -1900,7 +1901,7 @@ spec:
             # adopt-or-create by default: adopt any live association on this SA instead
             # of a bare Create that would 409; retain keeps it on prune.
             services.k8s.aws/adoption-policy: adopt-or-create
-            services.k8s.aws/deletion-policy: retain
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
         spec:
           clusterName: "${ekscluster.spec.name}"
           namespace: kyverno
@@ -2019,7 +2020,7 @@ spec:
             # adopt-or-create by default: adopt any live association on this SA instead
             # of a bare Create that would 409; retain keeps it on prune.
             services.k8s.aws/adoption-policy: adopt-or-create
-            services.k8s.aws/deletion-policy: retain
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
         spec:
           clusterName: "${ekscluster.spec.name}"
           namespace: kube-system
@@ -2099,7 +2100,7 @@ spec:
             # adopt-or-create by default: adopt any live association on this SA instead
             # of a bare Create that would 409; retain keeps it on prune.
             services.k8s.aws/adoption-policy: adopt-or-create
-            services.k8s.aws/deletion-policy: retain
+            services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
         spec:
           clusterName: "${ekscluster.spec.name}"
           namespace: amazon-cloudwatch
@@ -2260,6 +2261,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
+              services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
               services.k8s.aws/region: ${schema.spec.region}
               argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
               argocd.argoproj.io/sync-options: Prune=false
@@ -2318,6 +2320,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
+              services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"
               services.k8s.aws/region: ${schema.spec.region}
               argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
               argocd.argoproj.io/sync-options: Prune=false

--- a/gitops/addons/charts/kro/resource-groups/manifests/huggingface/rg-huggingface-model.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/huggingface/rg-huggingface-model.yaml
@@ -126,6 +126,8 @@ spec:
         metadata:
           name: ${schema.metadata.name}-podidentity
           namespace: ${schema.spec.namespace}
+          annotations:
+            services.k8s.aws/adoption-policy: adopt-or-create
         spec:
           clusterName: ${schema.spec.clusterName}
           namespace: ${schema.spec.namespace}

--- a/gitops/addons/charts/kro/resource-groups/manifests/pod-identity/pod-identity.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/pod-identity/pod-identity.yaml
@@ -80,6 +80,8 @@ spec:
       kind: PodIdentityAssociation
       metadata:
         name: ${schema.spec.name}-pod-association-${schema.spec.values.piAssociation.serviceAccount}
+        annotations:
+          services.k8s.aws/adoption-policy: adopt-or-create
       spec:
         clusterName: ${schema.spec.values.aws.clusterName}
         roleARN: ${podrole.status.ackResourceMetadata.arn}


### PR DESCRIPTION
## Context
Follow-up to #872 (spoke `<cluster>/config` adoption). Same theme: **reused-account hygiene** so a teardown cleans up and a redeploy doesn't collide.

## Changes

### 1. Honor the `deletionPolicy` flag (default `delete`) — nothing RETAINs by default
- **7 PodIdentityAssociations** in `rg-eks.yaml` hardcoded `services.k8s.aws/deletion-policy: retain` → now `"${schema.spec.deletionPolicy}"` (default **delete**). They already had `adopt-or-create`, so teardown removes them and a redeploy recreates/adopts cleanly (no leftover credentials).
- **3 EKS Capabilities** (`argocd`/`ack`/`kro`) had **no** ACK deletion-policy (relied on the default) → add `services.k8s.aws/deletion-policy: "${schema.spec.deletionPolicy}"` so the flag governs them (default delete).
  - ⚠️ `deletePropagationPolicy: RETAIN` is **left unchanged**: the ACK EKS Capability CRD documents RETAIN as the **only supported value**, and it controls the capability's **managed Kubernetes resources**, not the AWS-capability lifecycle (that is the ACK `deletion-policy`).

### 2. `adopt-or-create` on the PIAs that lacked it
`appmod-service` / `cicd-pipeline` / `huggingface` / `pod-identity` PodIdentityAssociations → add `services.k8s.aws/adoption-policy: adopt-or-create` (ACK keys on clusterName+namespace+serviceAccount — **no adoption-fields** needed, verified in-tree) so a redeploy adopts a leftover association instead of failing to create.

## Not in scope (verified, deferred)
Other ACK resources missing `adopt-or-create` (S3 Bucket, ECR Repository ×2, DynamoDB Table, `externalSecretsRole`, `accessEntry`) — all identify by `spec` (no adoption-fields), safe to add in a follow-up. SecurityGroups excluded (fresh SG-ID per new VPC → no name collision).

## Testing
`yaml.safe_load_all` passes on all five RGDs.
