### PR TITLE
fix(kro-ack): background the post-spokes observability re-seed (unblock install; #875)

### DIFF
--- a/workshop/Taskfile.yaml
+++ b/workshop/Taskfile.yaml
@@ -136,7 +136,14 @@ tasks:
       # are empty → no spoke AMP scrapers. Re-running here ensures spoke scraper values are
       # written to Secrets Manager and propagated to the ArgoCD cluster secret via ESO.
       # This fixes issue #41 (AMP scraper hub-only, spoke-dev metrics missing in Phase 30.5).
-      - 'if [ "{{.PROVIDER}}" = "kind-kro-ack" ]; then cd {{.PLATFORM_DIR}} && task kind-kro-ack:secrets-manager:seed-observability; fi'
+      # Re-seed in the BACKGROUND. seed-observability blocks up to 60min polling for the
+      # AMP workspace (provisioned by Crossplane), whose creation is flaky/slow on a fresh
+      # account (IAM eventual-consistency + etcd throttling on the kind bootstrap cluster).
+      # Running it inline can stall the whole install past the CFN IdeInitScriptWaitCondition
+      # (~2h) → CREATE_FAILED, even though the platform is otherwise up. The
+      # peeks-observability-seed.timer already retries this on a schedule, so fire-and-forget
+      # here (best-effort, non-blocking) to write spoke-scraper values once AMP is ACTIVE.
+      - 'if [ "{{.PROVIDER}}" = "kind-kro-ack" ]; then cd {{.PLATFORM_DIR}} && nohup task kind-kro-ack:secrets-manager:seed-observability >/tmp/seed-observability-reseed.log 2>&1 & echo "  observability re-seed launched in background (PID $!); peeks-observability-seed.timer also retries."; fi'
       - 'printf "{{.C_INFO}}  [%ds] observability re-seeded with spoke scraper data{{.C_RESET}}\n" "$(($(date +%s) - {{.INSTALL_START}}))"'
       # Write platform URLs + credentials to ~/.bashrc.d/platform.sh for IDE use
       - task: setup-env


### PR DESCRIPTION
## Summary

Fixes the `kind-kro-ack` full-install **timeout** (`IdeInitScriptWaitCondition` ~2h → `CREATE_FAILED`) caused by a **blocking** observability re-seed. Addresses part 1 of #875.

## Problem

`workshop:install` runs, right after `wait-for-spokes`:

```yaml
- 'if [ "{{.PROVIDER}}" = "kind-kro-ack" ]; then cd {{.PLATFORM_DIR}} && task kind-kro-ack:secrets-manager:seed-observability; fi'
```

`secrets-manager:seed-observability` **polls up to 60 min** (`for i in $(seq 1 120)`) for the AMP workspace, which is provisioned by **Crossplane** (`observability-aws` is Crossplane-only). On a fresh account this provisioning is flaky/slow (IAM eventual-consistency on `AttachRolePolicy` + etcd throttling on the single-node kind bootstrap cluster leaving MRs in `external-create-pending`). By the time the install reaches this step (~90 min in, after spokes are ACTIVE), a 60 min AMP block pushes total install time past the ~2 h WaitCondition → `CREATE_FAILED` — even though the platform is otherwise fully up (3 clusters, Ray, IDC).

Observed:
- **test5** (AMP stuck): install timed out at the blocking AMP wait; `list-workspaces=[]`.
- **another env** (AMP fast): same `external-create-pending` annotations present, but AMP came up in ~14 s → install finished in 71 min. → the provisioning is **flaky**, and the blocking wait turns slowness into a hard install failure.

## Fix

Run the post-spokes re-seed **fire-and-forget** (`nohup … &`). It is already best-effort (`exit 0` on timeout) and the **`peeks-observability-seed.timer`** retries seeding on a schedule, so backgrounding keeps the "seed spoke-scraper values sooner" intent without gating install success on AMP readiness.

Not a permissions issue (the least-privilege SharedRole is fine — 0 `AccessDenied`, full platform came up). This is timing/observability only.
