### PR TITLE
fix(kubevela): functional gate emits 'Testing for'/PASS/FAIL like the kro path

### DIFF
--- a/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
+++ b/gitops/addons/charts/kubevela/templates/components/appmod-service.yaml
@@ -342,7 +342,7 @@ spec:
         									command: ["sh"]
         									args: [
         										"-c",
-        										"wget -qO- http://\(previewService):\(parameter.port)\(parameter.appPath)/ | grep -q '\(parameter.functionalGate.extraArgs)'"
+        										"set -e; echo 'Fetching response...'; RESPONSE=$(wget -qO- http://\(previewService):\(parameter.port)\(parameter.appPath)/ 2>&1); echo 'Response received:'; echo \"$RESPONSE\"; echo ''; echo 'Testing for: \(parameter.functionalGate.extraArgs)'; if echo \"$RESPONSE\" | grep -q '\(parameter.functionalGate.extraArgs)'; then echo 'PASS: Found \(parameter.functionalGate.extraArgs)'; exit 0; else echo 'FAIL: \(parameter.functionalGate.extraArgs) not found'; exit 1; fi"
         									]
         								},
         							]


### PR DESCRIPTION
The kubevela functional-gate AnalysisTemplate ran a silent `wget … | grep -q <extraArgs>`, so AnalysisRun logs were uninformative and the shared workshop verification step (grep 'Testing for: …') only worked on the kro path. Mirror the kro command (echo Fetching/Response, 'Testing for: <extraArgs>', PASS/FAIL). Same pass/fail logic, now consistent across both delivery paths. Cherry-picked from fa36b916.