### PR TITLE
docs: align platform docs & steering with cluster-providers architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,8 +161,6 @@ workshop/cdk.out
 # Terraform build files
 .terraform.lock.hcl
 
-platform/infra/terraform/terraform-aws-observability-accelerator
-
 prodplan
 devplan
 devdbplan

--- a/.kiro/skills/manage-addons/SKILL.md
+++ b/.kiro/skills/manage-addons/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-addons
-description: Add, configure, or modify GitOps addons on the PEEKS platform. Use when adding a new addon, enabling an addon on a cluster, configuring addon values, troubleshooting addon deployment, or modifying hub-config.yaml. Do NOT use for general kubectl troubleshooting — use troubleshoot-platform instead.
+description: Add, configure, or modify GitOps addons on the PEEKS platform. Use when adding a new addon, enabling an addon on a cluster, configuring addon values, troubleshooting addon deployment, or editing addon enablement (`enabled-addons.yaml`). Do NOT use for general kubectl troubleshooting — use troubleshoot-platform instead.
 ---
 
 # Manage Addons
@@ -23,24 +23,24 @@ The platform uses a three-tier configuration system:
 
 | Layer | File | Purpose |
 |-------|------|---------|
-| Addon definitions | `gitops/addons/bootstrap/default/addons.yaml` | Central registry of all addons |
-| Environment config | `gitops/addons/environments/{env}/addons.yaml` | Per-environment enablement |
-| Cluster config | `platform/infra/terraform/hub-config.yaml` | Per-cluster activation via labels |
+| Addon registry | `gitops/addons/registry/<domain>.yaml` | Central registry of all addons (core, platform, security, observability, ml, gitops) |
+| Environment enablement | `gitops/overlays/environments/<env>/enabled-addons.yaml` | Per-environment enablement (source of truth for cluster secret `enable_*` labels) |
+| Value overlays | `gitops/overlays/environments/<env>/<addon>/values.yaml` | Per-environment/cluster value overrides |
 
 **Constraints:**
 - You MUST prefer GitOps workflow (modify Git → commit → push → ArgoCD sync) over manual kubectl apply because manual changes drift from Git state
-- You MUST NOT manually modify cluster secrets — always update through `hub-config.yaml` because Terraform owns these resources
+- You MUST NOT manually modify cluster secrets — always update through `gitops/overlays/environments/<env>/enabled-addons.yaml` because the fleet-secret chart generates these labels from it
 - Read-only kubectl operations (get, describe, logs) are allowed without confirmation
 
 ### 2. Add a New Addon
 
 **Constraints:**
-- You MUST add the addon entry in `gitops/addons/bootstrap/default/addons.yaml` with selector and valuesObject
-- You MUST add `enable_<addon>: false` to all clusters in `hub-config.yaml`
+- You MUST add the addon entry in the appropriate `gitops/addons/registry/<domain>.yaml` with selector and valuesObject
+- You MUST add `enable_<addon>: false` to the relevant `gitops/overlays/environments/<env>/enabled-addons.yaml`
 - You MUST choose an appropriate sync wave based on dependencies (see references/sync-waves.md)
 - You MUST NOT put dynamic template values (`{{.metadata.annotations.*}}`) in values.yaml files because they will be overridden — see [references/values-separation.md](references/values-separation.md)
 - You SHOULD create a values overlay at `gitops/addons/default/addons/<addon>/values.yaml` for static config
-- You SHOULD use `deploy.sh` scripts, never raw `terraform apply`
+- You SHOULD apply changes via GitOps (commit → push → ArgoCD sync); use `task install` for provider bootstrap, never raw `terraform apply`
 
 ### 3. Configure Addon Values
 

--- a/.kiro/skills/troubleshoot-platform/SKILL.md
+++ b/.kiro/skills/troubleshoot-platform/SKILL.md
@@ -101,7 +101,7 @@ kubectl get applications.argoproj.io -n argocd -o json | jq -r '.items[] | selec
 **For MCP tool failures:**
 - If EKS MCP tools fail, provide equivalent kubectl or AWS CLI commands as fallback
 - If Terraform MCP tools fail, use `terraform state` commands for inspection only
-- You MUST NOT run `terraform apply` or `terraform destroy` directly — use `deploy.sh`/`destroy.sh` scripts because they handle backend config and state management
+- You MUST NOT run `terraform apply` or `terraform destroy` directly — drive the configured cluster provider via `task install` / `task destroy` because they handle provider selection, backend config, and state management
 
 **Constraints:**
 - You MUST wait at least 150 seconds after a new AWS Load Balancer shows "active" before testing connectivity because DNS propagation takes up to 5 minutes

--- a/.kiro/steering/cluster-lifecycle.md
+++ b/.kiro/steering/cluster-lifecycle.md
@@ -98,5 +98,5 @@ argocd app diff <app> && argocd app sync <app> --prune
   appset YAML, or the disable tasks above.
 - Treat any prune/delete of a live cluster as high-risk: remove from Git, show
   the diff, and confirm before syncing with `--prune`.
-- For full teardown use `destroy.sh`, never prune.
+- For full teardown use `task destroy`, never prune.
 - ArgoCD CLI auth errors: `argocd-refresh-token && source ~/.bashrc.d/platform.sh`.

--- a/.kiro/steering/project.md
+++ b/.kiro/steering/project.md
@@ -10,11 +10,16 @@ Companion repo: [platform-engineering-on-eks](../platform-engineering-on-eks/) h
 
 | Path | Purpose |
 |------|---------|
