### PR TITLE
fix(ray): omit S3 LocationConstraint in us-east-1 for the Ray bucket

### DIFF
--- a/cluster-providers/common/Taskfile.ray.yaml
+++ b/cluster-providers/common/Taskfile.ray.yaml
@@ -22,7 +22,7 @@ tasks:
             echo "  ✓ S3 bucket {{.RAY_BUCKET}} exists"
           else
             aws s3api create-bucket --bucket "{{.RAY_BUCKET}}" --region {{.AWS_REGION}} \
-              --create-bucket-configuration LocationConstraint={{.AWS_REGION}} --output text >/dev/null
+              {{if ne .AWS_REGION "us-east-1"}}--create-bucket-configuration LocationConstraint={{.AWS_REGION}}{{end}} --output text >/dev/null
             aws s3api put-public-access-block --bucket "{{.RAY_BUCKET}}" \
               --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
             echo "  ✓ S3 bucket {{.RAY_BUCKET}} created"


### PR DESCRIPTION
## Problem
After #883 unblocked the hub EKS in non-us-west-2 regions, a **us-east-1** deploy now fails later at `kind-kro-ack:ray:setup`:
```
CreateBucket: InvalidLocationConstraint — The specified location-constraint is not valid
```
`cluster-providers/common/Taskfile.ray.yaml` calls `create-bucket --create-bucket-configuration LocationConstraint={{.AWS_REGION}}` unconditionally. **us-east-1** is the S3 default region and must NOT be given a LocationConstraint → the call errors, `task install` exits 254 → 201.

## Fix
Guard the LocationConstraint with the same go-task conditional already used in `workshop/Taskfile.yaml`:
```
{{if ne .AWS_REGION "us-east-1"}}--create-bucket-configuration LocationConstraint={{.AWS_REGION}}{{end}}
```
No-op outside us-east-1.

## Context
Region-agnostic support series (follow-up to #883). Confirmed on a fresh us-east-1 deploy: with #883, hub EKS reached ACTIVE + AMP ACTIVE + spokes declared, then failed only here. ap-southeast-1 / eu-west-1 don't hit this (LocationConstraint is valid there).