### PR TITLE
fix(kind-kro-ack): set managementRegion to deploy region (fix non-us-west-2 deploys)

### DIFF
--- a/cluster-providers/kind-kro-ack/Taskfile.yaml
+++ b/cluster-providers/kind-kro-ack/Taskfile.yaml
@@ -680,6 +680,12 @@ tasks:
           tenant: platform
           environment: control-plane
           region: {{.AWS_REGION}}
+          # managementRegion drives the ACK region annotation on the cluster-config
+          # Secrets Manager secret (clusterConfigSecret). For this single-region/account
+          # workshop it must equal the deploy region; otherwise it defaults to us-west-2
+          # (RGD schema) and the secret is created in us-west-2 while everything else is
+          # in AWS_REGION → clusterConfigSecret never syncs → hub EKS never ACTIVE.
+          managementRegion: {{.AWS_REGION}}
           k8sVersion: "{{.HUB_K8S_VERSION}}"
           accountId: "{{.AWS_ACCOUNT_ID}}"
           managementAccountId: "{{.AWS_ACCOUNT_ID}}"

--- a/gitops/abstractions/kro/kro-clusters/templates/clusters.yaml
+++ b/gitops/abstractions/kro/kro-clusters/templates/clusters.yaml
@@ -19,6 +19,7 @@ spec:
   deletionPolicy: {{ $cluster.deletionPolicy | default "delete" | quote }}
   provider: {{ $cluster.provider | default "" | quote }}
   region: {{ $cluster.region | default "us-west-2" | quote }}
+  managementRegion: {{ $cluster.region | default "us-west-2" | quote }}
   k8sVersion: {{ $cluster.k8sVersion | default "1.34" | quote }}
   accountId: {{ $cluster.accountId | quote }}
   managementAccountId: {{ $cluster.managementAccountId | quote }}

--- a/gitops/abstractions/resource-groups-kro/platform-cluster-kro/templates/claim.yaml
+++ b/gitops/abstractions/resource-groups-kro/platform-cluster-kro/templates/claim.yaml
@@ -15,6 +15,7 @@ spec:
   environment: {{ .Values.environment | default "dev" }}
   provider: kro-ack
   region: {{ .Values.region | default $.Values.global.region | default "us-west-2" }}
+  managementRegion: {{ .Values.region | default $.Values.global.region | default "us-west-2" }}
   k8sVersion: {{ .Values.kubernetesVersion | default "1.32" | quote }}
   accountId: {{ .Values.accountId | default $.Values.global.accountId | quote }}
   managementAccountId: {{ .Values.managementAccountId | default $.Values.global.accountId | quote }}


### PR DESCRIPTION
## Problem
Fresh workshop deploys in **us-east-1, ap-southeast-1, eu-west-1** all fail identically at `kind-kro-ack:hub:wait-for-eks` (`task install` exits 201): the hub EKS `ekscluster` kro instance never reaches ACTIVE because its child `clusterConfigSecret` (an ACK Secrets Manager `Secret`) never reaches `ACK.ResourceSynced=True`.

## Root cause
`rg-eks.yaml` schema: `managementRegion: string | default="us-west-2"`. It drives the ACK region annotation on `clusterConfigSecret`:
```yaml
services.k8s.aws/region: ${schema.spec.managementRegion}
```
The hub instance (kind-kro-ack Taskfile) and spoke instances set `region` but **not** `managementRegion` → it stays `us-west-2`. Outside us-west-2, ACK tries to manage the secret in us-west-2 while the cluster/VPC are in the deploy region → the secret never syncs → cluster never ACTIVE → 2400s timeout → install fails.

## Fix
Set `managementRegion` = the cluster's own region on all 3 EKS RGD instances:
- `cluster-providers/kind-kro-ack/Taskfile.yaml` (hub claim)
- `gitops/abstractions/kro/kro-clusters/templates/clusters.yaml` (spokes)
- `gitops/abstractions/resource-groups-kro/platform-cluster-kro/templates/claim.yaml` (spokes)

No-op in us-west-2 (already the default). This workshop is single-region/account, so region == managementRegion always.

## Validation
Confirmed failure reproduced on us-east-1 / ap-southeast-1 / eu-west-1 (init 201, hub EKS stuck, no spokes/AMP/AMG). Will re-validate a fresh deploy in eu-west-1 with this fix before merge.