-| `platform/infra/terraform/cluster/` | Terraform — EKS clusters (hub, spoke-dev, spoke-prod) |
-| `platform/infra/terraform/common/` | Terraform — platform addons (ArgoCD, secrets, pod identity, observability) |
-| `platform/infra/terraform/identity-center/` | Terraform — IDC/SCIM integration |
+| `Taskfile.yaml` | Entry point — `task install/status/destroy` delegate to the configured cluster provider |
+| `config.yaml` / `config.local.yaml` | Single config consumed by all providers (`clusterProvider`, repo, hub, aws, domain) |
+| `cluster-providers/kind-crossplane/` | Provider — Kind + Crossplane bootstrap of the hub EKS cluster (default) |
+| `cluster-providers/kind-kro-ack/` | Provider — Kind + KRO/ACK bootstrap of the hub EKS cluster |
+| `cluster-providers/terraform/` | Provider — direct Terraform provisioning of the hub EKS cluster |
+| `cluster-providers/byoc/` | Provider — Bring Your Own Cluster (existing cluster) |
+| `cluster-providers/common/` | Shared bootstrap logic reused by the providers |
 | `scripts/` | Workshop scripts: IDC config, ArgoCD token automation, setup validation |
-| `platform/infra/terraform/hub-config.yaml` | Single source of truth for cluster addon enablement |
+| `gitops/overlays/environments/<env>/enabled-addons.yaml` | Per-environment addon enablement (source of truth for cluster secret `enable_*` labels) |
+| `gitops/addons/registry/<domain>.yaml` | Addon registry (core, platform, security, observability, ml, gitops) |
 | `gitops/addons/` | ArgoCD addon definitions, charts, environments, tenants |
 | `gitops/apps/` | Application deployment manifests (backend, frontend, rollouts) |
 | `gitops/fleet/` | Fleet management (Kro values, bootstrap, members) |
@@ -30,7 +35,7 @@ Companion repo: [platform-engineering-on-eks](../platform-engineering-on-eks/) h
 
 ## Tech Stack
 
-- **IaC:** Terraform (cluster, common, identity-center modules)
+- **IaC:** Pluggable cluster providers under `cluster-providers/` (kind-crossplane, kind-kro-ack, terraform, byoc), selected via `clusterProvider` in `config.local.yaml`
 - **GitOps:** ArgoCD ApplicationSets with sync waves (-5 to 6)
 - **Kubernetes:** EKS Auto Mode + EKS Capabilities (ArgoCD, Kro, ACK)
 - **IDP:** Backstage with Keycloak SSO
@@ -41,10 +46,10 @@ Companion repo: [platform-engineering-on-eks](../platform-engineering-on-eks/) h
 
 ## Key Conventions
 
-- Resource prefix: `peeks` (flows from env var through Terraform to cluster secrets)
+- Resource prefix: `peeks` (flows from env var through the cluster provider to cluster secrets)
 - Cluster names: `peeks-hub`, `peeks-spoke-dev`, `peeks-spoke-prod`
-- Deployment scripts: always use `deploy.sh` / `destroy.sh`, never raw `terraform apply/destroy`
-- Addon enablement: `hub-config.yaml` → Terraform → cluster secret labels → ArgoCD ApplicationSets
+- Deployment: always use `task install` / `task destroy` (they delegate to the configured `clusterProvider`), never raw `terraform apply/destroy`
+- Addon enablement: `gitops/overlays/environments/<env>/enabled-addons.yaml` → cluster secret `enable_*` labels → ArgoCD ApplicationSets
 - Dynamic values (resource_prefix, domain, region) live in `addons.yaml` valuesObject only, never in `values.yaml`
 
 ## Two Usage Contexts
@@ -101,8 +106,8 @@ These are facts about the deployed platform that have been confirmed multiple ti
 - The control-plane components (`argo-cd-argocd-server`, `argo-cd-argocd-application-controller`, `argo-cd-argocd-repo-server`, etc.) **run inside the AWS-managed control plane** and are **not visible** via `kubectl get pods -n argocd`. That namespace looks empty for pods even when ArgoCD is fully operational.
 - What IS visible in the `argocd` namespace: `Application`, `ApplicationSet`, `AppProject`, and cluster `Secret` objects — these are user-facing CRDs that ArgoCD reconciles from outside.
 - "ArgoCD is broken because the namespace is empty" is **always wrong**. Verify ArgoCD health by checking that `Application` resources are reconciling (sync/health status) rather than by looking for pods.
-- Self-managed ArgoCD values files (e.g. anything under `gitops/addons/configs/argo-cd/values.yaml` or `platform/infra/terraform/common/manifests/argocd-initial-values.yaml`) are **dead code** from a prior install path and have been removed. The Capability does not consume them.
-- Capability configuration lives in `platform/infra/terraform/common/argocd.tf` and the EKS cluster module — not in Helm values files.
+- Self-managed ArgoCD values files (e.g. any `argocd-initial-values.yaml` under `gitops/addons/configs/argo-cd/` or a prior `platform/infra/terraform` install path) are **dead code** from a prior install path and have been removed. The Capability does not consume them.
+- Capability configuration lives with the active cluster provider under `cluster-providers/` (e.g. `cluster-providers/terraform/argocd-capability.tf` for the terraform provider; the Crossplane Composition / KRO RGD for the kind providers) — not in Helm values files.
 
 ### Multi-cluster register pattern
 
@@ -134,7 +139,7 @@ Note: The `-bootstrap` suffix is misleading — it's not hub-only bootstrap, it'
 
 ## Key Rules
 
-- **Use deploy.sh/destroy.sh** — never raw `terraform apply` or `terraform destroy`
+- **Use `task install`/`task destroy`** — they delegate to the configured `clusterProvider`; never run raw `terraform apply` or `terraform destroy`
 - **GitOps first** — modify Git files and let ArgoCD sync, don't `kubectl apply` manually
 - **Dynamic values only in addons.yaml** — never put template expressions in values.yaml
 - **Check env vars with echo** — `echo $AWS_REGION` etc., don't dump full environment

