### PR TITLE
fix(jupyterhub): set ALB healthcheck-path to /jupyterhub/hub/health

### DIFF
--- a/gitops/addons/charts/jupyterhub/templates/ingress.yaml
+++ b/gitops/addons/charts/jupyterhub/templates/ingress.yaml
@@ -6,6 +6,11 @@ metadata:
   name: jupyterhub
   namespace: jupyterhub
   annotations:
+    # JupyterHub's proxy-public returns 302 on "/" (redirects to {baseUrl}/hub/),
+    # so the AWS LBC default health check (GET / expecting 200) marks the target
+    # unhealthy (Target.ResponseCodeMismatch [302]). Point the health check at the
+    # hub's dedicated health endpoint (200) under the configured baseUrl instead.
+    alb.ingress.kubernetes.io/healthcheck-path: /jupyterhub/hub/health
 {{- if $insecure }}
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'


### PR DESCRIPTION
### Problem
The `jupyterhub` Ingress (`gitops/addons/charts/jupyterhub/templates/ingress.yaml`) sets no health-check annotations, so the AWS Load Balancer Controller falls back to its default probe: `HTTP GET /` expecting `200`. JupyterHub's `proxy-public` returns **302** on `/` (redirect to `{baseUrl}/hub/`), so the ALB target group marks the pod **unhealthy** with `Target.ResponseCodeMismatch [302]`.

Observed on a live Workshop Studio deployment (PeEKS, platform ALB `peeks-hub-platform`, target group `k8s-jupyterh-proxypub`): the target is unhealthy while the `hub`/`proxy` pods are 1/1 Running and the ArgoCD app is Synced+Healthy. The app is only reachable because the ALB "fails open" when the single target is unhealthy — fragile (a healthy 2nd replica would cause this one to be pulled) and it pollutes health/monitoring.

### Fix
Point the ALB health check at JupyterHub's dedicated health endpoint under the configured `baseUrl`:
```
alb.ingress.kubernetes.io/healthcheck-path: /jupyterhub/hub/health
```

### Verification (live)
- `GET /jupyterhub/hub/health` → **200**
- `GET /jupyterhub` → 302 → `/jupyterhub/hub/`
- `hub` + `proxy` pods 1/1 Running; ArgoCD `jupyterhub-peeks-hub` Synced+Healthy

### Notes
- `baseUrl` is `/jupyterhub` (see `gitops/addons/charts/jupyterhub/values.yaml`), so the health path must include the prefix.
- Alternative minimal fix would be `alb.ingress.kubernetes.io/success-codes: "200,302"`, but a dedicated health endpoint is a truer readiness signal.
