### PR TITLE
fix(teardown): authoritative final re-sweep of recreatable resources + ENI gate

### DIFF
--- a/scripts/sweep-workshop-resources.py
+++ b/scripts/sweep-workshop-resources.py
@@ -701,4 +701,140 @@ except Exception as e:
     log(f"IDE VPC SG cleanup: {e}")
 
 
+# ---------------------------------------------------------------------------
+# 16. Final authoritative re-sweep of recreatable resources + ENI gate
+#     Sections 2-5 delete CloudFront / ALB / RDS / AMP scrapers BEFORE the hub
+#     cluster is deleted (section 6). While the hub is still alive its
+#     ACK / Crossplane / addon controllers RE-CREATE those resources, which then
+#     end up orphaned once the hub is gone — observed on a reused account where
+#     `task destroy` did not fully stop the controllers first: the CloudFront
+#     "peeks-hub-platform" distribution + VPC origin, the DevLake RDS, the AMP
+#     scrapers and the hub security groups all came back and their ENIs
+#     (cloudfront_managed / RDSNetworkInterface / amp_collector) blocked the IDE
+#     VPC subnet deletion → stack DELETE_FAILED.
+#     Now that the hub AND spokes are deleted (sections 6/6b) the controllers are
+#     gone, so re-delete anything that came back, re-clear the IDE VPC security
+#     groups, then WAIT for those service-managed ENIs to detach so CloudFormation
+#     can delete the subnets. Cheap when nothing was recreated (the common case).
+# ---------------------------------------------------------------------------
+try:
+    def _find_ide_vpc():
+        """The IDE VPC is the only CloudFormation-owned VPC (aws:cloudformation:*
+        tags). Reliable even when the hub cluster was already gone at section 6."""
+        if hub_vpc_id:
+            return hub_vpc_id
+        for v in ec2.describe_vpcs().get("Vpcs", []):
+            if any(t["Key"].startswith("aws:cloudformation:") for t in v.get("Tags", [])):
+                return v["VpcId"]
+        return None
+
+    ide_vpc = _find_ide_vpc()
+
+    # 16a. AMP scrapers (recreated by the AMP capability / addon)
+    try:
+        for s in amp.list_scrapers().get("scrapers", []):
+            try:
+                amp.delete_scraper(scraperId=s["scraperId"])
+                log(f"  [re-sweep] Deleted recreated AMP scraper {s['scraperId']}")
+            except Exception:
+                pass
+    except Exception as e:
+        log(f"  [re-sweep] AMP: {e}")
+
+    # 16b. ALBs (recreated by the AWS Load Balancer Controller)
+    try:
+        for lb in elbv2.describe_load_balancers()["LoadBalancers"]:
+            if lb["LoadBalancerName"].startswith(prefix + "-"):
+                elbv2.delete_load_balancer(LoadBalancerArn=lb["LoadBalancerArn"])
+                log(f"  [re-sweep] Deleted recreated ALB {lb['LoadBalancerName']}")
+    except Exception as e:
+        log(f"  [re-sweep] ALB: {e}")
+
+    # 16c. RDS (recreated by ACK)
+    try:
+        for db in rds.describe_db_instances()["DBInstances"]:
+            if db["DBInstanceIdentifier"].startswith("devlake") \
+               and db["DBInstanceStatus"] not in ("deleting",):
+                rds.delete_db_instance(
+                    DBInstanceIdentifier=db["DBInstanceIdentifier"],
+                    SkipFinalSnapshot=True,
+                    DeleteAutomatedBackups=True,
+                )
+                log(f"  [re-sweep] Deleting recreated RDS {db['DBInstanceIdentifier']}")
+    except Exception as e:
+        log(f"  [re-sweep] RDS: {e}")
+
+    # 16d. CloudFront distribution + VPC origin (recreated by Crossplane)
+    try:
+        vos = cf.list_vpc_origins().get("VpcOriginList", {}).get("Items", [])
+        vo_ids = {vo["Id"] for vo in vos if vo.get("Name", "").startswith(hub + "-")}
+        dist_ids = set()
+        for d in cf.list_distributions().get("DistributionList", {}).get("Items", []):
+            if d.get("Comment", "").startswith(hub):
+                dist_ids.add(d["Id"])
+                continue
+            for o in d.get("Origins", {}).get("Items", []):
+                if o.get("VpcOriginConfig", {}).get("VpcOriginId", "") in vo_ids:
+                    dist_ids.add(d["Id"])
+        for dist_id in dist_ids:
+            resp = cf.get_distribution_config(Id=dist_id)
+            etag, cfg = resp["ETag"], resp["DistributionConfig"]
+            if cfg.get("Enabled", True):
+                cfg["Enabled"] = False
+                cf.update_distribution(Id=dist_id, DistributionConfig=cfg, IfMatch=etag)
+                log(f"  [re-sweep] Disabling recreated CF distribution {dist_id}...")
+                for _ in range(30):
+                    if cf.get_distribution(Id=dist_id)["Distribution"]["Status"] == "Deployed":
+                        break
+                    time.sleep(15)
+            etag2 = cf.get_distribution(Id=dist_id)["ETag"]
+            cf.delete_distribution(Id=dist_id, IfMatch=etag2)
+            log(f"  [re-sweep] Deleted recreated CF distribution {dist_id}")
+        if dist_ids:
+            time.sleep(5)
+        for vo_id in vo_ids:
+            try:
+                etag = cf.get_vpc_origin(Id=vo_id)["ETag"]
+                cf.delete_vpc_origin(Id=vo_id, IfMatch=etag)
+                log(f"  [re-sweep] Deleted recreated CF VPC origin {vo_id}")
+            except Exception:
+                pass
+    except Exception as e:
+        log(f"  [re-sweep] CloudFront: {e}")
+
+    # 16e. Re-clear leftover SGs in the IDE VPC (recreated / missed by section 15)
+    if ide_vpc:
+        n = _delete_vpc_sgs(ide_vpc)
+        if n:
+            log(f"  [re-sweep] Cleared {n} more leftover SG(s) in IDE VPC {ide_vpc}")
+
+    # 16f. ENI gate — wait for the service-managed ENIs that block subnet deletion
+    #      (cloudfront_managed / amp_collector / RDSNetworkInterface) to detach.
+    if ide_vpc:
+        def _blocking_enis():
+            out = []
+            try:
+                for e in ec2.describe_network_interfaces(
+                    Filters=[{"Name": "vpc-id", "Values": [ide_vpc]}]
+                )["NetworkInterfaces"]:
+                    if e.get("InterfaceType") in ("amp_collector", "cloudfront_managed") \
+                       or e.get("Description", "").startswith("RDSNetworkInterface"):
+                        out.append(e["NetworkInterfaceId"])
+            except Exception:
+                pass
+            return out
+        for i in range(36):  # up to ~12 min (36 × 20 s) — RDS ENI release is the long pole
+            b = _blocking_enis()
+            if not b:
+                log(f"  [re-sweep] No blocking ENIs left in IDE VPC {ide_vpc}")
+                break
+            if i % 3 == 0:
+                log(f"  [re-sweep] Waiting for {len(b)} blocking ENI(s) to detach from IDE VPC {ide_vpc}...")
+            time.sleep(20)
+    else:
+        log("  [re-sweep] IDE VPC not found — skipping final re-sweep")
+except Exception as e:
+    log(f"Final re-sweep: {e}")
+
+
 log("Extended sweep complete.")