--- a/.kiro/steering/terraform-best-practices.md
+++ b/.kiro/steering/terraform-best-practices.md
@@ -21,12 +21,12 @@ Ensures all Terraform operations follow Infrastructure as Code best practices an
 - NEVER run `terraform destroy` without explicit user confirmation and explanation of what will be destroyed (ID: TF_DESTROY_CONFIRM)
 - ALWAYS create a backup before state manipulation: `terraform state pull > backup.tfstate` (ID: TF_STATE_BACKUP)
 
-### Workshop Context
+### Cluster Provider Context
 
-- Infrastructure is pre-deployed and managed via Terraform - focus on understanding and extending rather than creating from scratch (ID: TF_PREDEPLOYED)
-- Terraform files are located in `/home/ec2-user/environment/platform-on-eks-workshop/platform/infra/terraform/` directory (ID: TF_WORKSHOP_STRUCTURE)
+- Terraform is now **one of several pluggable cluster providers** (`kind-crossplane`, `kind-kro-ack`, `terraform`, `byoc`), selected via `clusterProvider` in `config.local.yaml` — it is no longer the default nor the only deployment path (ID: TF_PROVIDER_MODEL)
+- The Terraform provider lives in `cluster-providers/terraform/` (flat `.tf` files: `eks.tf`, `vpc.tf`, `iam.tf`, `argocd-capability.tf`, `secrets-manager.tf`, etc.) — the old `platform/infra/terraform/` tree has been removed (ID: TF_PROVIDER_STRUCTURE)
 - Use `terraform show` and `terraform state show` to explore existing resources without modifications (ID: TF_EXPLORE)
-- NEVER use terraform apply or terraform destroy directly, ALWAYS use the deployment scripts `deploy.sh` or `destroy.sh` (ID: TF_USE_SCRIPTS)
+- NEVER run `terraform apply`/`terraform destroy` directly — always drive the provider through the Taskfile: `task install` / `task destroy` (which delegate to `terraform:install` / `terraform:destroy` when `clusterProvider: terraform`) (ID: TF_USE_TASKFILE)
 
 ## Priority
 

--- a/.kiro/steering/terraform-infrastructure.md
+++ b/.kiro/steering/terraform-infrastructure.md
@@ -7,16 +7,25 @@ fileMatchPattern: "**/terraform/**/*"
 
 ## Infrastructure Location
 
-All Terraform code is located in: `platform/infra/terraform/`
+Terraform is one of the pluggable cluster providers. Its code lives in: `cluster-providers/terraform/`
+(the old `platform/infra/terraform/` tree has been removed). It is selected by setting
+`clusterProvider: terraform` in `config.local.yaml` and driven via `task install` / `task destroy`.
 
 ## Project Structure
 
 ```
-platform/infra/terraform/
-├── modules/              # Reusable Terraform modules
-├── environments/         # Environment-specific configurations
-├── scripts/             # Helper scripts
-└── main.tf              # Root module
+cluster-providers/terraform/
+├── eks.tf                 # EKS Auto Mode cluster
+├── vpc.tf                 # VPC, subnets, IGW, NAT
+├── iam.tf                 # Cluster/node roles, ArgoCD capability role, ESO pod identity role
+├── argocd-capability.tf   # EKS ArgoCD Capability (via AWS CLI)
+├── secrets-manager.tf     # <cluster>/config + <cluster>/keycloak secrets
+├── helm.tf                # External Secrets Operator bootstrap
+├── variables.tf           # Input variables
+├── outputs.tf             # Output values
+├── versions.tf            # Provider versions
+├── terraform.tfvars.example
+└── Taskfile.yaml          # install / status / destroy tasks
 ```
 
 ## EKS Cluster Configuration

--- a/cluster-providers/README.md
+++ b/cluster-providers/README.md
@@ -8,8 +8,13 @@ cluster is created.
 
 | Provider | Description | When to use |
 |----------|-------------|-------------|
-| `kind-crossplane/` | Kind + Crossplane (zero Terraform) | Greenfield, full GitOps |
+| `kind-crossplane/` | Kind bootstrap + Crossplane provisions the hub EKS cluster (default) | Greenfield, full GitOps, no Terraform |
+| `kind-kro-ack/` | Kind bootstrap + KRO/ACK provisions the hub EKS cluster | Greenfield, full GitOps, KRO/ACK-based provisioning |
+| `terraform/` | Direct Terraform provisioning of the hub EKS cluster (no Kind, no Crossplane) | Teams standardized on Terraform |
 | `byoc/` | Bring Your Own Cluster | Existing cluster, any cloud provider |
+
+The provider is selected via `clusterProvider` in `config.yaml` / `config.local.yaml` and driven
+through the root `Taskfile.yaml` (`task install` / `task status` / `task destroy`).
 
 ## The Contract
 
@@ -127,32 +132,6 @@ must expose these tasks in its `Taskfile.yaml`:
 
 The root Taskfile calls these as `<provider-name>:install`, etc.
 
