### PR TITLE
fix(sweep): retry delete_cluster in §6b until ACK capabilities finish deleting

### DIFF
--- a/scripts/sweep-workshop-resources.py
+++ b/scripts/sweep-workshop-resources.py
@@ -284,20 +284,38 @@ try:
             except Exception:
                 pass
         pending.append(spoke)
-    for spoke in pending:  # wait ~5 min for capabilities to clear, then delete the cluster
-        for _ in range(20):
+    for spoke in pending:  # retry delete_cluster until capabilities finish deleting
+        # ACK capabilities can take ~15-20 min to finish DELETING; delete_cluster fails
+        # with ResourceInUseException ("Cluster has capabilities attached") until they
+        # clear. A single attempt after a fixed short wait (the old 5 min) races ACK and
+        # leaves the spoke orphaned. Retry delete_cluster (up to ~25 min) instead: as soon
+        # as the capabilities clear the call succeeds.
+        submitted = False
+        for i in range(100):  # ~25 min (100 × 15s)
             try:
-                if not eks.list_capabilities(clusterName=spoke).get("capabilities", []):
+                if eks.describe_cluster(name=spoke)["cluster"]["status"] == "DELETING":
+                    submitted = True
                     break
-            except Exception:
+            except eks.exceptions.ResourceNotFoundException:
+                submitted = True
                 break
-            time.sleep(15)
-        try:
-            if eks.describe_cluster(name=spoke)["cluster"]["status"] != "DELETING":
+            except Exception:
+                pass
+            try:
                 eks.delete_cluster(name=spoke)
                 log(f"  Spoke {spoke} deletion submitted")
-        except Exception as e:
-            log(f"  Spoke {spoke} delete: {e}")
+                submitted = True
+                break
+            except eks.exceptions.ResourceNotFoundException:
+                submitted = True
+                break
+            except Exception as e:
+                # Typically ResourceInUseException while capabilities are still DELETING.
+                if i % 8 == 0:
+                    log(f"  Spoke {spoke}: waiting for capabilities to clear before delete ({e.__class__.__name__})")
+                time.sleep(15)
+        if not submitted:
+            log(f"  Spoke {spoke}: delete still blocked after ~25 min — leaving for the next sweep")
     for spoke in pending:  # wait up to ~15 min per spoke for full deletion
         for _ in range(30):
             try:


### PR DESCRIPTION
Follow-up to #878, found by an end-to-end deploy+teardown test on a real reused account.

## Bug
§6b (orphaned spoke reaper) waited a fixed ~5 min for a spoke's EKS capabilities to clear, then made a **single** `delete_cluster` call. ACK capabilities take **~15-20 min** to finish `DELETING`, so the call raced them and failed:
```
Spoke peeks-spoke-dev delete: ResourceInUseException — Cluster has capabilities attached
```
→ the spoke was left ACTIVE/orphaned. (The original manual test of #878 passed only because it ran against an already-orphaned state where capabilities were already cleared.)

## Fix
Retry `delete_cluster` in a loop (up to ~25 min), handling `ResourceInUseException` (capabilities still `DELETING`) — as soon as they clear, the call succeeds. Also handles `ResourceNotFound` (already gone) and logs progress.

## Validation
`ast.parse` clean. To be confirmed on the next fresh deploy+teardown (the CodeBuild-CR response fix on the platform side, GitLab !578, already validated in the same test run — spoke reaping was the remaining gap).