### PR DESCRIPTION
## Root cause (found via parallel CFN-only teardown test: kro-c1 vs WS event)

Sweep sections 2-5 delete **CloudFront / ALB / RDS / AMP scrapers BEFORE** the hub cluster is deleted (section 6). While the hub is still alive, its **ACK/Crossplane/addon controllers RE-CREATE** those resources, which are then **orphaned** once the hub is gone.

On a reused account where `task destroy` did not fully stop the controllers first (kro-c1), the recreated CloudFront `peeks-hub-platform` distribution + VPC origin, DevLake RDS, AMP scrapers and hub security groups all came back, and their ENIs (`cloudfront_managed` / `RDSNetworkInterface` / `amp_collector`) **blocked the IDE VPC subnet deletion → CFN stack DELETE_FAILED**. When `task destroy` *does* stop the controllers first (the WS event), the existing sweep is enough and the stack deletes cleanly (~26 min).

This matters most on the **Workshop Studio path**, which does a plain `delete-stack` with **no retain-retry** (that only exists in the CI `taskcat-delete` job).

## Fix — section 16: final authoritative re-sweep + ENI gate

Runs **after** the hub AND spokes are deleted (sections 6/6b), so controllers are gone and nothing gets recreated:
- re-delete recreated AMP scrapers, prefix ALBs, DevLake RDS, hub CloudFront distribution + VPC origin;
- re-clear leftover SGs in the IDE VPC (robust IDE-VPC lookup via the `aws:cloudformation:*` tag — `hub_vpc_id` is unset when the hub was already gone at section 6);
- **ENI gate**: wait up to ~12 min for `cloudfront_managed` / `amp_collector` / `RDSNetworkInterface` ENIs to detach so CFN can delete the subnets.

**Cheap when nothing was recreated** (common case: all list calls return empty). Exit code stays 0 (per-section try/except). Complements #878 / #881.

## Test plan
After merge + WS republish: re-run the parallel CFN-only teardown (a reused account where the previous run left orphans) and confirm the IDE VPC + stack reach DELETE_COMPLETE without manual intervention.

Targets `release/v0.3.0-rc4`.