### PR TITLE
fix(kro): adopt-or-create on remaining spec-keyed ACK resources (follow-up to #873)

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/appmod-service.yaml
@@ -145,6 +145,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
+            services.k8s.aws/adoption-policy: adopt-or-create
             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
         spec:
           tableName: ${schema.spec.components.dynamodb.tableName}

--- a/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/cicd-pipeline/cicd-pipeline.yaml
@@ -116,6 +116,8 @@ spec:
           # This prevents accidental deletion of ECR repositories containing production container images
           # annotations:
           #   services.k8s.aws/deletion-policy: retain
+          annotations:
+            services.k8s.aws/adoption-policy: adopt-or-create
           ownerReferences:
              - apiVersion: kro.run/v1alpha1
                kind: ${schema.kind}
@@ -177,6 +179,8 @@ spec:
           # This prevents accidental deletion of ECR repositories containing cached build layers
           # annotations:
           #   services.k8s.aws/deletion-policy: retain
+          annotations:
+            services.k8s.aws/adoption-policy: adopt-or-create
           ownerReferences:
              - apiVersion: kro.run/v1alpha1
                kind: ${schema.kind}
@@ -388,6 +392,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
+            services.k8s.aws/adoption-policy: adopt-or-create
             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
             services.k8s.aws/region: ${schema.spec.aws.region}
         spec:

--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks.yaml
@@ -1034,6 +1034,7 @@ spec:
               blockOwnerDeletion: true
               controller: false
           annotations:
+            services.k8s.aws/adoption-policy: adopt-or-create
             argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
             services.k8s.aws/region: ${schema.spec.region}
         spec:

--- a/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/rg-s3-bucket.yaml
@@ -57,6 +57,7 @@ spec:
             blockOwnerDeletion: true
             controller: false
         annotations:
+          services.k8s.aws/adoption-policy: adopt-or-create
           argocd.argoproj.io/tracking-id: ${schema.metadata.?annotations["argocd.argoproj.io/tracking-id"].orValue("")}
           services.k8s.aws/region: ${schema.spec.region}
           argocd.argoproj.io/sync-options: "Ignore=true,SkipDryRunOnMissingResource=true"


### PR DESCRIPTION
## Context
Follow-up to #872 / #873 — completes **reused-account idempotency** for the spoke RGDs. #873 covered the PIAs + Capabilities + `deletion-policy` flag; this PR closes the remaining gap: ACK resources that had **no** `adopt-or-create`, so a redeploy into an account with leftovers fails at `CreateX` (name already exists) instead of adopting.

## Changes — add `services.k8s.aws/adoption-policy: adopt-or-create`
| Resource | RGD | Adopts by |
|---|---|---|
| `s3bucket` (Bucket) | `rg-s3-bucket.yaml` | `spec.name` |
| `ecrmainrepo`, `ecrcacherepo` (Repository) | `cicd-pipeline.yaml` | `spec.name` (annotations block added) |
| `dynamodbtable` (Table) | `appmod-service.yaml` | `spec.tableName` |
| `externalSecretsRole` (Role) | `rg-eks.yaml` | `spec.name` |
| `accessentry` (AccessEntry) | `cicd-pipeline.yaml` | `clusterName` + `principalARN` |

All identify by `spec` → **no `adoption-fields` needed** (same as the PIAs in #873).
`deletion-policy` is **not** touched — none of these hardcode `retain` (they already default to `delete`).

## Excluded (intentional)
SecurityGroups — a fresh VPC yields new SG IDs, so no name collision on redeploy.

## Testing
`yaml.safe_load_all` passes on all four RGDs. Adoption to be **validated empirically** on the next reused-account redeploy (as done for the PIAs).
