### PR TITLE
fix(kro): declare managementRegion in EksclusterWithVpc RGD schema (unblock spokes)

### DIFF
--- a/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks-vpc.yaml
+++ b/gitops/addons/charts/kro/resource-groups/manifests/eks/rg-eks-vpc.yaml
@@ -16,6 +16,14 @@ spec:
       deletionPolicy: string | default="delete"
       provider: string | default=""
       region: string | default="us-west-2"
+      # Region where the hub's ACK controllers manage this cluster's cross-region
+      # resources (e.g. the Secrets Manager config secrets). Passed through to the
+      # nested EksCluster (which wires it to services.k8s.aws/region, see rg-eks.yaml).
+      # MUST be declared here: the spoke/platform instances set spec.managementRegion
+      # (gitops/abstractions/.../clusters.yaml, claim.yaml) and kro rejects any field
+      # not declared in the RGD schema ("field not declared in schema"), which
+      # otherwise blocks EksclusterWithVpc (spoke) creation entirely.
+      managementRegion: string | default="us-west-2"
       k8sVersion: string | default="1.34"
       accountId: string
       managementAccountId: string
@@ -177,6 +185,7 @@ spec:
           deletionPolicy: ${schema.spec.deletionPolicy}
           provider: ${schema.spec.provider}
           region: ${schema.spec.region}
+          managementRegion: ${schema.spec.managementRegion}
           accountId: ${schema.spec.accountId}
           managementAccountId: ${schema.spec.managementAccountId}
           argoCdHubRoleArn: ${schema.spec.argoCdHubRoleArn}


### PR DESCRIPTION
## Problem — spokes never provision on rc4

Found while retesting on a fresh rc4 deploy: the hub comes up but **spoke clusters never provision**. `clusters-kro-peeks-spoke-dev/prod` stay **OutOfSync**, no `EksCluster` CR is ever created, and the kro apply loops on:

```
one or more objects failed to apply, reason: failed to create typed patch object
(peeks-spoke-dev; kro.run/v1alpha1, Kind=EksclusterWithVpc):
.spec.managementRegion: field not declared in schema
```

## Root cause

`managementRegion` is set on the **instances** (`gitops/abstractions/kro/kro-clusters/templates/clusters.yaml`, `.../platform-cluster-kro/templates/claim.yaml`) and is declared in the **EksCluster** RGD (`rg-eks.yaml`). But the **EksclusterWithVpc** RGD (`rg-eks-vpc.yaml`) — which the **spokes** use (they create their own VPC) — never declared it. kro rejects the undeclared field, so the entire `EksclusterWithVpc` instance fails to apply and the spoke is never submitted to AWS.

The **hub is unaffected**: it reuses the pre-created IDE VPC and uses the `EksCluster` RGD (which already has the field) → classic *hub OK, spokes broken*.

## Fix (`rg-eks-vpc.yaml`)
- declare `managementRegion: string | default="us-west-2"` in the `EksclusterWithVpc` `schema.spec`;
- pass it through to the nested `EksCluster` (alongside `region`), so it reaches the `services.k8s.aws/region` wiring on the management-region ACK Secrets in `rg-eks.yaml`.

Same-region deploys are unblocked by the schema declaration; the pass-through preserves the multi-region intent for the spoke path. YAML validated (multi-doc parse).

## Test plan
On an rc4 deploy: confirm `clusters-kro-peeks-spoke-*` sync, the `EksclusterWithVpc`/`EksCluster` CRs are created, and `peeks-spoke-dev`/`peeks-spoke-prod` reach ACTIVE.

Targets `release/v0.3.0-rc4`.