-### Domain handling (required behaviour)
-
-A provider reads `domain` from config and must **fail rather than install with an empty
-one** — an empty domain silently misconfigures Keycloak realm URLs, the OIDC issuer and
-every ingress host. The domain is a static config value; providers do not resolve, discover,
-or wait for it.
-
-Consumers without a registered domain reserve a free CloudFront hostname before installing
-(`scripts/cloudfront-reserve-domain.sh`, then `scripts/cloudfront-attach-origin.sh`
-afterwards). That is entirely outside the provider: it produces an ordinary `domain` value,
-so no provider needs CloudFront-specific code. See
-[docs/platform/cloudfront-exposure.md](../docs/platform/cloudfront-exposure.md).
-
-### Capability parity (binding)
-
-Providers are interchangeable behind one `config.yaml`, so **a capability added to one
-provider must be added to all of them**. Where that is not yet true, the lacking provider
-must **fail fast** with a clear message rather than silently ignore the input — a silently
-ignored field means `config.local.yaml` means different things depending on
-`clusterProvider`.
-
-Current known gap: `kind-crossplane` cannot provision the hub into a pre-existing VPC, so it
-rejects `hub.network.vpcId` in pre-flight
-([#833](https://github.com/aws-samples/appmod-blueprints/issues/833)). `kind-kro-ack`
-supports it. This does not affect CloudFront exposure, which needs no pre-existing VPC.
-
 ### Configuration
 
 Providers read shared configuration from `gitops/config.yaml`:
@@ -165,11 +144,9 @@ Providers read shared configuration from `gitops/config.yaml`:
 | `repo.basepath` | Path prefix in the repo |
 | `hub.clusterName` | Hub cluster name |
 | `hub.kubernetesVersion` | Kubernetes version |
-| `hub.network.vpcId`, `hub.network.subnetIds` | Optional: install into an existing VPC instead of creating one. Only `subnetIds[0]` and `[1]` are read. `kind-kro-ack` only; `kind-crossplane` fails fast (see above) |
 | `aws.region` | AWS region |
 | `aws.accountId` | AWS account ID |
-| `domain` | Ingress hostname. Must be known before install |
-| `insecure` | ALB serves plain HTTP because TLS is terminated upstream (e.g. CloudFront). Also makes the platform ALB `internal` and names it `<clusterName>-platform` |
+| `domain` | Base domain for ingress |
 | `identityCenter.*` | AWS Identity Center config (for EKS ArgoCD Capability) |
 | `argocdCapability.*` | ArgoCD capability config |
 

--- a/docs/EKS-Capabilities-ArgoCD-Setup.md
+++ b/docs/EKS-Capabilities-ArgoCD-Setup.md
@@ -8,32 +8,41 @@ When using EKS Capabilities, ArgoCD runs as a managed service outside the cluste
 
 ## Required Changes
 
-### 1. GitOps Bridge Configuration
+### 1. Cluster Secret (ArgoCD cluster registration)
 
-Update the `gitops_bridge_bootstrap` module in `platform/infra/terraform/common/argocd.tf` to create the cluster secret with the EKS cluster ARN:
+The active cluster provider (under `cluster-providers/`) creates the ArgoCD **seed cluster secret**
+in the `argocd` namespace during bootstrap. Because ArgoCD runs as an EKS Capability outside the
+cluster, the secret's `server` field must be the **EKS cluster ARN** (not
+`https://kubernetes.default.svc`). The minimal seed secret looks like:
 
-```hcl
-module "gitops_bridge_bootstrap" {
-  source  = "gitops-bridge-dev/gitops-bridge/helm"
-  version = "0.1.0"
-  
-  create  = true
-  install = false  # Skip ArgoCD installation since EKS Capabilities provides it
-  
-  cluster = {
-    cluster_name = local.hub_cluster.name
-    environment  = local.hub_cluster.environment
-    metadata     = local.addons_metadata[local.hub_cluster_key]
-    addons       = local.addons[local.hub_cluster_key]
-    server       = data.aws_eks_cluster.clusters[local.hub_cluster_key].arn  # Use cluster ARN
-  }
-
-  apps = local.argocd_apps
-}
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <clusterName>
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    fleet_member: control-plane
+    environment: control-plane
+  annotations:
+    addonsRepoURL: <repo.url>
+    addonsRepoRevision: <repo.revision>
+    addonsRepoBasepath: <repo.basepath>
+stringData:
+  name: <clusterName>
+  server: <clusterARN>   # EKS cluster ARN, NOT https://kubernetes.default.svc
+  config: '{"tlsClientConfig":{"insecure":false}}'
 ```
 
+The `fleet-secret` chart later enriches this seed secret with the full set of `enable_*` labels and
+metadata annotations. See `cluster-providers/README.md` ("Seed Cluster Secret" and "The Contract")
+for the complete provider contract. Where the secret is created depends on the provider — e.g.
+`cluster-providers/terraform/` (`argocd-capability.tf` / `secrets-manager.tf`) for the terraform
+provider, or the Crossplane Composition / KRO RGD for the kind providers.
+
 **Key points:**
-- Set `install = false` to skip ArgoCD installation
+- ArgoCD is provided by the EKS Capability — no ArgoCD is installed into the cluster
 - Set `server` to the EKS cluster ARN instead of `https://kubernetes.default.svc`
 
 ### 2. EKS Access Policy
@@ -116,7 +125,7 @@ argocd app list
 
 **Cause:** The cluster secret uses `name` instead of `server` with the cluster ARN.
 
-**Solution:** Update the gitops_bridge_bootstrap module to include `server = data.aws_eks_cluster.clusters[...].arn` (see step 1 above).
+**Solution:** Ensure the cluster secret sets `server` to the EKS cluster ARN (see step 1 above).
 
 ### Error: "cluster is disabled"
 

--- a/docs/huggingface-model-download.md
+++ b/docs/huggingface-model-download.md
@@ -73,13 +73,10 @@ huggingfaceModels:
 
 ### Enabling the Addon
 
-In `hub-config.yaml`:
+In the target environment's `gitops/overlays/environments/<env>/enabled-addons.yaml`:
 
 ```yaml
-clusters:
-  hub:
-    addons:
-      enable_platform_manifests: true
+platform_manifests: true
 ```
 
 ### Monitoring Downloads

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -1,149 +1,28 @@
+# Platform Documentation
 
-![overview](../images/overview.jpg)
+The platform is bootstrapped through the root `Taskfile.yaml`, which delegates to a pluggable
+**cluster provider** (`kind-crossplane`, `kind-kro-ack`, `terraform`, or `byoc`) selected via
+`clusterProvider` in `config.local.yaml`. After the hub cluster is created and `root-appset.yaml`
+is applied, ArgoCD takes over and the platform is fully self-managing via GitOps.
 
+> The previous CNOE-style install flow (`platform/infra/terraform/setup-environments.sh`) has been
+> removed. Use `task install` / `task status` / `task destroy` instead.
 
-# Installation
+## Getting started
 
-- Installation script must be used with a EKS cluster because we use IRSA to talk to AWS services.
-- Components are installed as ArgoCD Applications.
-- Files under the `/packages` directory are meant to be usable without any modifications. This means certain configuration options like domain name must be passed outside of this directory. e.g. use ArgoCD's Helm parameters.
+- [Root README](../../README.md) — quick start, workshop bootstrap, and platform URLs/credentials
+- [Cluster Providers](../../cluster-providers/README.md) — the provider model, the provider contract, and how to add a provider
+- [GitOps Platform](../../gitops/README.md) — ArgoCD ApplicationSets, addon registry, overlays, and fleet management
 
-## Basic installation flow
+## Architecture and operations
 
-The installation process follows the following pattern. 
-
-1. Install ArgoCD.
-2. Run Terraform. Terraform is responsible for:
-    - Managing AWS resources necessary for the Kubernetes operators to function. Mostly IAM Roles.
-    - Install components as ArgoCD applications. Pass IAM role information where necessary.
-    - Apply Kubernetes manifests such as secrets and ingress where information cannot easily be passed to ArgoCD.
-    - Run all the above in an order because installation order matters for many of these components. For example, Keycloak must be installed and ready before Backstage can be installed and configured.
-
-```mermaid
----
-title: Installation Process
----
-erDiagram
-  "Local Machine" ||--o{ "ArgoCD" : "1. installs"
-  "Local Machine" ||--o{ "Terraform" : "2. invokes"
-  "Terraform" ||--o{ "AWS Resources" : "3. creates"
-  "Terraform" ||--o{ "ArgoCD" : "4. create ArgoCD Apps"
-  "ArgoCD" ||--o{ "This Repo" : "pulls manifests"
-  "ArgoCD" ||--o{ "Components" : "installs to the cluster"
-```
-
-This installation pattern where some Kubernetes manifests are handled in Terraform while others are handled in GitOps manner may not be suitable for many organizations. If you can be certain about parameters such as domain name and certificate handling, it is better to utilize GitOps approach where these information are committed to a repository. The reason it is handled this way is to allow for customization for different organizations without forking this repository and committing organization specific information into the repository.
-
-## Requirements
-
-- An existing EKS cluster version (1.30+)
-- AWS CLI (2.17+)
-- Kubectl CLI (1.30+)
-- jq
-- git
-- yq
-- curl
-- kustomize
-- envsubst
-
-## Install
-
-Follow the following steps to get started.
-
-1. Run the following commands to setup your IDP environment:
-```bash
-cd ./platform/infra/terraform
-./setup-environments.sh
-```
-
-### Monitoring installation progress
-
-Components are installed as ArgoCD Applications. You can monitor installation progress by going to ArgoCD UI. 
-
-```bash
-# Get the admin password 
-kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
-
-kubectl port-forward svc/argocd-server -n argocd 8081:80
-```
-
-Go to [`http://localhost:8081`](http://localhost:8081) and login with the username `admin` and password obtained above. In the UI you can look at resources created, their logs, and events.
-
-### If you installed it without Cert Manager.
-
-
-## What was created?
-
-The following components are installed if you chose the full installation option.
-
-| Name | Version |
-|---|---------|
-| argo-workflows | v3.4.8  |
-| argocd | v2.10.7 |
-| aws-load-balancer-controller | v2.5.3  |
-| backstage | v1.16.0 |
-| cert-manager | v1.12.2 |
-| crossplane | v1.15.1 |
-| external-dns | v0.13.5 |
-| ingress-nginx | v1.8.0  |
-| keycloak | v22.0.0 |
-| external-secrets | v0.9.2  |
-
-## How to access the Components of the Platform?
-
-Once the setup is complete, use the URLs from the output to login to backstage, ArgoCD, Argo, KeyCloak, Argo Workflows and Gitea.
-
-#### ArgoCD
-
-Click on the ArgoCD URL to navigate to your browser to access the ArgoCD App. User is `Admin` and the password is available in the `argocd` namespace.
-
-```bash
-# Get the admin password 
-kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
-```
-
-### Argo Workflows:
-
-Click on the Argo Workflows URL to navigate to your browser to access the Argo Workflows App.  Two users are created during the installation process: `user1` and `user2`. Their passwords are available in the keycloak namespace.
-
-```bash
-k get secrets -n keycloak keycloak-user-config -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'
-```
-
-### Backstage:
-
-Click on the Backstage URL to navigate to your browser to access the Backstage App.  Two users are created during the installation process: `user1` and `user2`. Their passwords are available in the keycloak namespace.
-
-```bash
-k get secrets -n keycloak keycloak-user-config -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'
-```
-
-### Gitea:
-
-Click on the Gitea URL to navigate to your browser to access the Gitea App.  Pleae use the below command to obtain the username and password of Gitea user.
-
-```bash
-k get secrets -n gitea gitea-credential -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'
-````
-
-### KeyCloak:
-
-Click on the KeyCloak URL to navigate to your browser to access the Backstage App.  `cnoe-admin` is the user and their passwords are available in the keycloak namespace under the data `KEYCLOAK_ADMIN_PASSWORD`.
-
-```bash
-k get secrets -n keycloak keycloak-config -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'
-```
-
-### Grafana Access:
-
-At the end of the automation you will see Amazon Managed Grafana URL getting displayed along with passwords for `admin` and `editor` users. Please use this to access the Amazon Managed Grafana instance to monitor your Infrastructure and workloads.
-
-## Uninstall
-1. Run `./platform/infra/terraform/mgmt/setups/uninstall.sh` and follow the prompts.
+- [GitOps Bridge Architecture](gitops-bridge-architecture.md) — how cluster metadata and addon enablement flow into cluster secrets
+- [Spoke Cluster Lifecycle](cluster-lifecycle.md) — creating, enabling, and safely deleting spoke clusters
+- [Hub Networking](HUB_NETWORKING.md)
+- [ACK Pod Identity Design](ack-pod-identity-design.md)
+- [Multi-Cluster Auth](MULTI_CLUSTER_AUTH.md) — and the [Consumer Guide](MULTI_CLUSTER_AUTH_CONSUMER_GUIDE.md)
+- [EKS Capabilities: ArgoCD Setup](../EKS-Capabilities-ArgoCD-Setup.md) and [KRO/ACK Setup](../EKS-Capabilities-KRO-ACK-Setup.md)
 
 ## Troubleshooting
 
-See [the troubleshooting doc](TROUBLESHOOTING.md) for more information.
-
-
-
+- [Troubleshooting guide](../Troubleshoot.md)

--- a/docs/platform/cluster-lifecycle.md
+++ b/docs/platform/cluster-lifecycle.md
@@ -103,7 +103,7 @@ argocd-refresh-token && source ~/.bashrc.d/platform.sh
 - **Don't `kubectl delete` / `argocd app delete` while the cluster is still in
   Git.** Auto-sync is on, so ArgoCD will just recreate it. Remove it from Git
   first, then prune.
-- For a **full environment teardown**, use `destroy.sh`, not prune. Prune is for
+- For a **full environment teardown**, use `task destroy`, not prune. Prune is for
   selective, intentional removals.
 
 ## Related files

--- a/docs/platform/gitops-bridge-architecture.md
+++ b/docs/platform/gitops-bridge-architecture.md
@@ -4,16 +4,17 @@ This document explains how the platform uses the GitOps Bridge pattern to dynami
 
 ## Overview
 
-The GitOps Bridge is a data pipeline that passes infrastructure metadata from Terraform to Kubernetes secrets. Argo CD ApplicationSets then use these cluster secrets to dynamically determine which addons to deploy to each cluster.
+The GitOps Bridge is a data pipeline that passes infrastructure metadata into Kubernetes cluster secrets. Argo CD ApplicationSets then use these cluster secrets to dynamically determine which addons to deploy to each cluster. Cluster metadata originates from the active cluster provider (under `cluster-providers/`) and per-environment addon enablement from `enabled-addons.yaml`.
 
 ```mermaid
 graph TB
-    subgraph "Terraform Layer"
-        TF[Terraform]
-        HUB_CONFIG[hub-config.yaml]
+    subgraph "Provider / Config Layer"
+        PROVIDER[Cluster Provider<br/>cluster-providers/*]
+        ENABLED[enabled-addons.yaml]
     end
     
     subgraph "GitOps Bridge"
+        FLEET[fleet-secret chart]
         CLUSTER_SECRETS[Cluster Secrets<br/>Labels & Annotations]
     end
     
@@ -27,8 +28,10 @@ graph TB
         AWS_SM[AWS Secrets Manager]
     end
     
-    TF --> HUB_CONFIG
-    HUB_CONFIG --> CLUSTER_SECRETS
+    PROVIDER --> AWS_SM
+    ENABLED --> FLEET
+    AWS_SM --> FLEET
+    FLEET --> CLUSTER_SECRETS
     CLUSTER_SECRETS --> APPSETS
     APPSETS --> APPS
     ESO --> AWS_SM
@@ -39,9 +42,9 @@ graph TB
 
 The platform uses a three-tier GitOps configuration system:
 
-### 1. Addon Definitions
+### 1. Addon Registry
 
-Located in `gitops/addons/bootstrap/default/addons.yaml`, this is the central registry of all available platform addons:
+Located in `gitops/addons/registry/<domain>.yaml` (core, platform, security, observability, ml, gitops), this is the central registry of all available platform addons:
 
 ```yaml
 jupyterhub:
@@ -65,37 +68,38 @@ jupyterhub:
 
 ### 2. Environment Configuration
 
-Located in `gitops/addons/environments/{environment}/addons.yaml`, this enables addons for specific environments:
+Located in `gitops/overlays/environments/<env>/enabled-addons.yaml`, this enables addons for specific environments:
 
 ```yaml
-jupyterhub:
-  enabled: true
-keycloak:
-  enabled: true
-backstage:
-  enabled: true
+jupyterhub: true
+keycloak: true
+backstage: true
 ```
 
 ### 3. Cluster Configuration
 
-Located in `platform/infra/terraform/hub-config.yaml`, this defines per-cluster addon activation:
+Per-environment addon activation is declared in `gitops/overlays/environments/<env>/enabled-addons.yaml`
+(the source of truth for the cluster secret `enable_*` labels):
 
 ```yaml
-clusters:
-  hub:
-    addons:
-      enable_jupyterhub: true
-      enable_keycloak: true
-      enable_backstage: true
-  spoke-dev:
-    addons:
-      enable_jupyterhub: false
-      enable_keycloak: false
+# gitops/overlays/environments/control-plane/enabled-addons.yaml
+jupyterhub: true
+keycloak: true
+backstage: true
+```
+
+```yaml
+# gitops/overlays/environments/dev/enabled-addons.yaml
+jupyterhub: false
+keycloak: false
 ```
 
 ## Cluster Secrets
 
-Terraform creates Kubernetes secrets for each cluster with labels and annotations that ApplicationSets use for dynamic configuration.
+The `fleet-secret` chart generates a Kubernetes cluster secret for each cluster with the labels and
+annotations that ApplicationSets use for dynamic configuration. The `enable_*` labels are derived
+from the environment's `enabled-addons.yaml`; other annotations (region, account, domain, resource
+prefix) come from the `<cluster>/config` Secrets Manager entry seeded by the cluster provider.
 
 ### Labels (for addon selection)
 
@@ -224,7 +228,7 @@ These changes allow addons to deploy in parallel with other services instead of 
 
 ## Deployment Flow
 
-1. **Terraform** reads `hub-config.yaml` and creates cluster secrets with appropriate labels
+1. **The cluster provider** seeds cluster metadata into Secrets Manager; the `fleet-secret` chart reads `enabled-addons.yaml` and creates cluster secrets with the appropriate `enable_*` labels
 2. **Cluster secrets** are created in the `argocd` namespace with addon enablement labels
 3. **ApplicationSets** detect clusters matching their label selectors
 4. **Applications** are generated for each matching cluster
@@ -234,11 +238,10 @@ These changes allow addons to deploy in parallel with other services instead of 
 
 ## Adding a New Addon
 
-1. Define the addon in `gitops/addons/bootstrap/default/addons.yaml`
-2. Enable in environment config `gitops/addons/environments/{env}/addons.yaml`
-3. Add enablement flag to `platform/infra/terraform/hub-config.yaml`
-4. Apply Terraform changes to update cluster secrets
-5. Argo CD automatically detects and deploys the addon
+1. Define the addon in the appropriate `gitops/addons/registry/<domain>.yaml`
+2. Enable it in the environment's `gitops/overlays/environments/<env>/enabled-addons.yaml`
+3. Commit and push — the `fleet-secret` chart regenerates the cluster secret `enable_*` labels
+4. Argo CD automatically detects and deploys the addon
 
 ## References
 

--- a/docs/ray-s3-model-cache-implementation.md
+++ b/docs/ray-s3-model-cache-implementation.md
@@ -7,15 +7,15 @@ This document describes the implemented S3-based model caching system for Ray Se
 
 To add a new model to the cache:
 
-1. Update `gitops/addons/bootstrap/default/addons.yaml`:
+1. Add the model to `gitops/addons/configs/ray-operator/values.yaml`:
 ```yaml
-ray-operator:
-  valuesObject:
-    modelPrestage:
-      models:
-        - name: new-model
-          huggingfaceId: "org/model-name"
-          s3Path: "models/new-model"
+modelPrestage:
+  models:
+    new-model:
+      enabled: true
+      repoId: "org/model-name"
+      memory: "8Gi"
+      storageSize: "20Gi"
 ```
 
 2. Sync ray-operator addon:
@@ -44,45 +44,34 @@ kubectl get jobs -n ray-system | grep prestage
 
 ### 1. S3 Bucket and IAM Roles
 
-**Created by Terraform**: `platform/infra/terraform/common/model-storage.tf`
+**Created by the cluster provider**: `cluster-providers/common/Taskfile.ray.yaml` (the `setup` task,
+run during `task install`). This provider-agnostic task (shared by the `kind-crossplane` and
+`kind-kro-ack` providers) provisions, via the AWS CLI:
 
-```hcl
-# S3 bucket for model storage
-resource "aws_s3_bucket" "ray_models" {
-  bucket = "${local.context_prefix}-ray-models-${data.aws_caller_identity.current.account_id}"
-}
-
-# IAM role for model prestage jobs
-resource "aws_iam_role" "model_prestage" {
-  name = "${local.context_prefix}-model-prestage-role"
-  # Permissions: s3:PutObject, s3:GetObject, s3:ListBucket
-}
-
-# IAM role for Ray workers
-resource "aws_iam_role" "ray_worker" {
-  name = "${local.context_prefix}-ray-worker-role"
-  # Permissions: s3:GetObject, s3:ListBucket (read-only)
-}
-```
+- **S3 bucket** `<resourcePrefix>-ray-models-<accountId>` (public access blocked) for model storage
+- **IAM role** `<resourcePrefix>-model-prestage-role` — for model prestage jobs (`s3:PutObject`, `s3:GetObject`, `s3:ListBucket`)
+- **IAM role** `<resourcePrefix>-ray-worker-role` — for Ray workers (`s3:GetObject`, `s3:ListBucket`, read-only)
+- Plus the ECR repo, custom vLLM image, Mountpoint-S3 CSI driver, and Pod Identity associations
 
 **Outputs**:
 - Bucket: `peeks-ray-models-<AWS_ACCOUNT_ID>`
 - Models path: `s3://peeks-ray-models-<AWS_ACCOUNT_ID>/models/`
 
-**GitOps Bridge Integration**:
+**Cluster-secret metadata injection**:
 
-The S3 bucket name is dynamically injected into the ray-operator addon via GitOps bridge cluster secret annotations:
+The S3 bucket name is dynamically injected into the ray-operator addon via cluster-secret annotations:
 
-1. **Terraform adds metadata** to cluster secret (`platform/infra/terraform/common/locals.tf`):
-```hcl
-addons_metadata = {
-  resource_prefix = var.resource_prefix  # "peeks"
-  aws_account_id  = data.aws_caller_identity.current.account_id  # "<AWS_ACCOUNT_ID>"
-  # ... other metadata
-}
+1. **The cluster provider seeds metadata** (`resource_prefix`, `aws_account_id`, etc.) into the
+   `<cluster>/config` Secrets Manager entry; the `fleet-secret` chart writes it onto the cluster
+   secret annotations.
+
+2. **The addon registry** derives the bucket name from those annotations
+   (`gitops/addons/registry/platform.yaml`):
+```yaml
+    model_s3_bucket: '{{.metadata.annotations.resource_prefix}}-ray-models-{{.metadata.annotations.aws_account_id}}'
 ```
 
-2. **ArgoCD ApplicationSet** reads annotations (`gitops/addons/bootstrap/default/addons.yaml`):
+   and the ray-operator ApplicationSet passes it through to the chart:
 ```yaml
 ray-operator:
   valuesObject:
@@ -98,7 +87,7 @@ This approach ensures the S3 bucket name is consistent across all environments w
 
 **Location**: `gitops/addons/charts/ray-operator/templates/model-prestage-job.yaml`
 
-**Configuration**: `gitops/addons/bootstrap/default/addons.yaml`
+**Configuration**: `gitops/addons/configs/ray-operator/values.yaml`
 
 ```yaml
 ray-operator:
@@ -125,7 +114,7 @@ ray-operator:
 
 ### 3. S3 CSI Driver Integration
 
-**Enabled in**: `gitops/addons/bootstrap/default/addons.yaml`
+**Enabled in**: `gitops/addons/configs/ray-operator/values.yaml`
 
 ```yaml
 mountpoint-s3-csi-driver:
@@ -249,7 +238,7 @@ workerMemory: ${{ parameters.modelId === '/mnt/models/models/mistral-7b' and '48
 
 ### Initial Setup (Already Completed)
 
-1. ✅ Terraform creates S3 bucket and IAM roles
+1. ✅ The cluster provider (`cluster-providers/common/Taskfile.ray.yaml`) creates the S3 bucket and IAM roles
 2. ✅ Ray operator addon enabled with modelPrestage config
 3. ✅ Model prestage jobs run and populate S3 bucket
 4. ✅ S3 CSI driver installed

--- a/platform/backstage/templates/catalog-info.yaml
+++ b/platform/backstage/templates/catalog-info.yaml
@@ -28,7 +28,8 @@ metadata:
   description: Holds system information i.e, hostname, IP, OS, etc
 spec:
   owner: guest
-  # values dynamically replaced by platform/infra/terraform/common/deploy.sh on bootstrap
+  # values dynamically populated at bootstrap via `task backstage-catalog`
+  # (the cluster provider's hub:backstage-catalog step updates the backstage-dynamic-catalog ConfigMap)
   ingress_hostname: '{{ values.ingressDomain }}'
   gitlab_hostname: '{{ values.gitlabDomain }}'
   argocd_hostname: '{{ values.argocdDomain }}'

--- a/scripts/validation/validate-workshop-from-content.md
+++ b/scripts/validation/validate-workshop-from-content.md
@@ -107,8 +107,8 @@ the platform bootstrap deployed everything correctly. **Do NOT fix issues manual
 (no `helm install`, no `argocd cluster add`, no `kubectl apply` of addons). Instead:
 
 1. **Identify** what is missing or broken.
-2. **Trace the root cause** back to the bootstrap scripts (`deploy.sh`, SSM documents,
-   Terraform, GitOps ApplicationSets) to understand *why* it wasn't deployed.
+2. **Trace the root cause** back to the bootstrap (the `task install` cluster-provider flow,
+   SSM documents, the workshop Taskfile, GitOps ApplicationSets) to understand *why* it wasn't deployed.
 3. **Log each issue** with the specific bootstrap script/step that should have handled it.
 4. **Stop and report** — the platform build scripts need fixing, not manual workarounds.
 
@@ -139,7 +139,7 @@ kubectl get secrets -n argocd -l argocd.argoproj.io/secret-type=cluster \
 
 If spoke clusters are missing, trace the root cause:
 - Which bootstrap step registers spoke clusters with ArgoCD?
-- Check the SSM document / `deploy.sh` / Terraform that creates cluster secrets.
+- Check the SSM document / `task install` cluster-provider bootstrap that creates cluster secrets.
 - Check the `clusters` ApplicationSet and the GitOps fleet config.
 - Flag as 🔴 Blocker with the specific script that failed.
 
@@ -194,9 +194,10 @@ curl -s -H "Authorization: Bearer $BS_TOKEN" \
 **Expected**: A real hostname (e.g., `d3asb3i2t94xpq.cloudfront.net`).
 
 If it shows `{{ values.gitlabDomain }}`, the `catalog-info.yaml` was never rendered
-by the bootstrap. Trace to `platform/infra/terraform/scripts/utils.sh` →
-`update_backstage_templates()` which does the `yq` substitution and git push.
-Flag as 🔴 Blocker — identify which deploy step should have called this function.
+by the bootstrap. Trace to the `backstage-catalog` bootstrap step (`task backstage-catalog`
+→ the cluster provider's `hub:backstage-catalog`), which performs the substitution and
+updates the `backstage-dynamic-catalog` ConfigMap.
+Flag as 🔴 Blocker — identify which deploy step should have called this.
 
 ### 0.4 — DNS_DEV / DNS_PROD
 


### PR DESCRIPTION
## What

The platform moved from a monolithic `platform/infra/terraform` layout (`deploy.sh`/`destroy.sh` + `hub-config.yaml`) to **pluggable cluster-providers** (`kind-crossplane`, `kind-kro-ack`, `terraform`, `byoc`) driven by `task install`/`task destroy` and per-environment `gitops/overlays/environments/<env>/enabled-addons.yaml`.

The **code already shipped** this, but the docs and steering guides still described the old model (e.g. `docs/platform/README.md` still said `cd ./platform/infra/terraform`; `.kiro/steering/project.md` still referenced `deploy.sh`/`hub-config.yaml` with no mention of `cluster-providers`). This PR brings the documentation back in line with the current architecture.

## Changes (docs-only, no functional changes)

- `docs/platform/{README,cluster-lifecycle,gitops-bridge-architecture}.md`, `docs/ray-s3-model-cache-implementation.md`, `docs/EKS-Capabilities-ArgoCD-Setup.md`, `docs/huggingface-model-download.md`
- `.kiro/steering/{project,cluster-lifecycle,terraform-best-practices,terraform-infrastructure}.md`
- `.kiro/skills/{manage-addons,troubleshoot-platform}/SKILL.md`
- `cluster-providers/README.md`, `platform/backstage/templates/catalog-info.yaml`
- `scripts/validation/validate-workshop-from-content.md`
- `.gitignore`: drop stale `terraform-aws-observability-accelerator` entry

## Testing

Docs/steering only — no code paths affected.